### PR TITLE
disable autocomplete for username

### DIFF
--- a/damus/Views/CreateAccountView.swift
+++ b/damus/Views/CreateAccountView.swift
@@ -47,6 +47,7 @@ struct CreateAccountView: View {
                                     .padding(.leading, -25.0)
                                 
                                 FormTextInput("satoshi", text: $account.nick_name)
+                                    .autocorrectionDisabled(true)
                                     .textInputAutocapitalization(.never)
                                 
                             }


### PR DESCRIPTION
When creating new account, autocomplete for username was enabled by default.
This fixes #63.