### PR TITLE
fix: Add Divider() to bottom of navigation bar

### DIFF
--- a/damus/Views/MainTabView.swift
+++ b/damus/Views/MainTabView.swift
@@ -81,9 +81,7 @@ struct TabBar: View {
                 TabButton(timeline: .search, img: "magnifyingglass.circle", selected: $selected, new_events: $new_events, action: action)
                 TabButton(timeline: .notifications, img: "bell", selected: $selected, new_events: $new_events, action: action)
             }
+            Divider()
         }
     }
 }
-
-
-


### PR DESCRIPTION
It bugged me whenever I opened the app that the icons in the bottom main tab bar weren't centered and were too close to the bottom of the screen. I added a divider to the bottom of the tab bar to center it and give a bit more space from the bottom of the screen (or window in macOS). In my personal opinion it makes it look much better.