### PR TITLE
animate images everywhere

### DIFF
--- a/damus/Components/ImageCarousel.swift
+++ b/damus/Components/ImageCarousel.swift
@@ -17,11 +17,14 @@ struct ImageViewer: View {
                 VStack{
                     Text(url.lastPathComponent)
                     
-                    KFImage(url)
+                    KFAnimatedImage(url)
+                        .configure { view in
+                            view.framePreloadCount = 3
+                        }
+                        .cacheOriginalImage()
                         .loadDiskFileSynchronously()
                         .scaleFactor(UIScreen.main.scale)
                         .fade(duration: 0.1)
-                        .resizable()
                         .aspectRatio(contentMode: .fit)
                         .tabItem {
                             Text(url.absoluteString)

--- a/damus/Components/ImageCarousel.swift
+++ b/damus/Components/ImageCarousel.swift
@@ -46,11 +46,14 @@ struct ImageCarousel: View {
     var body: some View {
         TabView {
             ForEach(urls, id: \.absoluteString) { url in
-                KFImage(url)
+                KFAnimatedImage(url)
+                    .configure { view in
+                        view.framePreloadCount = 3
+                    }
+                    .cacheOriginalImage()
                     .loadDiskFileSynchronously()
                     .scaleFactor(UIScreen.main.scale)
                     .fade(duration: 0.1)
-                    .resizable()
                     .aspectRatio(contentMode: .fit)
                     .tabItem {
                         Text(url.absoluteString)

--- a/damus/Views/ProfilePicView.swift
+++ b/damus/Views/ProfilePicView.swift
@@ -56,16 +56,19 @@ struct ProfilePicView: View {
         Group {
             let pic = picture ?? profiles.lookup(id: pubkey)?.picture ?? robohash(pubkey)
             let url = URL(string: pic)
-            let processor = ResizingImageProcessor(referenceSize: CGSize(width: size, height: size))
             
-            KFImage.url(url)
+            KFAnimatedImage(url)
+                .configure { view in
+                    view.framePreloadCount = 1
+                }
                 .placeholder { _ in
                     Placeholder
                 }
-                .setProcessor(processor)
+                .cacheOriginalImage()
                 .scaleFactor(UIScreen.main.scale)
                 .loadDiskFileSynchronously()
                 .fade(duration: 0.1)
+                .frame(width: size, height: size)
                 .clipShape(Circle())
                 .overlay(Circle().stroke(highlight_color(highlight), lineWidth: pfp_line_width(highlight)))
         }


### PR DESCRIPTION
https://user-images.githubusercontent.com/543668/208597862-04333cd0-3707-4561-9d81-c94f0118c204.mov

not sure if damus is anti-animation but thought I'd give it a shot. only animates when open in the pop-over view, not in the timeline

I borrowed the cache image and preload settings from the kingfisher demo code:
https://github.com/sean-a-wilson/Kingfisher/blob/1897586f01041d6ddc025714be156aee2d79509d/Demo/Demo/Kingfisher-Demo/SwiftUIViews/AnimatedImageDemo.swift#L41

Not sure why this doesn't take the `resizable()` property but seems to size just fine

also checked on non-animated pngs / jpgs and they still work the same