### PR TITLE
Small UI update to ContentView

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -85,7 +85,7 @@ struct ContentView: View {
                 ContentTimelineView
                     .tag(FilterState.posts_and_replies)
             }
-            .tabViewStyle(.page)
+            .tabViewStyle(.page(indexDisplayMode: .never))
         }
         .safeAreaInset(edge: .top) {
             VStack(spacing: 0) {

--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -78,18 +78,13 @@ struct ContentView: View {
     @Environment(\.colorScheme) var colorScheme
 
     var PostingTimelineView: some View {
-        VStack{
-            ZStack {
-                if let damus = self.damus_state {
-                    TimelineView(events: $home.events, loading: $home.loading, damus: damus, show_friend_icon: false, filter: filter_event)
-                }
-                if privkey != nil {
-                    PostButtonContainer {
-                        self.active_sheet = .post
-                    }
-                }
-            }
+        TabView(selection: $filter_state) {
+            ContentTimelineView
+                .tag(FilterState.posts)
+            ContentTimelineView
+                .tag(FilterState.posts_and_replies)
         }
+        .tabViewStyle(.page)
         .safeAreaInset(edge: .top) {
             VStack(spacing: 0) {
                 FiltersView
@@ -99,6 +94,19 @@ struct ContentView: View {
                     .frame(height: 1)
             }
             .background(colorScheme == .dark ? Color.black : Color.white)
+        }
+    }
+    
+    var ContentTimelineView: some View {
+        ZStack {
+            if let damus = self.damus_state {
+                TimelineView(events: $home.events, loading: $home.loading, damus: damus, show_friend_icon: false, filter: filter_event)
+            }
+            if privkey != nil {
+                PostButtonContainer {
+                    self.active_sheet = .post
+                }
+            }
         }
     }
     

--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -78,13 +78,15 @@ struct ContentView: View {
     @Environment(\.colorScheme) var colorScheme
 
     var PostingTimelineView: some View {
-        TabView(selection: $filter_state) {
-            ContentTimelineView
-                .tag(FilterState.posts)
-            ContentTimelineView
-                .tag(FilterState.posts_and_replies)
+        VStack {
+            TabView(selection: $filter_state) {
+                ContentTimelineView
+                    .tag(FilterState.posts)
+                ContentTimelineView
+                    .tag(FilterState.posts_and_replies)
+            }
+            .tabViewStyle(.page)
         }
-        .tabViewStyle(.page)
         .safeAreaInset(edge: .top) {
             VStack(spacing: 0) {
                 FiltersView


### PR DESCRIPTION
By putting the feed content inside a `TabView` with `.page` style users can swipe between the `Posts` and `Posts & Replies` tabs.


https://user-images.githubusercontent.com/1885323/209225698-0418250d-411f-4aae-9f93-edbb689b06ed.mov

