### PR TITLE
added ability to zoom profile pic on double-tap

### DIFF
--- a/damus/Views/ProfilePicView.swift
+++ b/damus/Views/ProfilePicView.swift
@@ -34,16 +34,18 @@ func pfp_line_width(_ h: Highlight) -> CGFloat {
 
 struct InnerProfilePicView: View {
     @Environment(\.redactionReasons) private var reasons
-    
+
     let url: URL?
     let pubkey: String
     let size: CGFloat
     let highlight: Highlight
-    
+
+    @State var is_zoomed: Bool = false
+
     var PlaceholderColor: Color {
         return id_to_color(pubkey)
     }
-    
+
     var Placeholder: some View {
         PlaceholderColor
             .frame(width: size, height: size)
@@ -51,7 +53,7 @@ struct InnerProfilePicView: View {
             .overlay(Circle().stroke(highlight_color(highlight), lineWidth: pfp_line_width(highlight)))
             .padding(2)
     }
-    
+
     var body: some View {
         Group {
             if reasons.isEmpty {
@@ -73,8 +75,18 @@ struct InnerProfilePicView: View {
         .frame(width: size, height: size)
         .clipShape(Circle())
         .overlay(Circle().stroke(highlight_color(highlight), lineWidth: pfp_line_width(highlight)))
+        .onTapGesture(count: 2) {
+            is_zoomed.toggle()
+        }
+        .sheet(isPresented: $is_zoomed) {
+            KFAnimatedImage(url)
+                .cacheOriginalImage()
+                .loadDiskFileSynchronously()
+                .tag(2)
+                .clipShape(Circle())
+                .frame(width: 300, height: 300, alignment: .center)
+        }
     }
-    
 }
 
 struct ProfilePicView: View {

--- a/damus/Views/ProfilePicView.swift
+++ b/damus/Views/ProfilePicView.swift
@@ -40,8 +40,6 @@ struct InnerProfilePicView: View {
     let size: CGFloat
     let highlight: Highlight
 
-    @State var is_zoomed: Bool = false
-
     var PlaceholderColor: Color {
         return id_to_color(pubkey)
     }
@@ -75,17 +73,6 @@ struct InnerProfilePicView: View {
         .frame(width: size, height: size)
         .clipShape(Circle())
         .overlay(Circle().stroke(highlight_color(highlight), lineWidth: pfp_line_width(highlight)))
-        .onTapGesture(count: 2) {
-            is_zoomed.toggle()
-        }
-        .sheet(isPresented: $is_zoomed) {
-            KFAnimatedImage(url)
-                .cacheOriginalImage()
-                .loadDiskFileSynchronously()
-                .tag(2)
-                .clipShape(Circle())
-                .frame(width: 300, height: 300, alignment: .center)
-        }
     }
 }
 

--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -113,11 +113,13 @@ struct EditButton: View {
 
 struct ProfileView: View {
     let damus_state: DamusState
+    let zoom_size: CGFloat = 350
     
     @State private var selected_tab: ProfileTab = .posts
     @StateObject var profile: ProfileModel
     @StateObject var followers: FollowersModel
     @State private var showingEditProfile = false
+    @State var is_zoomed: Bool = false
     
     @Environment(\.dismiss) var dismiss
     @Environment(\.colorScheme) var colorScheme
@@ -153,6 +155,13 @@ struct ProfileView: View {
             
             HStack(alignment: .center) {
                 ProfilePicView(pubkey: profile.pubkey, size: PFP_SIZE, highlight: .custom(Color.black, 2), profiles: damus_state.profiles)
+                    .onTapGesture {
+                        is_zoomed.toggle()
+                    }
+                    .sheet(isPresented: $is_zoomed) {
+                        ProfilePicView(pubkey: profile.pubkey, size: zoom_size, highlight: .custom(Color.black, 2), profiles: damus_state.profiles)
+                            .clipShape(Circle())
+                    }
                 
                 Spacer()
                 

--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -160,7 +160,6 @@ struct ProfileView: View {
                     }
                     .sheet(isPresented: $is_zoomed) {
                         ProfilePicView(pubkey: profile.pubkey, size: zoom_size, highlight: .custom(Color.black, 2), profiles: damus_state.profiles)
-                            .clipShape(Circle())
                     }
                 
                 Spacer()


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <niteshbalusu@icloud.com>

Added ability to zoom photo on double tap, Single tap zooming is adding complexity because the same ProfilePicView is used in a lot of places. 