### PR TITLE
Loading View Patch

### DIFF
--- a/damus/Components/Shimmer.swift
+++ b/damus/Components/Shimmer.swift
@@ -41,6 +41,7 @@ struct ShimmeringView<Content: View>: View {
         _startPoint = .init(wrappedValue: configuration.initialLocation.start)
         _endPoint = .init(wrappedValue: configuration.initialLocation.end)
     }
+    
     var body: some View {
         ZStack {
             content()
@@ -71,7 +72,12 @@ public struct ShimmerModifier: ViewModifier {
 
 
 public extension View {
-    func shimmer(configuration: ShimmerConfiguration = .default) -> some View {
-        modifier(ShimmerModifier(configuration: configuration))
+    
+    @ViewBuilder func shimmer(configuration: ShimmerConfiguration = .default, _ loading: Bool) -> some View {
+        if loading {
+            modifier(ShimmerModifier(configuration: configuration))
+        } else {
+            self
+        }
     }
 }

--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -274,6 +274,20 @@ class NostrEvent: Codable, Identifiable, CustomStringConvertible, Equatable {
         self.tags = tags
         self.created_at = Int64(Date().timeIntervalSince1970)
     }
+    
+    /// Intiialization statement used to specificy ID
+    ///
+    /// This is mainly used for contant and testing data
+    init(id: String, content: String, pubkey: String, kind: Int = 1, tags: [[String]] = []) {
+        self.id = id
+        self.sig = ""
+
+        self.content = content
+        self.pubkey = pubkey
+        self.kind = kind
+        self.tags = tags
+        self.created_at = Int64(Date().timeIntervalSince1970)
+    }
 
     init(from: NostrEvent, content: String? = nil) {
         self.id = from.id

--- a/damus/Util/Constants.swift
+++ b/damus/Util/Constants.swift
@@ -14,12 +14,14 @@ public class Constants {
     static let EXAMPLE_DEMOS = DamusState(pool: RelayPool(), keypair: Keypair(pubkey: PUB_KEY, privkey: "privkey"), likes: EventCounter(our_pubkey: PUB_KEY), boosts: EventCounter(our_pubkey: PUB_KEY), contacts: Contacts(), tips: TipCounter(our_pubkey: PUB_KEY), profiles: Profiles(), dms: DirectMessagesModel())
     
     static let EXAMPLE_EVENTS = [
-        NostrEvent(content: "Icecream", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
-        NostrEvent(content: "This is a test for a really long note that somebody sent because they thought they were super cool or maybe they were just really excited to share something with the world.", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
-        NostrEvent(content: "Bonjour Le Monde", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
-        NostrEvent(content: "Why am I helping on this app? Because it's fun!", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
-        NostrEvent(content: "PIzza", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
-        NostrEvent(content: "Hello World! This is so cool!", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
-        NostrEvent(content: "Nostr - Damus... Haha get it?", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
+        NostrEvent(id: UUID().description, content: "Nostr - Damus... Haha get it? Bonjour Le Monde mon Ami! C'est la tres importante", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
+        NostrEvent(id: UUID().description, content: "This is a test for a really long note that somebody sent because they thought they were super cool or maybe they were just really excited to share something with the world.", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
+        NostrEvent(id: UUID().description, content: "Bonjour Le Monde", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
+        NostrEvent(id: UUID().description, content: "Why am I helping on this app? Because it's fun!", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
+        NostrEvent(id: UUID().description, content: "Pizza and Icecream! Pizza and Icecream! Testing Testing! 1 .. 2.. 3..", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
+        NostrEvent(id: UUID().description, content: "Hello World! This is so cool!", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
+        NostrEvent(id: UUID().description, content: "Nostr - Damus... Haha get it?", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
+        NostrEvent(id: UUID().description, content: "Hello World! This is so cool!", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
+        NostrEvent(id: UUID().description, content: "Bonjour Le Monde", pubkey: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"),
     ]
 }

--- a/damus/Views/ProfilePicView.swift
+++ b/damus/Views/ProfilePicView.swift
@@ -33,10 +33,14 @@ func pfp_line_width(_ h: Highlight) -> CGFloat {
 }
 
 struct ProfilePicView: View {
+    
+    @Environment(\.redactionReasons) private var reasons
+    
     let pubkey: String
     let size: CGFloat
     let highlight: Highlight
     let profiles: Profiles
+    let isPlaceholder: Bool = false
     
     @State var picture: String? = nil
     
@@ -57,21 +61,25 @@ struct ProfilePicView: View {
             let pic = picture ?? profiles.lookup(id: pubkey)?.picture ?? robohash(pubkey)
             let url = URL(string: pic)
             
-            KFAnimatedImage(url)
-                .configure { view in
-                    view.framePreloadCount = 1
-                }
-                .placeholder { _ in
-                    Placeholder
-                }
-                .cacheOriginalImage()
-                .scaleFactor(UIScreen.main.scale)
-                .loadDiskFileSynchronously()
-                .fade(duration: 0.1)
-                .frame(width: size, height: size)
-                .clipShape(Circle())
-                .overlay(Circle().stroke(highlight_color(highlight), lineWidth: pfp_line_width(highlight)))
+            if reasons.isEmpty {
+                KFAnimatedImage(url)
+                    .configure { view in
+                        view.framePreloadCount = 1
+                    }
+                    .placeholder { _ in
+                        Placeholder
+                    }
+                    .cacheOriginalImage()
+                    .scaleFactor(UIScreen.main.scale)
+                    .loadDiskFileSynchronously()
+                    .fade(duration: 0.1)
+            } else {
+                KFImage(url)
+            }
         }
+        .frame(width: size, height: size)
+        .clipShape(Circle())
+        .overlay(Circle().stroke(highlight_color(highlight), lineWidth: pfp_line_width(highlight)))
     }
     
     var body: some View {

--- a/damus/Views/SearchHomeView.swift
+++ b/damus/Views/SearchHomeView.swift
@@ -42,7 +42,8 @@ struct SearchHomeView: View {
     var GlobalContent: some View {
         return TimelineView(events: $model.events, loading: $model.loading, damus: damus_state, show_friend_icon: true, filter: { _ in true })
             .refreshable {
-                // Fetch new information by resubscribing to the relay
+                // Fetch new information by unsubscribing and resubscribing to the relay
+                model.unsubscribe()
                 model.subscribe()
             }
     }
@@ -50,7 +51,8 @@ struct SearchHomeView: View {
     var SearchContent: some View {
         SearchResultsView(damus_state: damus_state, search: $search)
             .refreshable {
-                // Fetch new information by resubscribing to the relay
+                // Fetch new information by unsubscribing and resubscribing to the relay
+                model.unsubscribe()
                 model.subscribe()
             }
     }
@@ -68,9 +70,7 @@ struct SearchHomeView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var body: some View {
-        VStack {
-            MainContent
-        }
+        MainContent
         .safeAreaInset(edge: .top) {
             VStack(spacing: 0) {
                 SearchInput

--- a/damus/Views/TimelineView.swift
+++ b/damus/Views/TimelineView.swift
@@ -40,25 +40,6 @@ struct InnerTimelineView: View {
     }
 }
 
-struct InnerTimelineRedactedView: View {
-    let events: [NostrEvent]
-    let damus: DamusState
-    let show_friend_icon: Bool
-    
-    var body: some View {
-        VStack {
-            ForEach(events, id: \.id) { event in
-                EventView(event: event, highlight: .none, has_action_bar: true, damus: damus, show_friend_icon: show_friend_icon)
-                    .buttonStyle(PlainButtonStyle())
-            }
-        }
-        .shimmer()
-        .redacted(reason: .placeholder)
-        .padding(.horizontal)
-        .disabled(true)
-    }
-}
-
 struct TimelineView: View {
     
     @Binding var events: [NostrEvent]
@@ -75,13 +56,10 @@ struct TimelineView: View {
     var MainContent: some View {
         ScrollViewReader { scroller in
             ScrollView {
-                if loading {
-                    InnerTimelineRedactedView(events: Constants.EXAMPLE_EVENTS, damus: damus, show_friend_icon: true)
-                    ProgressView()
-                        .progressViewStyle(.circular)
-                } else {
-                    InnerTimelineView(events: $events, damus: damus, show_friend_icon: show_friend_icon, filter: filter)
-                }
+                InnerTimelineView(events: loading ? .constant(Constants.EXAMPLE_EVENTS) : $events, damus: damus, show_friend_icon: show_friend_icon, filter: loading ? { _ in true } : filter)
+                    .redacted(reason: loading ? .placeholder : [])
+                    .shimmer(loading)
+                    .disabled(loading)
             }
             .onReceive(NotificationCenter.default.publisher(for: .scroll_to_top)) { _ in
                 guard let event = events.filter(self.filter).first else {


### PR DESCRIPTION
Fixed an issue I noticed with the loading view since we pushed to TestFlight. The `KFAnimatedImage` doesn't really respond to the redacted modifier, so we were getting this weird effect where the Damus logo was showing up instead of a redacted image:

![IMG_0420 Medium](https://user-images.githubusercontent.com/30542196/209248968-1f7405e3-daef-438f-a5a6-1d9b62f7f999.jpeg)

I fixed this and also tried to fix the issue with loading. Jack was saying he noticed less notes in his feed and I was worried that had something to do with constantly subscribing every time you refresh. I put some code to unsubscribe first and then resubscribe to see if maybe that might resolve that issue. Let me know what you think @jb55 .

Here is a renderings with the new patch:
<img width="397" alt="Screenshot 2022-12-22 at 5 16 58 PM" src="https://user-images.githubusercontent.com/30542196/209249170-bcaa9e68-fede-4cfe-aec9-cad79bc0b5b2.png">
(The profile looks light but thats just cuz of the shimmer when I took the screenshot)
