### PR TITLE
Rounded Images in Timelines

### DIFF
--- a/damus/Components/ImageCarousel.swift
+++ b/damus/Components/ImageCarousel.swift
@@ -46,21 +46,25 @@ struct ImageCarousel: View {
     var body: some View {
         TabView {
             ForEach(urls, id: \.absoluteString) { url in
-                KFAnimatedImage(url)
-                    .configure { view in
-                        view.framePreloadCount = 3
+                Rectangle()
+                    .overlay {
+                        KFAnimatedImage(url)
+                            .configure { view in
+                                view.framePreloadCount = 3
+                            }
+                            .cacheOriginalImage()
+                            .loadDiskFileSynchronously()
+                            .scaleFactor(UIScreen.main.scale)
+                            .fade(duration: 0.1)
+                            .aspectRatio(contentMode: .fill)
+                            .tabItem {
+                                Text(url.absoluteString)
+                            }
+                            .id(url.absoluteString)
                     }
-                    .cacheOriginalImage()
-                    .loadDiskFileSynchronously()
-                    .scaleFactor(UIScreen.main.scale)
-                    .fade(duration: 0.1)
-                    .aspectRatio(contentMode: .fit)
-                    .tabItem {
-                        Text(url.absoluteString)
-                    }
-                    .id(url.absoluteString)
             }
         }
+        .cornerRadius(10)
         .sheet(isPresented: $open_sheet) {
             ImageViewer(urls: urls)
         }


### PR DESCRIPTION
Wanted to make gifs and images a bit more consistent in terms of layout and design. Had some time in between commits and PR reviews for work and wanted to do some Damus coding 😎

Some renderings of what they look like: (Note: I temporarily disabled our sensitive-content filter so I could test on some random images. That filter has been restored before pushing up this change. Just in case seeing photos in the search tab alarmed anyone. Don't worry the dirty photos filter is still there).

Also I kept the full screen view the same.

<img width="372" alt="Screenshot 2022-12-22 at 1 45 10 PM" src="https://user-images.githubusercontent.com/30542196/209223955-ecae16cc-83ca-4014-915c-e5747eac38c9.png">
<img width="363" alt="Screenshot 2022-12-22 at 1 46 24 PM" src="https://user-images.githubusercontent.com/30542196/209223957-e518de76-30fd-4926-b32d-0f20675edecf.png">
<img width="371" alt="Screenshot 2022-12-22 at 1 42 20 PM" src="https://user-images.githubusercontent.com/30542196/209223950-5ec3c4ea-6a23-49ea-87b7-3a1475fe2493.png">

