### PR TITLE
save the private key to the iOS keychain and not user defaults

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		4CEE2AF7280B2DEA00AB5EEF /* ProfileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEE2AF6280B2DEA00AB5EEF /* ProfileName.swift */; };
 		4CEE2AF9280B2EAC00AB5EEF /* PowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEE2AF8280B2EAC00AB5EEF /* PowView.swift */; };
 		4CEE2B02280B39E800AB5EEF /* EventActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEE2B01280B39E800AB5EEF /* EventActionBar.swift */; };
+		6C7DE41F2955169800E66263 /* Vault in Frameworks */ = {isa = PBXBuildFile; productRef = 6C7DE41E2955169800E66263 /* Vault */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -314,6 +315,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C06670428FC7EC500038D2A /* Kingfisher in Frameworks */,
+				6C7DE41F2955169800E66263 /* Vault in Frameworks */,
 				4CE6DF1227F7A2B300C66700 /* Starscream in Frameworks */,
 				4C649881286E0EE300EAE2B3 /* secp256k1 in Frameworks */,
 			);
@@ -623,6 +625,7 @@
 				4CE6DF1127F7A2B300C66700 /* Starscream */,
 				4C649880286E0EE300EAE2B3 /* secp256k1 */,
 				4C06670328FC7EC500038D2A /* Kingfisher */,
+				6C7DE41E2955169800E66263 /* Vault */,
 			);
 			productName = damus;
 			productReference = 4CE6DEE327F7A08100C66700 /* damus.app */;
@@ -702,6 +705,7 @@
 				4C64987F286E0EE300EAE2B3 /* XCRemoteSwiftPackageReference "secp256k1" */,
 				4C06670228FC7EC500038D2A /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				3169CAE9294FCABA00EE4006 /* XCRemoteSwiftPackageReference "Shimmer" */,
+				6C7DE41D2955169800E66263 /* XCRemoteSwiftPackageReference "Vault" */,
 			);
 			productRefGroup = 4CE6DEE427F7A08100C66700 /* Products */;
 			projectDirPath = "";
@@ -1238,6 +1242,14 @@
 				minimumVersion = 4.0.0;
 			};
 		};
+		6C7DE41D2955169800E66263 /* XCRemoteSwiftPackageReference "Vault" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SparrowTek/Vault";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1255,6 +1267,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4CE6DF1027F7A2B300C66700 /* XCRemoteSwiftPackageReference "Starscream" */;
 			productName = Starscream;
+		};
+		6C7DE41E2955169800E66263 /* Vault */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6C7DE41D2955169800E66263 /* XCRemoteSwiftPackageReference "Vault" */;
+			productName = Vault;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -40,8 +40,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SparrowTek/Vault",
       "state" : {
-        "revision" : "f5707fac23f4a17b3e5ed32dd444f502773615ae",
-        "version" : "1.0.2"
+        "revision" : "87db56c3c8b6421c65b0745f73e08b0dc56f79d4",
+        "version" : "1.0.3"
       }
     }
   ],

--- a/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -34,6 +34,15 @@
         "revision" : "df8d82047f6654d8e4b655d1b1525c64e1059d21",
         "version" : "4.0.4"
       }
+    },
+    {
+      "identity" : "vault",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SparrowTek/Vault",
+      "state" : {
+        "revision" : "f5707fac23f4a17b3e5ed32dd444f502773615ae",
+        "version" : "1.0.2"
+      }
     }
   ],
   "version" : 2

--- a/damus/Views/LoginView.swift
+++ b/damus/Views/LoginView.swift
@@ -52,14 +52,24 @@ struct LoginView: View {
     func process_login(_ key: ParsedKey, is_pubkey: Bool) -> Bool {
         switch key {
         case .priv(let priv):
-            save_privkey(privkey: priv)
+            do {
+                try save_privkey(privkey: priv)
+            } catch {
+                return false
+            }
+            
             guard let pk = privkey_to_pubkey(privkey: priv) else {
                 return false
             }
             save_pubkey(pubkey: pk)
 
         case .pub(let pub):
-            clear_saved_privkey()
+            do {
+                try clear_saved_privkey()
+            } catch {
+                return false
+            }
+            
             save_pubkey(pubkey: pub)
 
         case .nip05(let id):
@@ -82,10 +92,20 @@ struct LoginView: View {
 
         case .hex(let hexstr):
             if is_pubkey {
-                clear_saved_privkey()
+                do {
+                    try clear_saved_privkey()
+                } catch {
+                    return false
+                }
+                
                 save_pubkey(pubkey: hexstr)
             } else {
-                save_privkey(privkey: hexstr)
+                do {
+                    try save_privkey(privkey: hexstr)
+                } catch {
+                    return false
+                }
+                
                 guard let pk = privkey_to_pubkey(privkey: hexstr) else {
                     return false
                 }

--- a/damus/Views/SaveKeysView.swift
+++ b/damus/Views/SaveKeysView.swift
@@ -107,8 +107,13 @@ struct SaveKeysView: View {
                     self.pool.send(.event(contacts_ev))
                 }
                 
-                save_keypair(pubkey: account.pubkey, privkey: account.privkey)
-                notify(.login, account.keypair)
+                do {
+                    try save_keypair(pubkey: account.pubkey, privkey: account.privkey)
+                    notify(.login, account.keypair)
+                } catch {
+                    self.error = "Failed to save keys"
+                }
+                
             case .error(let err):
                 self.loading = false
                 self.error = "\(err.debugDescription)"

--- a/damus/damus.entitlements
+++ b/damus/damus.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.jb55.damus2</string>
+	</array>
 </dict>
 </plist>

--- a/damus/damusApp.swift
+++ b/damus/damusApp.swift
@@ -36,7 +36,7 @@ struct MainView: View {
             }
         }
         .onReceive(handle_notify(.logout)) { _ in
-            clear_keypair()
+            try? clear_keypair()
             keypair = nil
         }
         .onAppear {


### PR DESCRIPTION
User defaults are saved to disk as plain text that can be easily compromised. This PR saves the private key to the iOS keychain which is safe and encrypted.

Vault is a swift package that I created to help save and retrieve items from the keychain. If you'd prefer to use another package or no package at all I can modify this PR.