### PR TITLE
add dropshadow to profile pic view and realigned event action bar

### DIFF
--- a/damus/Views/EventActionBar.swift
+++ b/damus/Views/EventActionBar.swift
@@ -37,7 +37,7 @@ struct EventActionBar: View {
             if damus_state.keypair.privkey != nil {
                 EventActionButton(img: "bubble.left", col: nil) {
                     notify(.reply, event)
-                }
+                }.frame(maxWidth: .infinity)
             }
             
             HStack(alignment: .bottom) {
@@ -52,7 +52,7 @@ struct EventActionBar: View {
                         self.confirm_boost = true
                     }
                 }
-            }
+            }.frame(maxWidth: .infinity)
 
             HStack(alignment: .bottom) {
                 Text("\(bar.likes > 0 ? "\(bar.likes)" : "")")
@@ -66,7 +66,7 @@ struct EventActionBar: View {
                         send_like()
                     }
                 }
-            }
+            }.frame(maxWidth: .infinity)
             
             /*
             HStack(alignment: .bottom) {
@@ -139,7 +139,7 @@ func EventActionButton(img: String, col: Color?, action: @escaping () -> ()) -> 
             .font(.footnote)
             .foregroundColor(col == nil ? Color.gray : col!)
     }
-    .padding(.trailing, 40)
+    
 }
 
 

--- a/damus/Views/ProfilePicView.swift
+++ b/damus/Views/ProfilePicView.swift
@@ -67,7 +67,7 @@ struct ProfilePicView: View {
                 .loadDiskFileSynchronously()
                 .fade(duration: 0.1)
                 .clipShape(Circle())
-                .shadow(color: .gray, radius: 5, x: 0, y: 5)
+                .shadow(color: Color(UIColor.darkGray), radius: 5, x: 0, y: 2)
                 .overlay(Circle().stroke(highlight_color(highlight), lineWidth: pfp_line_width(highlight)))
         }
     }

--- a/damus/Views/ProfilePicView.swift
+++ b/damus/Views/ProfilePicView.swift
@@ -67,6 +67,7 @@ struct ProfilePicView: View {
                 .loadDiskFileSynchronously()
                 .fade(duration: 0.1)
                 .clipShape(Circle())
+                .shadow(color: .gray, radius: 5, x: 0, y: 5)
                 .overlay(Circle().stroke(highlight_color(highlight), lineWidth: pfp_line_width(highlight)))
         }
     }


### PR DESCRIPTION
I realigned the buttons on the action bar for a nicer UI. Tested if the double arrow button was not there and they realign for two buttons just as nicely. Also added a dropshadow for the profile picture which seems to be subtle but looks good on light and dark mode. 