### PR TITLE
Copy image

### DIFF
--- a/damus/Components/ImageCarousel.swift
+++ b/damus/Components/ImageCarousel.swift
@@ -47,7 +47,7 @@ struct ImageContextMenuModifier: ViewModifier {
                 Button {
                     UIPasteboard.general.image = someImage
                 } label: {
-                    Label("Copy Image", systemImage: "doc.on.doc")
+                    Label("Copy Image", systemImage: "photo.on.rectangle")
                 }
             }
             Button {

--- a/damus/Components/ImageCarousel.swift
+++ b/damus/Components/ImageCarousel.swift
@@ -8,8 +8,77 @@
 import SwiftUI
 import Kingfisher
 
+// TODO: all this ShareSheet complexity can be replaced with ShareLink once we update to iOS 16
+struct ShareSheet: UIViewControllerRepresentable {
+    typealias Callback = (_ activityType: UIActivity.ActivityType?, _ completed: Bool, _ returnedItems: [Any]?, _ error: Error?) -> Void
+    
+    let activityItems: [URL]
+    let callback: Callback? = nil
+    let applicationActivities: [UIActivity]? = nil
+    let excludedActivityTypes: [UIActivity.ActivityType]? = nil
+    
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let controller = UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: applicationActivities)
+        controller.excludedActivityTypes = excludedActivityTypes
+        controller.completionWithItemsHandler = callback
+        return controller
+    }
+    
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
+        // nothing to do here
+    }
+}
+
+struct ImageContextMenuModifier: ViewModifier {
+    let url: URL
+    let image: UIImage?
+    @Binding var showShareSheet: Bool
+    
+    func body(content: Content) -> some View {
+        return content.contextMenu {
+            Button {
+                UIPasteboard.general.url = url
+            } label: {
+                Label("Copy Image URL", systemImage: "doc.on.doc")
+            }
+            if let someImage = image {
+                Button {
+                    UIPasteboard.general.image = someImage
+                } label: {
+                    Label("Copy Image", systemImage: "doc.on.doc")
+                }
+            }
+            Button {
+                showShareSheet = true
+            } label: {
+                Label("Share", systemImage: "square.and.arrow.up")
+            }
+        }
+    }
+}
+
 struct ImageViewer: View {
     let urls: [URL]
+    
+    private struct ImageHandler: ImageModifier {
+        @Binding var handler: UIImage?
+        
+        func modify(_ image: UIImage) -> UIImage {
+            handler = image
+            return image
+        }
+    }
+
+    @State private var image: UIImage?
+    @State private var showShareSheet = false
+    
+    func onShared(completed: Bool) -> Void {
+        if (completed) {
+            showShareSheet = false
+        }
+    }
     
     var body: some View {
         TabView {
@@ -22,6 +91,7 @@ struct ImageViewer: View {
                             view.framePreloadCount = 3
                         }
                         .cacheOriginalImage()
+                        .imageModifier(ImageHandler(handler: $image))
                         .loadDiskFileSynchronously()
                         .scaleFactor(UIScreen.main.scale)
                         .fade(duration: 0.1)
@@ -30,6 +100,11 @@ struct ImageViewer: View {
                             Text(url.absoluteString)
                         }
                         .id(url.absoluteString)
+                        .modifier(ImageContextMenuModifier(url: url, image: image, showShareSheet: $showShareSheet))
+                        .sheet(isPresented: $showShareSheet) {
+                            ShareSheet(activityItems: [url])
+                        }
+
                 }
             }
         }


### PR DESCRIPTION
about half of this code is just for the sharesheet which tbh doesn't provide a TON of value

ios 16's ShareLink seems a lot better for what we're doing: https://www.hackingwithswift.com/quick-start/swiftui/how-to-let-users-share-content-using-the-system-share-sheet (which I believe also sidesteps any potential permissions issues? like you don't have to add camera roll permissions because it conforms to Transferable protocol (( need to investigate further )))

I'd be happy to rip out the sharesheet stuff or leave it in, up to you

(p.s. not sure why the image always blanks out in the press-hold actions... maybe a Kingfisher bug or setting? it was doing that before I got here though!)
 
![Screen Shot 2022-12-20 at 7 56 43 PM](https://user-images.githubusercontent.com/543668/208802417-80b2726b-57f5-4a70-9ed0-ffc5c65e7f7e.png)

