### PR TITLE
Improved visual composition for threads

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		4CEE2AF9280B2EAC00AB5EEF /* PowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEE2AF8280B2EAC00AB5EEF /* PowView.swift */; };
 		4CEE2B02280B39E800AB5EEF /* EventActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEE2B01280B39E800AB5EEF /* EventActionBar.swift */; };
 		E990020F2955F837003BBC5A /* EditMetadataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E990020E2955F837003BBC5A /* EditMetadataView.swift */; };
+		E9E4ED0B295867B900DD7078 /* ThreadV2View.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E4ED0A295867B900DD7078 /* ThreadV2View.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -308,6 +309,7 @@
 		4CEE2AF8280B2EAC00AB5EEF /* PowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowView.swift; sourceTree = "<group>"; };
 		4CEE2B01280B39E800AB5EEF /* EventActionBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventActionBar.swift; sourceTree = "<group>"; };
 		E990020E2955F837003BBC5A /* EditMetadataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMetadataView.swift; sourceTree = "<group>"; };
+		E9E4ED0A295867B900DD7078 /* ThreadV2View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadV2View.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -476,6 +478,7 @@
 				4C216F33286F5ACD00040376 /* DMView.swift */,
 				4C06670028FC7C5900038D2A /* RelayView.swift */,
 				E990020E2955F837003BBC5A /* EditMetadataView.swift */,
+				E9E4ED0A295867B900DD7078 /* ThreadV2View.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -788,6 +791,7 @@
 				4C363A9A28283854006E126D /* Reply.swift in Sources */,
 				4C90BD18283A9EE5008EE7EF /* LoginView.swift in Sources */,
 				4C3EA66828FF5F9900C48A62 /* hex.c in Sources */,
+				E9E4ED0B295867B900DD7078 /* ThreadV2View.swift in Sources */,
 				4C3BEFDC281DCE6100B3DE84 /* Liked.swift in Sources */,
 				4C75EFB128049D510006080F /* NostrResponse.swift in Sources */,
 				4CEE2AF7280B2DEA00AB5EEF /* ProfileName.swift in Sources */,

--- a/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -40,8 +40,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SparrowTek/Vault",
       "state" : {
-        "revision" : "f5707fac23f4a17b3e5ed32dd444f502773615ae",
-        "version" : "1.0.2"
+        "revision" : "87db56c3c8b6421c65b0745f73e08b0dc56f79d4",
+        "version" : "1.0.3"
       }
     }
   ],

--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -166,8 +166,7 @@ struct ContentView: View {
     var MaybeThreadView: some View {
         Group {
             if let evid = self.active_event_id {
-                let thread_model = ThreadModel(evid: evid, damus_state: damus_state!)
-                ThreadView(thread: thread_model, damus: damus_state!, is_chatroom: false)
+                BuildThreadV2View(damus: damus_state!, event_id: evid)
             } else {
                 EmptyView()
             }

--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -264,7 +264,7 @@ class NostrEvent: Codable, Identifiable, CustomStringConvertible, Equatable {
         return (self.flags & 1) != 0
     }
 
-    init(content: String, pubkey: String, kind: Int = 1, tags: [[String]] = []) {
+    init(content: String, pubkey: String, kind: Int = 1, tags: [[String]] = [], createdAt: Int64 = Int64(Date().timeIntervalSince1970)) {
         self.id = ""
         self.sig = ""
 
@@ -272,7 +272,7 @@ class NostrEvent: Codable, Identifiable, CustomStringConvertible, Equatable {
         self.pubkey = pubkey
         self.kind = kind
         self.tags = tags
-        self.created_at = Int64(Date().timeIntervalSince1970)
+        self.created_at = createdAt
     }
     
     /// Intiialization statement used to specificy ID

--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -45,9 +45,17 @@ struct EventId: Identifiable, CustomStringConvertible {
     }
 }
 
-class NostrEvent: Codable, Identifiable, CustomStringConvertible, Equatable {
+class NostrEvent: Codable, Identifiable, CustomStringConvertible, Equatable, Hashable, Comparable {
     static func == (lhs: NostrEvent, rhs: NostrEvent) -> Bool {
         return lhs.id == rhs.id
+    }
+    
+    static func < (lhs: NostrEvent, rhs: NostrEvent) -> Bool {
+        return lhs.created_at < rhs.created_at
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
     
     var id: String

--- a/damus/Views/ChatView.swift
+++ b/damus/Views/ChatView.swift
@@ -106,7 +106,7 @@ struct ChatView: View {
                         }
                     }
                     
-                    NoteContentView(privkey: damus_state.keypair.privkey, event: event, profiles: damus_state.profiles, show_images: should_show_images(contacts: damus_state.contacts, ev: event), artifacts: .just_content(event.content))
+                    NoteContentView(privkey: damus_state.keypair.privkey, event: event, profiles: damus_state.profiles, show_images: should_show_images(contacts: damus_state.contacts, ev: event), artifacts: .just_content(event.content), size: .normal)
 
                     if is_active || next_ev == nil || next_ev!.pubkey != event.pubkey {
                         let bar = make_actionbar_model(ev: event, damus: damus_state)

--- a/damus/Views/DMView.swift
+++ b/damus/Views/DMView.swift
@@ -21,7 +21,7 @@ struct DMView: View {
                 Spacer()
             }
             
-            NoteContentView(privkey: damus_state.keypair.privkey, event: event, profiles: damus_state.profiles, show_images: should_show_images(contacts: damus_state.contacts, ev: event), artifacts: .just_content(event.get_content(damus_state.keypair.privkey)))
+            NoteContentView(privkey: damus_state.keypair.privkey, event: event, profiles: damus_state.profiles, show_images: should_show_images(contacts: damus_state.contacts, ev: event), artifacts: .just_content(event.get_content(damus_state.keypair.privkey)), size: .normal)
                 .foregroundColor(is_ours ? Color.white : Color.primary)
                 .padding(10)
                 .background(is_ours ? Color.accentColor : Color.secondary.opacity(0.15))

--- a/damus/Views/EventActionBar.swift
+++ b/damus/Views/EventActionBar.swift
@@ -86,7 +86,6 @@ struct EventActionBar: View {
             }
              */
         }
-        .padding(.top, 1)
         .alert("Boost", isPresented: $confirm_boost) {
             Button("Boost") {
                 send_boost()
@@ -139,7 +138,7 @@ struct EventActionBar: View {
 
 func EventActionButton(img: String, col: Color?, action: @escaping () -> ()) -> some View {
     Button(action: action) {
-        Label("", systemImage: img)
+        Label("&nbsp;", systemImage: img)
             .font(.footnote.weight(.medium))
             .foregroundColor(col == nil ? Color.gray : col!)
     }

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -171,7 +171,7 @@ struct EventView: View {
                             .font(eventviewsize_to_font(size))
                             .foregroundColor(.gray)
                     }
-                }.padding(.bottom, 10)
+                }.padding(.bottom, size == .selected ? 10 : 1)
                 
                 if event.is_reply(damus.keypair.privkey) {
                     Text("\(reply_desc(profiles: damus.profiles, event: event))")

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -187,7 +187,7 @@ struct EventView: View {
                     if size == .selected {
                         Text("\(format_date(event.created_at))")
                             .padding(.top, 10)
-                            .font(.body)
+                            .font(.footnote)
                             .foregroundColor(.gray)
                         
                         Divider()

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -169,8 +169,10 @@ struct EventView: View {
                 if has_action_bar {
                     if size == .selected {
                         Text("\(format_date(event.created_at))")
+                            .padding(.top, 10)
                             .font(eventviewsize_to_font(size))
                             .foregroundColor(.gray)
+                        Divider()
                     }
                     
                     let bar = make_actionbar_model(ev: event, damus: damus)

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -187,7 +187,7 @@ struct EventView: View {
                     if size == .selected {
                         Text("\(format_date(event.created_at))")
                             .padding(.top, 10)
-                            .font(eventviewsize_to_font(size))
+                            .font(.body)
                             .foregroundColor(.gray)
                         Divider()
                     }

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -36,6 +36,23 @@ enum Highlight {
     }
 }
 
+enum EventViewSize {
+    case small
+    case normal
+    case big
+}
+
+func eventviewsize_to_font(_ size: EventViewSize) -> Font {
+    switch size {
+    case .small:
+        return .caption
+    case .normal:
+        return .body
+    case .big:
+        return .headline
+    }
+}
+
 struct EventView: View {
     let event: NostrEvent
     let highlight: Highlight
@@ -43,34 +60,38 @@ struct EventView: View {
     let damus: DamusState
     let pubkey: String
     let show_friend_icon: Bool
+    let size: EventViewSize
 
     @EnvironmentObject var action_bar: ActionBarModel
 
-    init(event: NostrEvent, highlight: Highlight, has_action_bar: Bool, damus: DamusState, show_friend_icon: Bool) {
+    init(event: NostrEvent, highlight: Highlight, has_action_bar: Bool, damus: DamusState, show_friend_icon: Bool, size: EventViewSize = .normal) {
         self.event = event
         self.highlight = highlight
         self.has_action_bar = has_action_bar
         self.damus = damus
         self.pubkey = event.pubkey
         self.show_friend_icon = show_friend_icon
+        self.size = size
     }
 
-    init(damus: DamusState, event: NostrEvent, show_friend_icon: Bool) {
+    init(damus: DamusState, event: NostrEvent, show_friend_icon: Bool, size: EventViewSize = .normal) {
         self.event = event
         self.highlight = .none
         self.has_action_bar = false
         self.damus = damus
         self.pubkey = event.pubkey
         self.show_friend_icon = show_friend_icon
+        self.size = size
     }
 
-    init(damus: DamusState, event: NostrEvent, pubkey: String, show_friend_icon: Bool) {
+    init(damus: DamusState, event: NostrEvent, pubkey: String, show_friend_icon: Bool, size: EventViewSize = .normal) {
         self.event = event
         self.highlight = .none
         self.has_action_bar = false
         self.damus = damus
         self.pubkey = pubkey
         self.show_friend_icon = show_friend_icon
+        self.size = size
     }
 
     var body: some View {
@@ -124,9 +145,9 @@ struct EventView: View {
 
             VStack(alignment: .leading) {
                 HStack(alignment: .center) {
-                    EventProfileName(pubkey: pubkey, profile: profile, contacts: damus.contacts, show_friend_confirmed: show_friend_icon)
+                    EventProfileName(pubkey: pubkey, profile: profile, contacts: damus.contacts, show_friend_confirmed: show_friend_icon, size: size)
                     Text("\(format_relative_time(event.created_at))")
-                        .font(.body)
+                        .font(eventviewsize_to_font(size))
                         .foregroundColor(.gray)
                 }
                 
@@ -137,7 +158,7 @@ struct EventView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                NoteContentView(privkey: damus.keypair.privkey, event: event, profiles: damus.profiles, show_images: should_show_images(contacts: damus.contacts, ev: event), artifacts: .just_content(content))
+                NoteContentView(privkey: damus.keypair.privkey, event: event, profiles: damus.profiles, show_images: should_show_images(contacts: damus.contacts, ev: event), artifacts: .just_content(content), size: self.size)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 if has_action_bar {
@@ -286,6 +307,10 @@ func make_actionbar_model(ev: NostrEvent, damus: DamusState) -> ActionBarModel {
 
 struct EventView_Previews: PreviewProvider {
     static var previews: some View {
-        EventView(damus: test_damus_state(), event: NostrEvent(content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool", pubkey: "pk"), show_friend_icon: true)
+        VStack {
+            EventView(damus: test_damus_state(), event: NostrEvent(content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool", pubkey: "pk"), show_friend_icon: true, size: .small)
+            EventView(damus: test_damus_state(), event: NostrEvent(content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool", pubkey: "pk"), show_friend_icon: true, size: .normal)
+            EventView(damus: test_damus_state(), event: NostrEvent(content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool", pubkey: "pk"), show_friend_icon: true, size: .big)
+        }
     }
 }

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -189,7 +189,11 @@ struct EventView: View {
                             .padding(.top, 10)
                             .font(.body)
                             .foregroundColor(.gray)
+                        
                         Divider()
+                            .padding([.bottom], 4)
+                    } else {
+                        Rectangle().frame(height: 2).opacity(0)
                     }
                     
                     let bar = make_actionbar_model(ev: event, damus: damus)

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -56,6 +56,70 @@ func eventviewsize_to_font(_ size: EventViewKind) -> Font {
     }
 }
 
+struct BuilderEventView: View {
+    let damus: DamusState
+    let event_id: String
+    @State var event: NostrEvent?
+    @State var subscription_uuid: String = UUID().description
+    
+    func unsubscribe() {
+        damus.pool.unsubscribe(sub_id: subscription_uuid)
+    }
+    
+    func subscribe(filters: [NostrFilter]) {
+        damus.pool.register_handler(sub_id: subscription_uuid, handler: handle_event)
+        damus.pool.send(.subscribe(.init(filters: filters, sub_id: subscription_uuid)))
+    }
+    
+    func handle_event(relay_id: String, ev: NostrConnectionEvent) {
+        guard case .nostr_event(let nostr_response) = ev else {
+            return
+        }
+        
+        guard case .event(let id, let nostr_event) = nostr_response else {
+            return
+        }
+        
+        // Is current event
+        if id == subscription_uuid {
+            if event != nil {
+                return
+            }
+            
+            event = nostr_event
+            
+            unsubscribe()
+        }
+    }
+    
+    func load() {
+        subscribe(filters: [
+            NostrFilter(
+                ids: [self.event_id],
+                limit: 1
+            )
+        ])
+    }
+    
+    var body: some View {
+        VStack {
+            if event == nil {
+                ProgressView().padding()
+            } else {
+                NavigationLink(destination: BuildThreadV2View(damus: damus, event_id: event!.id)) {
+                    EventView(damus: damus, event: event!, show_friend_icon: true, size: .small, embedded: true)
+                }.buttonStyle(.plain)
+            }
+        }
+        .frame(minWidth: 0, maxWidth: .infinity)
+        .border(Color.gray.opacity(0.2), width: 1)
+        .cornerRadius(2)
+        .onAppear {
+            self.load()
+        }
+    }
+}
+
 struct EventView: View {
     let event: NostrEvent
     let highlight: Highlight
@@ -64,10 +128,11 @@ struct EventView: View {
     let pubkey: String
     let show_friend_icon: Bool
     let size: EventViewKind
+    let embedded: Bool
 
     @EnvironmentObject var action_bar: ActionBarModel
 
-    init(event: NostrEvent, highlight: Highlight, has_action_bar: Bool, damus: DamusState, show_friend_icon: Bool, size: EventViewKind = .normal) {
+    init(event: NostrEvent, highlight: Highlight, has_action_bar: Bool, damus: DamusState, show_friend_icon: Bool, size: EventViewKind = .normal, embedded: Bool = false) {
         self.event = event
         self.highlight = highlight
         self.has_action_bar = has_action_bar
@@ -75,9 +140,10 @@ struct EventView: View {
         self.pubkey = event.pubkey
         self.show_friend_icon = show_friend_icon
         self.size = size
+        self.embedded = embedded
     }
 
-    init(damus: DamusState, event: NostrEvent, show_friend_icon: Bool, size: EventViewKind = .normal) {
+    init(damus: DamusState, event: NostrEvent, show_friend_icon: Bool, size: EventViewKind = .normal, embedded: Bool = false) {
         self.event = event
         self.highlight = .none
         self.has_action_bar = false
@@ -85,9 +151,10 @@ struct EventView: View {
         self.pubkey = event.pubkey
         self.show_friend_icon = show_friend_icon
         self.size = size
+        self.embedded = embedded
     }
 
-    init(damus: DamusState, event: NostrEvent, pubkey: String, show_friend_icon: Bool, size: EventViewKind = .normal) {
+    init(damus: DamusState, event: NostrEvent, pubkey: String, show_friend_icon: Bool, size: EventViewKind = .normal, embedded: Bool = false) {
         self.event = event
         self.highlight = .none
         self.has_action_bar = false
@@ -95,6 +162,7 @@ struct EventView: View {
         self.pubkey = pubkey
         self.show_friend_icon = show_friend_icon
         self.size = size
+        self.embedded = embedded
     }
 
     var body: some View {
@@ -141,8 +209,10 @@ struct EventView: View {
                     let pmodel = ProfileModel(pubkey: pubkey, damus: damus)
                     let pv = ProfileView(damus_state: damus, profile: pmodel, followers: FollowersModel(damus_state: damus, target: pubkey))
                     
-                    NavigationLink(destination: pv) {
-                        ProfilePicView(pubkey: pubkey, size: PFP_SIZE, highlight: highlight, profiles: damus.profiles)
+                    if !embedded {
+                        NavigationLink(destination: pv) {
+                            ProfilePicView(pubkey: pubkey, size: PFP_SIZE, highlight: highlight, profiles: damus.profiles)
+                        }
                     }
                     
                     Spacer()
@@ -179,26 +249,52 @@ struct EventView: View {
 
                 NoteContentView(privkey: damus.keypair.privkey, event: event, profiles: damus.profiles, show_images: should_show_images(contacts: damus.contacts, ev: event), artifacts: .just_content(content), size: self.size)
                     .frame(maxWidth: .infinity, alignment: .leading)
-
-                if has_action_bar {
-                    if size == .selected {
-                        Text("\(format_date(event.created_at))")
-                            .padding(.top, 10)
-                            .font(.footnote)
-                            .foregroundColor(.gray)
+                
+                if !embedded {
+                    let blocks = event.blocks(damus.keypair.privkey).filter { block in
+                        guard case .mention(let mention) = block else {
+                            return false
+                        }
                         
-                        Divider()
-                            .padding([.bottom], 4)
-                    } else {
-                        Rectangle().frame(height: 2).opacity(0)
+                        guard case .event = mention.type else {
+                            return false
+                        }
+                        
+                        if mention.ref.key != "e" {
+                            return false
+                        }
+                        
+                        
+                        return true
                     }
                     
-                    let bar = make_actionbar_model(ev: event, damus: damus)
-                    EventActionBar(damus_state: damus, event: event, bar: bar)
+                    /// MARK: - Preview
+                    if let firstBlock = blocks.first, case .mention(let mention) = firstBlock, mention.ref.key == "e" {
+                        BuilderEventView(damus: damus, event_id: mention.ref.id)
+                    }
                 }
 
-                Divider()
-                    .padding([.top], 4)
+                if !embedded {
+                    if has_action_bar {
+                        if size == .selected {
+                            Text("\(format_date(event.created_at))")
+                                .padding(.top, 10)
+                                .font(.footnote)
+                                .foregroundColor(.gray)
+                            
+                            Divider()
+                                .padding([.bottom], 4)
+                        } else {
+                            Rectangle().frame(height: 2).opacity(0)
+                        }
+                        
+                        let bar = make_actionbar_model(ev: event, damus: damus)
+                        EventActionBar(damus_state: damus, event: event, bar: bar)
+                    }
+
+                    Divider()
+                        .padding([.top], 4)
+                }
             }
             .padding([.leading], 2)
         }

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -162,7 +162,7 @@ struct EventView: View {
                             }
                             
                             Spacer()
-                        }.padding(.bottom, 10)
+                        }
                     }
                     
                     EventProfileName(pubkey: pubkey, profile: profile, contacts: damus.contacts, show_friend_confirmed: show_friend_icon, size: size)
@@ -171,7 +171,7 @@ struct EventView: View {
                             .font(eventviewsize_to_font(size))
                             .foregroundColor(.gray)
                     }
-                }
+                }.padding(.bottom, 10)
                 
                 if event.is_reply(damus.keypair.privkey) {
                     Text("\(reply_desc(profiles: damus.profiles, event: event))")

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -249,6 +249,7 @@ struct EventView: View {
 
                 NoteContentView(privkey: damus.keypair.privkey, event: event, profiles: damus.profiles, show_images: should_show_images(contacts: damus.contacts, ev: event), artifacts: .just_content(content), size: self.size)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .allowsHitTesting(!embedded)
                 
                 if !embedded {
                     let blocks = event.blocks(damus.keypair.privkey).filter { block in

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -159,8 +159,6 @@ struct EventView: View {
                             NavigationLink(destination: pv) {
                                 ProfilePicView(pubkey: pubkey, size: PFP_SIZE, highlight: highlight, profiles: damus.profiles)
                             }
-                            
-                            Spacer()
                         }
                     }
                     

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -171,7 +171,7 @@ struct EventView: View {
                             .font(eventviewsize_to_font(size))
                             .foregroundColor(.gray)
                     }
-                }.padding(.bottom, size == .selected ? 10 : 1)
+                }
                 
                 if event.is_reply(damus.keypair.privkey) {
                     Text("\(reply_desc(profiles: damus.profiles, event: event))")

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -133,21 +133,38 @@ struct EventView: View {
 
     func TextEvent(_ event: NostrEvent, pubkey: String) -> some View {
         let content = event.get_content(damus.keypair.privkey)
+        
         return HStack(alignment: .top) {
             let profile = damus.profiles.lookup(id: pubkey)
-            VStack {
-                let pmodel = ProfileModel(pubkey: pubkey, damus: damus)
-                let pv = ProfileView(damus_state: damus, profile: pmodel, followers: FollowersModel(damus_state: damus, target: pubkey))
-
-                NavigationLink(destination: pv) {
-                    ProfilePicView(pubkey: pubkey, size: PFP_SIZE, highlight: highlight, profiles: damus.profiles)
+            
+            if size != .selected {
+                VStack {
+                    let pmodel = ProfileModel(pubkey: pubkey, damus: damus)
+                    let pv = ProfileView(damus_state: damus, profile: pmodel, followers: FollowersModel(damus_state: damus, target: pubkey))
+                    
+                    NavigationLink(destination: pv) {
+                        ProfilePicView(pubkey: pubkey, size: PFP_SIZE, highlight: highlight, profiles: damus.profiles)
+                    }
+                    
+                    Spacer()
                 }
-
-                Spacer()
             }
 
             VStack(alignment: .leading) {
                 HStack(alignment: .center) {
+                    if size == .selected {
+                        VStack {
+                            let pmodel = ProfileModel(pubkey: pubkey, damus: damus)
+                            let pv = ProfileView(damus_state: damus, profile: pmodel, followers: FollowersModel(damus_state: damus, target: pubkey))
+                            
+                            NavigationLink(destination: pv) {
+                                ProfilePicView(pubkey: pubkey, size: PFP_SIZE, highlight: highlight, profiles: damus.profiles)
+                            }
+                            
+                            Spacer()
+                        }.padding(.bottom, 10)
+                    }
+                    
                     EventProfileName(pubkey: pubkey, profile: profile, contacts: damus.contacts, show_friend_confirmed: show_friend_icon, size: size)
                     if size != .selected {
                         Text("\(format_relative_time(event.created_at))")

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -57,7 +57,7 @@ struct NoteContentView: View {
     
     @State var artifacts: NoteArtifacts
     
-    let size: EventViewSize
+    let size: EventViewKind
     
     func MainContent() -> some View {
         let md_opts: AttributedString.MarkdownParsingOptions =

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -57,6 +57,8 @@ struct NoteContentView: View {
     
     @State var artifacts: NoteArtifacts
     
+    let size: EventViewSize
+    
     func MainContent() -> some View {
         let md_opts: AttributedString.MarkdownParsingOptions =
             .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -64,10 +66,10 @@ struct NoteContentView: View {
         return VStack(alignment: .leading) {
             if let txt = try? AttributedString(markdown: artifacts.content, options: md_opts) {
                 Text(txt)
-                    .font(.body)
+                    .font(eventviewsize_to_font(size))
             } else {
                 Text(artifacts.content)
-                    .font(.body)
+                    .font(eventviewsize_to_font(size))
             }
             if show_images && artifacts.images.count > 0 {
                 ImageCarousel(urls: artifacts.images)
@@ -126,6 +128,6 @@ struct NoteContentView_Previews: PreviewProvider {
         let state = test_damus_state()
         let content = "hi there https://jb55.com/s/Oct12-150217.png 5739a762ef6124dd.jpg"
         let artifacts = NoteArtifacts(content: content, images: [], invoices: [])
-        NoteContentView(privkey: "", event: NostrEvent(content: content, pubkey: "pk"), profiles: state.profiles, show_images: true, artifacts: artifacts)
+        NoteContentView(privkey: "", event: NostrEvent(content: content, pubkey: "pk"), profiles: state.profiles, show_images: true, artifacts: artifacts, size: .normal)
     }
 }

--- a/damus/Views/ProfileName.swift
+++ b/damus/Views/ProfileName.swift
@@ -104,20 +104,24 @@ struct EventProfileName: View {
     
     @State var display_name: String?
     
-    init(pubkey: String, profile: Profile?, contacts: Contacts, show_friend_confirmed: Bool) {
+    let size: EventViewSize
+    
+    init(pubkey: String, profile: Profile?, contacts: Contacts, show_friend_confirmed: Bool, size: EventViewSize = .normal) {
         self.pubkey = pubkey
         self.profile = profile
         self.prefix = ""
         self.contacts = contacts
         self.show_friend_confirmed = show_friend_confirmed
+        self.size = size
     }
     
-    init(pubkey: String, profile: Profile?, prefix: String, contacts: Contacts, show_friend_confirmed: Bool) {
+    init(pubkey: String, profile: Profile?, prefix: String, contacts: Contacts, show_friend_confirmed: Bool, size: EventViewSize = .normal) {
         self.pubkey = pubkey
         self.profile = profile
         self.prefix = prefix
         self.contacts = contacts
         self.show_friend_confirmed = show_friend_confirmed
+        self.size = size
     }
     
     var friend_icon: String? {
@@ -144,10 +148,10 @@ struct EventProfileName: View {
                 
                 Text("@" + String(display_name ?? Profile.displayName(profile: profile, pubkey: pubkey)))
                     .foregroundColor(.gray)
-                    .font(.body)
+                    .font(eventviewsize_to_font(size))
             } else {
                 Text(String(display_name ?? Profile.displayName(profile: profile, pubkey: pubkey)))
-                    .font(.body)
+                    .font(eventviewsize_to_font(size))
                     .fontWeight(.bold)
             }
             

--- a/damus/Views/ProfileName.swift
+++ b/damus/Views/ProfileName.swift
@@ -104,9 +104,9 @@ struct EventProfileName: View {
     
     @State var display_name: String?
     
-    let size: EventViewSize
+    let size: EventViewKind
     
-    init(pubkey: String, profile: Profile?, contacts: Contacts, show_friend_confirmed: Bool, size: EventViewSize = .normal) {
+    init(pubkey: String, profile: Profile?, contacts: Contacts, show_friend_confirmed: Bool, size: EventViewKind = .normal) {
         self.pubkey = pubkey
         self.profile = profile
         self.prefix = ""
@@ -115,7 +115,7 @@ struct EventProfileName: View {
         self.size = size
     }
     
-    init(pubkey: String, profile: Profile?, prefix: String, contacts: Contacts, show_friend_confirmed: Bool, size: EventViewSize = .normal) {
+    init(pubkey: String, profile: Profile?, prefix: String, contacts: Contacts, show_friend_confirmed: Bool, size: EventViewKind = .normal) {
         self.pubkey = pubkey
         self.profile = profile
         self.prefix = prefix

--- a/damus/Views/ReplyQuoteView.swift
+++ b/damus/Views/ReplyQuoteView.swift
@@ -31,7 +31,7 @@ struct ReplyQuoteView: View {
                         .foregroundColor(.gray)
                 }
                 
-                NoteContentView(privkey: privkey, event: event, profiles: profiles, show_images: false, artifacts: .just_content(event.content))
+                NoteContentView(privkey: privkey, event: event, profiles: profiles, show_images: false, artifacts: .just_content(event.content), size: .normal)
                     .font(.callout)
                     .foregroundColor(.accentColor)
                 

--- a/damus/Views/SearchResultsView.swift
+++ b/damus/Views/SearchResultsView.swift
@@ -53,8 +53,11 @@ struct SearchResultsView: View {
                     let prof_model = ProfileModel(pubkey: h, damus: damus_state)
                     let f = FollowersModel(damus_state: damus_state, target: h)
                     let prof_view = ProfileView(damus_state: damus_state, profile: prof_model, followers: f)
-                    let thread_model = ThreadModel(evid: h, damus_state: damus_state)
-                    let ev_view = ThreadView(thread: thread_model, damus: damus_state, is_chatroom: false)
+                    let ev_view = BuildThreadV2View(
+                        damus: damus_state,
+                        event_id: h
+                    )
+
                     VStack(spacing: 50) {
                         NavigationLink(destination: prof_view) {
                             Text("Goto profile \(h)")
@@ -66,8 +69,10 @@ struct SearchResultsView: View {
                 case .note(let nid):
                     let decoded = try? bech32_decode(nid)
                     let hex = hex_encode(decoded!.data)
-                    let thread_model = ThreadModel(evid: hex, damus_state: damus_state)
-                    let ev_view = ThreadView(thread: thread_model, damus: damus_state, is_chatroom: false)
+                    let ev_view = BuildThreadV2View(
+                        damus: damus_state,
+                        event_id: hex
+                    )
                     NavigationLink(destination: ev_view) {
                         Text("Goto post \(nid)")
                     }

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -214,11 +214,55 @@ struct ThreadV2View: View {
     let thread: ThreadV2
     
     var body: some View {
-        ScrollView {
-            VStack {
-                // MARK: - Parents events view
+        ScrollViewReader { reader in
+            ScrollView {
                 VStack {
-                    ForEach(thread.parentEvents, id: \.id) { event in
+                    // MARK: - Parents events view
+                    VStack {
+                        ForEach(thread.parentEvents, id: \.id) { event in
+                            NavigationLink(destination: BuildThreadV2View(
+                                damus: damus,
+                                event_id: event.id
+                            )){
+                                EventView(
+                                    event: event,
+                                    highlight: .none,
+                                    has_action_bar: true,
+                                    damus: damus,
+                                    show_friend_icon: true, // TODO: change it
+                                    size: .small
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .onAppear {
+                                // TODO: find another solution to prevent layout shifting and layout blocking on large responses
+                                reader.scrollTo("main", anchor: .center)
+                            }
+                        }
+                    }.background(GeometryReader { geometry in
+                        // get the height and width of the EventView view
+                        let eventHeight = geometry.frame(in: .global).height
+                        //                    let eventWidth = geometry.frame(in: .global).width
+                        
+                        // vertical gray line in the background
+                        Rectangle()
+                            .fill(Color.gray.opacity(0.5))
+                            .frame(width: 2, height: eventHeight)
+                            .offset(x: 25, y: 40)
+                    })
+                    
+                    // MARK: - Actual event view
+                    EventView(
+                        event: thread.current,
+                        highlight: .none,
+                        has_action_bar: true,
+                        damus: damus,
+                        show_friend_icon: true, // TODO: change it
+                        size: .selected
+                    ).id("main")
+                    
+                    // MARK: - Responses of the actual event view
+                    ForEach(thread.childEvents, id: \.id) { event in
                         NavigationLink(destination: BuildThreadV2View(
                             damus: damus,
                             event_id: event.id
@@ -233,46 +277,9 @@ struct ThreadV2View: View {
                             )
                         }.buttonStyle(.plain)
                     }
-                }.background(GeometryReader { geometry in
-                    // get the height and width of the EventView view
-                    let eventHeight = geometry.frame(in: .global).height
-//                    let eventWidth = geometry.frame(in: .global).width
-
-                    // vertical gray line in the background
-                    Rectangle()
-                        .fill(Color.gray.opacity(0.5))
-                        .frame(width: 2, height: eventHeight)
-                        .offset(x: 25, y: 40)
-                })
-                
-                // MARK: - Actual event view
-                EventView(
-                    event: thread.current,
-                    highlight: .none,
-                    has_action_bar: true,
-                    damus: damus,
-                    show_friend_icon: true, // TODO: change it
-                    size: .selected
-                )
-                
-                // MARK: - Responses of the actual event view
-                ForEach(thread.childEvents, id: \.id) { event in
-                    NavigationLink(destination: BuildThreadV2View(
-                        damus: damus,
-                        event_id: event.id
-                    )){
-                        EventView(
-                            event: event,
-                            highlight: .none,
-                            has_action_bar: true,
-                            damus: damus,
-                            show_friend_icon: true, // TODO: change it
-                            size: .small
-                        )
-                    }.buttonStyle(.plain)
                 }
-            }
-        }.padding().navigationBarTitle("Thread")
+            }.padding().navigationBarTitle("Thread")
+        }
     }
 }
 

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -13,6 +13,35 @@ struct ThreadV2 {
     var childEvents: [NostrEvent]
 }
 
+struct BuildThreadV2View: View {
+    let damus: DamusState
+    let event_id: String
+    
+    @State var thread: ThreadV2?
+    
+    init(damus: DamusState, event_id: String, thread: ThreadV2? = nil) {
+        self.damus = damus
+        self.event_id = event_id
+        self.thread = thread
+        
+        if self.thread == nil {
+            self.reload()
+        }
+    }
+    
+    func reload() {
+        // TODO: construct the thread
+    }
+    
+    var body: some View {
+        if thread == nil {
+            ProgressView()
+        } else {
+            ThreadV2View(damus: damus, thread: thread!)
+        }
+    }
+}
+
 struct ThreadV2View: View {
     let damus: DamusState
     let thread: ThreadV2
@@ -72,6 +101,7 @@ struct ThreadV2View: View {
 
 struct ThreadV2View_Previews: PreviewProvider {
     static var previews: some View {
+        BuildThreadV2View(damus: test_damus_state(), event_id: "ac9fd97b53b0c1d22b3aea2a3d62e11ae393960f5f91ee1791987d60151339a7")
         ThreadV2View(
             damus: test_damus_state(),
             thread: ThreadV2(

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -33,11 +33,11 @@ struct ThreadV2View: View {
                         )
                     }
                 }.background(GeometryReader { geometry in
-                    // définition de la hauteur et de la largeur de la vue EventView
+                    // get the height and width of the EventView view
                     let eventHeight = geometry.frame(in: .global).height
-                    let eventWidth = geometry.frame(in: .global).width
+//                    let eventWidth = geometry.frame(in: .global).width
 
-                    // trait gris vertical en arrière-plan
+                    // vertical gray line in the background
                     Rectangle()
                         .fill(Color.gray.opacity(0.5))
                         .frame(width: 2, height: eventHeight)

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -13,9 +13,28 @@ struct ThreadV2 {
     var childEvents: [NostrEvent]
 }
 
+//class ThreadV2: ObservableObject {
+//    @Published var initial_event: NostrEvent
+//    @Published var parentEvents: [NostrEvent]
+//    @Published var current: NostrEvent
+//    @Published var childEvents: [NostrEvent]
+//    @Published var loading: Bool = false
+//
+//    let damus_state: DamusState
+//
+//    init(initial_event: NostrEvent, damus_state: DamusState) {
+//        self.damus_state = damus_state
+//        self.initial_event = initial_event
+//    }
+//}
+
 struct BuildThreadV2View: View {
     let damus: DamusState
+    
+    @State var parents_ids: [String]
     let event_id: String
+    
+    @State var current_event: NostrEvent? = nil
     
     @State var thread: ThreadV2?
     
@@ -23,19 +42,85 @@ struct BuildThreadV2View: View {
         self.damus = damus
         self.event_id = event_id
         self.thread = thread
-        
-        if self.thread == nil {
-            self.reload()
-        }
+        self.parents_ids = []
     }
     
+    let current_events_uuid = UUID().description
+    let parents_events_uuid = UUID().description
+    let childs_events_uuid = UUID().description
+    
+    func handle_event(relay_id: String, ev: NostrConnectionEvent) {
+        guard case .nostr_event(let nostr_response) = ev else {
+            return
+        }
+        
+        guard case .event(_, let nostr_event) = nostr_response else {
+            return
+        }
+        
+        // Is current event
+        if nostr_event.id == event_id {
+            if current_event != nil {
+                return
+            }
+            
+            current_event = nostr_event
+            
+            thread = ThreadV2(
+                parentEvents: [],
+                current: current_event!,
+                childEvents: []
+            )
+            
+            // Get parents
+            parents_ids = current_event!.tags.filter { tag in
+              return tag.count == 2 && tag[0] == "e"
+            }.map { tag in
+              return tag[1]
+            }
+            
+            // Ask for parents
+            var parents_events = NostrFilter(
+                ids: parents_ids,
+                limit: UInt32(parents_ids.count)
+            )
+            damus.pool.send(.subscribe(.init(filters: [parents_events], sub_id: parents_events_uuid)))
+            
+            // Ask for children
+            var childs_events = NostrFilter(
+                referenced_ids: [self.event_id],
+                limit: 50
+            )
+            damus.pool.send(.subscribe(.init(filters: [childs_events], sub_id: childs_events_uuid)))
+            
+            return
+        }
+        
+        print("event!")
+        print(nostr_event.description)
+    }
+
+    
     func reload() {
-        // TODO: construct the thread
+        damus.pool.register_handler(sub_id: current_events_uuid, handler: handle_event)
+        
+        // Get the current event
+        print("subscribing to threadV2 \(event_id) with sub_id \(current_events_uuid)")
+        var current_events = NostrFilter(
+            ids: [self.event_id],
+            limit: 1
+        )
+        damus.pool.send(.subscribe(.init(filters: [current_events], sub_id: current_events_uuid)))
     }
     
     var body: some View {
         if thread == nil {
             ProgressView()
+                .onAppear {
+                    if self.thread == nil {
+                        self.reload()
+                    }
+                }
         } else {
             ThreadV2View(damus: damus, thread: thread!)
         }

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -180,9 +180,6 @@ struct BuildThreadV2View: View {
             thread!.clean()
             return
         }
-        
-//        print("ThreadV2View: Unknown event id: \(id)")
-//        print(nostr_event.content)
     }
 
     func reload() {
@@ -196,7 +193,6 @@ struct BuildThreadV2View: View {
                 limit: 1
             )
         ])
-        damus.pool.register_handler(sub_id: current_events_uuid, handler: handle_event)
         print("subscribing to threadV2 \(event_id) with sub_id \(current_events_uuid)")
     }
     

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -106,7 +106,7 @@ struct BuildThreadV2View: View {
         
         // Get the current event
         print("subscribing to threadV2 \(event_id) with sub_id \(current_events_uuid)")
-        var current_events = NostrFilter(
+        let current_events = NostrFilter(
             ids: [self.event_id],
             limit: 1
         )

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -169,7 +169,7 @@ struct BuildThreadV2View: View {
             }
             
             thread!.clean()
-            // damus.pool.unsubscribe(sub_id: id)
+            unsubscribe(id)
             return
         }
         

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -219,14 +219,19 @@ struct ThreadV2View: View {
                 // MARK: - Parents events view
                 VStack {
                     ForEach(thread.parentEvents, id: \.id) { event in
-                        EventView(
-                            event: event,
-                            highlight: .none,
-                            has_action_bar: true,
+                        NavigationLink(destination: BuildThreadV2View(
                             damus: damus,
-                            show_friend_icon: true, // TODO: change it
-                            size: .small
-                        )
+                            event_id: event.id
+                        )){
+                            EventView(
+                                event: event,
+                                highlight: .none,
+                                has_action_bar: true,
+                                damus: damus,
+                                show_friend_icon: true, // TODO: change it
+                                size: .small
+                            )
+                        }.buttonStyle(.plain)
                     }
                 }.background(GeometryReader { geometry in
                     // get the height and width of the EventView view
@@ -252,14 +257,19 @@ struct ThreadV2View: View {
                 
                 // MARK: - Responses of the actual event view
                 ForEach(thread.childEvents, id: \.id) { event in
-                    EventView(
-                        event: event,
-                        highlight: .none,
-                        has_action_bar: true,
+                    NavigationLink(destination: BuildThreadV2View(
                         damus: damus,
-                        show_friend_icon: true, // TODO: change it
-                        size: .small
-                    )
+                        event_id: event.id
+                    )){
+                        EventView(
+                            event: event,
+                            highlight: .none,
+                            has_action_bar: true,
+                            damus: damus,
+                            show_friend_icon: true, // TODO: change it
+                            size: .small
+                        )
+                    }.buttonStyle(.plain)
                 }
             }
         }.padding().navigationBarTitle("Thread")

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -24,8 +24,10 @@ struct ThreadV2View: View {
                 VStack {
                     ForEach(thread.parentEvents, id: \.id) { event in
                         EventView(
-                            damus: damus,
                             event: event,
+                            highlight: .none,
+                            has_action_bar: true,
+                            damus: damus,
                             show_friend_icon: true, // TODO: change it
                             size: .small
                         )
@@ -44,17 +46,21 @@ struct ThreadV2View: View {
                 
                 // MARK: - Actual event view
                 EventView(
-                    damus: damus,
                     event: thread.current,
+                    highlight: .none,
+                    has_action_bar: true,
+                    damus: damus,
                     show_friend_icon: true, // TODO: change it
-                    size: .big
+                    size: .selected
                 )
                 
                 // MARK: - Responses of the actual event view
                 ForEach(thread.childEvents, id: \.id) { event in
                     EventView(
-                        damus: damus,
                         event: event,
+                        highlight: .none,
+                        has_action_bar: true,
+                        damus: damus,
                         show_friend_icon: true, // TODO: change it
                         size: .small
                     )

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -1,0 +1,85 @@
+//
+//  ThreadV2View.swift
+//  damus
+//
+//  Created by Thomas Tastet on 25/12/2022.
+//
+
+import SwiftUI
+
+struct ThreadV2 {
+    var parentEvents: [NostrEvent]
+    var current: NostrEvent
+    var childEvents: [NostrEvent]
+}
+
+struct ThreadV2View: View {
+    let damus: DamusState
+    let thread: ThreadV2
+    
+    var body: some View {
+        ScrollView {
+            VStack {
+                // MARK: - Parents events view
+                VStack {
+                    ForEach(thread.parentEvents, id: \.id) { event in
+                        EventView(
+                            damus: damus,
+                            event: event,
+                            show_friend_icon: true, // TODO: change it
+                            size: .small
+                        )
+                    }
+                }.background(GeometryReader { geometry in
+                    // définition de la hauteur et de la largeur de la vue EventView
+                    let eventHeight = geometry.frame(in: .global).height
+                    let eventWidth = geometry.frame(in: .global).width
+
+                    // trait gris vertical en arrière-plan
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.5))
+                        .frame(width: 2, height: eventHeight)
+                        .offset(x: 25, y: 40)
+                })
+                
+                // MARK: - Actual event view
+                EventView(
+                    damus: damus,
+                    event: thread.current,
+                    show_friend_icon: true, // TODO: change it
+                    size: .big
+                )
+                
+                // MARK: - Responses of the actual event view
+                ForEach(thread.childEvents, id: \.id) { event in
+                    EventView(
+                        damus: damus,
+                        event: event,
+                        show_friend_icon: true, // TODO: change it
+                        size: .small
+                    )
+                }
+            }
+        }.padding().navigationBarTitle("Thread")
+    }
+}
+
+struct ThreadV2View_Previews: PreviewProvider {
+    static var previews: some View {
+        ThreadV2View(
+            damus: test_damus_state(),
+            thread: ThreadV2(
+                parentEvents: [
+                    NostrEvent(id: "1", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                    NostrEvent(id: "2", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                    NostrEvent(id: "3", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                ],
+                current: NostrEvent(id: "4", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                childEvents: [
+                    NostrEvent(id: "5", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                    NostrEvent(id: "6", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                ]
+            )
+        )
+    }
+}

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -110,6 +110,7 @@ struct BuildThreadV2View: View {
                 parents_events_uuids.append(uuid)
                 print("ThreadV2View: Ask for parents (\(uuid)) (\(parents_events))")
                 damus.pool.register_handler(sub_id: uuid, handler: handle_event)
+                //OK
                 damus.pool.send(.subscribe(.init(filters: [parents_events], sub_id: uuid)))
             }
             
@@ -121,6 +122,7 @@ struct BuildThreadV2View: View {
             childs_events_uuid = UUID().description
             print("ThreadV2View: Ask for children (\(childs_events) (\(childs_events_uuid))")
             damus.pool.register_handler(sub_id: childs_events_uuid, handler: handle_event)
+            //OK
             damus.pool.send(.subscribe(.init(filters: [childs_events], sub_id: childs_events_uuid)))
             
             return
@@ -154,6 +156,7 @@ struct BuildThreadV2View: View {
                 parents_events_uuids.append(uuid)
                 print("ThreadV2View: Ask for sub_parents (\(local_parents_ids)) \(uuid)")
                 damus.pool.register_handler(sub_id: uuid, handler: handle_event)
+                //OK
                 damus.pool.send(.subscribe(.init(filters: [parents_events], sub_id: uuid)))
             }
             
@@ -176,6 +179,7 @@ struct BuildThreadV2View: View {
 
     func reload() {
         self.unsubscribe_all()
+        print("ThreadV2View: Reload!")
         
         // Get the current event
         current_events_uuid = UUID().description
@@ -192,18 +196,19 @@ struct BuildThreadV2View: View {
         VStack {
             if thread == nil {
                 ProgressView()
-                    .onAppear {
-                        if self.thread == nil {
-                            self.reload()
-                        }
-                    }
-                    .onDisappear {
-                        self.unsubscribe_all()
-                    }
             } else {
                 ThreadV2View(damus: damus, thread: thread!)
             }
-        }.onReceive(handle_notify(.switched_timeline)) { n in
+        }
+        .onAppear {
+            if self.thread == nil {
+                self.reload()
+            }
+        }
+        .onDisappear {
+            self.unsubscribe_all()
+        }
+        .onReceive(handle_notify(.switched_timeline)) { n in
             dismiss()
         }
     }

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -108,10 +108,10 @@ struct BuildThreadV2View: View {
             )
             
             // Get parents
-            parents_ids = current_event!.tags.filter { tag in
-              return tag.count == 2 && tag[0] == "e"
+            parents_ids = current_event!.tags.enumerated().filter { (index, tag) in
+                return tag.count >= 2 && tag[0] == "e" && !current_event!.content.contains("#[\(index)]")
             }.map { tag in
-              return tag[1]
+                return tag.1[1]
             }
             
             print("ThreadV2View: Parents list: (\(parents_ids)")
@@ -144,10 +144,10 @@ struct BuildThreadV2View: View {
             thread!.parentEvents.append(nostr_event)
             
             // Get parents of parents
-            let local_parents_ids = nostr_event.tags.filter { tag in
-              return tag.count >= 2 && tag[0] == "e"
+            let local_parents_ids = nostr_event.tags.enumerated().filter { (index, tag) in
+                return tag.count >= 2 && tag[0] == "e" && !nostr_event.content.contains("#[\(index)]")
             }.map { tag in
-              return tag[1]
+                return tag.1[1]
             }.filter { tag_id in
                 return !parents_ids.contains(tag_id)
             }

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -39,24 +39,23 @@ struct ThreadV2 {
 struct BuildThreadV2View: View {
     let damus: DamusState
     
-    @State var parents_ids: [String]
+    @State var parents_ids: [String] = []
     let event_id: String
     
     @State var current_event: NostrEvent? = nil
     
-    @State var thread: ThreadV2?
+    @State var thread: ThreadV2? = nil
     
     @State var current_events_uuid: String = ""
     @State var childs_events_uuid: String = ""
+    @State var parents_events_uuids: [String] = []
     
-    init(damus: DamusState, event_id: String, thread: ThreadV2? = nil) {
+    @Environment(\.dismiss) var dismiss
+    
+    init(damus: DamusState, event_id: String) {
         self.damus = damus
         self.event_id = event_id
-        self.thread = thread
-        self.parents_ids = []
     }
-    
-    @State var parents_events_uuids: [String] = []
     
     func unsubscribe_all() {
         print("ThreadV2View: Unsubscribe all..")
@@ -190,18 +189,22 @@ struct BuildThreadV2View: View {
     }
     
     var body: some View {
-        if thread == nil {
-            ProgressView()
-                .onAppear {
-                    if self.thread == nil {
-                        self.reload()
+        VStack {
+            if thread == nil {
+                ProgressView()
+                    .onAppear {
+                        if self.thread == nil {
+                            self.reload()
+                        }
                     }
-                }
-                .onDisappear {
-                    self.unsubscribe_all()
-                }
-        } else {
-            ThreadV2View(damus: damus, thread: thread!)
+                    .onDisappear {
+                        self.unsubscribe_all()
+                    }
+            } else {
+                ThreadV2View(damus: damus, thread: thread!)
+            }
+        }.onReceive(handle_notify(.switched_timeline)) { n in
+            dismiss()
         }
     }
 }

--- a/damus/Views/TimelineView.swift
+++ b/damus/Views/TimelineView.swift
@@ -24,9 +24,9 @@ struct InnerTimelineView: View {
                 EmptyTimelineView()
             } else {
                 ForEach(events.filter(filter), id: \.id) { (ev: NostrEvent) in
-                    let tm = ThreadModel(event: inner_event_or_self(ev: ev), damus_state: damus)
-                    let is_chatroom = should_show_chatroom(ev)
-                    let tv = ThreadView(thread: tm, damus: damus, is_chatroom: is_chatroom)
+                    //let tm = ThreadModel(event: inner_event_or_self(ev: ev), damus_state: damus)
+                    //let is_chatroom = should_show_chatroom(ev)
+                    //let tv = ThreadView(thread: tm, damus: damus, is_chatroom: is_chatroom)
                                 
                     NavigationLink(destination: BuildThreadV2View(
                         damus: damus,

--- a/damus/Views/TimelineView.swift
+++ b/damus/Views/TimelineView.swift
@@ -28,20 +28,10 @@ struct InnerTimelineView: View {
                     let is_chatroom = should_show_chatroom(ev)
                     let tv = ThreadView(thread: tm, damus: damus, is_chatroom: is_chatroom)
                                 
-                    NavigationLink(destination: ThreadV2View(
+                    NavigationLink(destination: BuildThreadV2View(
                         damus: damus,
-                        thread: ThreadV2(
-                            parentEvents: [
-                                NostrEvent(id: "1", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
-                                NostrEvent(id: "2", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
-                                NostrEvent(id: "3", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
-                            ],
-                            current: NostrEvent(id: "4", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
-                            childEvents: [
-                                NostrEvent(id: "5", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
-                                NostrEvent(id: "6", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
-                            ]
-                        )                    )) {
+                        event_id: ev.id
+                    )) {
                         EventView(event: ev, highlight: .none, has_action_bar: true, damus: damus, show_friend_icon: show_friend_icon)
                     }
                     .isDetailLink(true)

--- a/damus/Views/TimelineView.swift
+++ b/damus/Views/TimelineView.swift
@@ -28,7 +28,20 @@ struct InnerTimelineView: View {
                     let is_chatroom = should_show_chatroom(ev)
                     let tv = ThreadView(thread: tm, damus: damus, is_chatroom: is_chatroom)
                                 
-                    NavigationLink(destination: tv) {
+                    NavigationLink(destination: ThreadV2View(
+                        damus: damus,
+                        thread: ThreadV2(
+                            parentEvents: [
+                                NostrEvent(id: "1", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                                NostrEvent(id: "2", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                                NostrEvent(id: "3", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                            ],
+                            current: NostrEvent(id: "4", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                            childEvents: [
+                                NostrEvent(id: "5", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                                NostrEvent(id: "6", content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool 4", pubkey: "916b7aca250f43b9f842faccc831db4d155088632a8c27c0d140f2043331ba57"),
+                            ]
+                        )                    )) {
                         EventView(event: ev, highlight: .none, has_action_bar: true, damus: damus, show_friend_icon: show_friend_icon)
                     }
                     .isDetailLink(true)


### PR DESCRIPTION
Hi everyone,

I modified the threads to make them more like those on Twitter.
The functionality is simple: parent events are displayed above, and the direct child events of the currently viewed event are displayed (no other replies).

TODO:

- [x] Home button dismiss the thread view
- [x] Navigation link on others events in the thread view
- [x] Center current event when loading parents
- [x] Extra spaces cleanup
- [x] Subscription rejected: Too many subscriptions: Number of subscriptions must be less than or equal to 10