### PR TITLE
Better post editor placeholder

### DIFF
--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -77,8 +77,9 @@ struct PostView: View {
                 if post.isEmpty {
                     Text(POST_PLACEHOLDER)
                         .padding(.top, 8)
-                        .padding(.leading, 10)
+                        .padding(.leading, 4)
                         .foregroundColor(Color(uiColor: .placeholderText))
+                        .allowsHitTesting(false)
                 }
             }
         }


### PR DESCRIPTION
* Smaller padding
* The context menu shows up when you touch the placeholder

Reasoning for smaller padding: it seems to be the default in iOS apps. E.g. Safari search bar:

<img width="414" alt="image" src="https://user-images.githubusercontent.com/1523306/209238046-57afba86-6075-498b-80c5-28121c6c1cac.png">

Longform notes in Passwords:

<img width="414" alt="image" src="https://user-images.githubusercontent.com/1523306/209238186-e88c7630-25ad-48d6-958f-513587f4ba1c.png">

Admittedly zero padding seemed even more appropriate but it doesn't mesh well with the letter T.