### PR TITLE
SF Symbols in Profile View Should Respond to Dark Mode

### DIFF
--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -85,6 +85,7 @@ struct ProfileView: View {
     @StateObject var followers: FollowersModel
     
     @Environment(\.dismiss) var dismiss
+    @Environment(\.colorScheme) var colorScheme
     
     //@EnvironmentObject var profile: ProfileModel
     
@@ -94,7 +95,7 @@ struct ProfileView: View {
         }) {
             Image(systemName: "bolt.circle")
                 .symbolRenderingMode(.palette)
-                .foregroundStyle(.black, .gray)
+                .foregroundStyle(colorScheme == .dark ? .white : .black, .gray)
                 .font(.system(size: 27).weight(.thin))
         }
     }
@@ -107,7 +108,7 @@ struct ProfileView: View {
             Image(systemName: "bubble.left.circle")
                 .symbolRenderingMode(.palette)
                 .font(.system(size: 29).weight(.thin))
-                .foregroundStyle(.black, .gray)
+                .foregroundStyle(colorScheme == .dark ? .white : .black, .gray)
         }
     }
     


### PR DESCRIPTION
#59 

**Before:**
<img width="464" alt="Screenshot 2022-12-19 at 10 58 38 AM" src="https://user-images.githubusercontent.com/264977/208501101-0ca2dfda-e8cc-4f61-bb09-b7d5527df081.png">

**After:**
<img width="488" alt="Screenshot 2022-12-19 at 11 04 45 AM" src="https://user-images.githubusercontent.com/264977/208501089-128327c5-d886-43f2-afdb-a012f303978b.png">
<img width="468" alt="Screenshot 2022-12-19 at 11 04 39 AM" src="https://user-images.githubusercontent.com/264977/208501097-72a48ac7-748f-403e-abf1-4f004c45ac7e.png">



