### PR TITLE
Resolved Disappearing Profile Button

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -187,7 +187,13 @@ struct ContentView: View {
                                 let prof_dest = ProfileView(damus_state: damus_state!, profile: profile_model, followers: followers_model)
 
                                 NavigationLink(destination: prof_dest) {
-                                    ProfilePicView(pubkey: damus_state!.pubkey, size: 32, highlight: .none, profiles: damus_state!.profiles)
+                                    /// Verify that the user has a profile picture, if not display a generic SF Symbol
+                                    /// (Resolves an in-app error where ``Robohash`` pictures are not generated so the button dissapears
+                                    if let picture = damus_state?.profiles.lookup(id: pubkey)?.picture {
+                                        ProfilePicView(pubkey: damus_state!.pubkey, size: 32, highlight: .none, profiles: damus_state!.profiles, picture: picture)
+                                    } else {
+                                        Image(systemName: "person.fill")
+                                    }
                                 }
                                 .buttonStyle(PlainButtonStyle())
                             }


### PR DESCRIPTION
If a user has not chosen a profile picture (me), the `ProfilePicView` does not generate a `roboHash` image that can be clicked on to view your on profile. I am not sure if this is a robohash thing, or potentially the return type of `ProfilePicView` that is interfering. But regardless I wanted to put a default SF Symbol there so that users can still click and view their own profile.