### PR TITLE
Hide private key in settings page by default, add press and hold to copy/share

### DIFF
--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -36,6 +36,13 @@ struct ConfigView: View {
                             UIPasteboard.general.string = state.keypair.pubkey_bech32
                             AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
                         }
+                        .clipShape(RoundedRectangle(cornerRadius: 5))
+                        .gesture(
+                            LongPressGesture(minimumDuration: 1.0)
+                                .onEnded { _ in
+                                    UIPasteboard.general.string = state.keypair.pubkey_bech32
+                                }
+                        )
                 }
                 
                 if let sec = state.keypair.privkey_bech32 {
@@ -47,6 +54,13 @@ struct ConfigView: View {
                                     UIPasteboard.general.string = sec
                                     AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
                                 }
+                                .clipShape(RoundedRectangle(cornerRadius: 5))
+                                .gesture(
+                                    LongPressGesture(minimumDuration: 1.0)
+                                        .onEnded { _ in
+                                            UIPasteboard.general.string = sec
+                                        }
+                                )
                         }
                         
                         if isHidden == true {

--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -5,8 +5,8 @@
 //  Created by William Casarin on 2022-06-09.
 //
 
-import SwiftUI
 import AVFoundation
+import SwiftUI
 
 struct ConfigView: View {
     let state: DamusState
@@ -14,6 +14,7 @@ struct ConfigView: View {
     @State var show_add_relay: Bool = false
     @State var confirm_logout: Bool = false
     @State var new_relay: String = ""
+    @State var isHidden: Bool = true
     
     var body: some View {
         ZStack(alignment: .leading) {
@@ -25,7 +26,6 @@ struct ConfigView: View {
                                 RelayView(state: state, ev: ev, relay: relay)
                             }
                         }
-                        
                     }
                 }
                 
@@ -37,15 +37,25 @@ struct ConfigView: View {
                             AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
                         }
                 }
-                    
+                
                 if let sec = state.keypair.privkey_bech32 {
                     Section("Secret Account Login Key") {
-                        Text(sec)
-                            .textSelection(.enabled)
-                            .onTapGesture {
-                                UIPasteboard.general.string = sec
-                                AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
-                            }
+                        if isHidden == false {
+                            Text(sec)
+                                .textSelection(.enabled)
+                                .onTapGesture {
+                                    UIPasteboard.general.string = sec
+                                    AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
+                                }
+                        }
+                        
+                        if isHidden == true {
+                            Text("*******")
+                        }
+   
+                        Button("Show/Hide Key") {
+                            isHidden.toggle()
+                        }
                     }
                 }
                     

--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -4,7 +4,6 @@
 //
 //  Created by William Casarin on 2022-06-09.
 //
-
 import AVFoundation
 import SwiftUI
 
@@ -14,7 +13,13 @@ struct ConfigView: View {
     @State var show_add_relay: Bool = false
     @State var confirm_logout: Bool = false
     @State var new_relay: String = ""
-    @State var isHidden: Bool = true
+    @State var showPrivateKey: Bool = false
+    @State var privateKey: String
+    
+    init(state: DamusState) {
+        self.state = state
+        _privateKey = State(initialValue: self.state.keypair.privkey_bech32 ?? "")
+    }
     
     var body: some View {
         ZStack(alignment: .leading) {
@@ -47,7 +52,10 @@ struct ConfigView: View {
                 
                 if let sec = state.keypair.privkey_bech32 {
                     Section("Secret Account Login Key") {
-                        if isHidden == false {
+                        if showPrivateKey == false {
+                            SecureField("PrivateKey", text: $privateKey)
+                                .disabled(true)
+                        } else {
                             Text(sec)
                                 .textSelection(.enabled)
                                 .onTapGesture {
@@ -62,14 +70,8 @@ struct ConfigView: View {
                                         }
                                 )
                         }
-                        
-                        if isHidden == true {
-                            Text("*******")
-                        }
    
-                        Button("Show/Hide Key") {
-                            isHidden.toggle()
-                        }
+                        Toggle("Show PrivateKey", isOn: $showPrivateKey)
                     }
                 }
                     


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <niteshbalusu@icloud.com>

A small UI change that hides private key by default in the settings page and shows up on clicking a button.
Also added press and hold to copy/share keys.
