### PR TITLE
Horizontally distribute actionbar items

### DIFF
--- a/damus/Views/EventActionBar.swift
+++ b/damus/Views/EventActionBar.swift
@@ -36,12 +36,15 @@ struct EventActionBar: View {
             Spacer()
             
              */
-            if damus_state.keypair.privkey != nil {
-                EventActionButton(img: "bubble.left", col: nil) {
-                    notify(.reply, event)
+            HStack(alignment: .bottom) {
+                if damus_state.keypair.privkey != nil {
+                    EventActionButton(img: "bubble.left", col: nil) {
+                        notify(.reply, event)
+                    }
                 }
             }
-            
+            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+
             HStack(alignment: .bottom) {
                 Text("\(bar.boosts > 0 ? "\(bar.boosts)" : "")")
                     .font(.footnote.weight(.medium))
@@ -55,6 +58,8 @@ struct EventActionBar: View {
                     }
                 }
             }
+            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+
 
             HStack(alignment: .bottom) {
                 Text("\(bar.likes > 0 ? "\(bar.likes)" : "")")
@@ -69,6 +74,8 @@ struct EventActionBar: View {
                     }
                 }
             }
+            .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+
             
             /*
             HStack(alignment: .bottom) {
@@ -86,7 +93,7 @@ struct EventActionBar: View {
             }
              */
         }
-        .padding(.top, 1)
+        .padding([.bottom, .top], 3)
         .alert("Boost", isPresented: $confirm_boost) {
             Button("Boost") {
                 send_boost()
@@ -151,7 +158,7 @@ struct EventActionBar_Previews: PreviewProvider {
     static var previews: some View {
         let pk = "pubkey"
         let ds = test_damus_state()
-        let bar = ActionBarModel(likes: 0, boosts: 0, tips: 0, our_like: nil, our_boost: nil, our_tip: nil)
+        let bar = ActionBarModel(likes: 145, boosts: 25, tips: 0, our_like: nil, our_boost: nil, our_tip: nil)
         let ev = NostrEvent(content: "hi", pubkey: pk)
         EventActionBar(damus_state: ds, event: ev, bar: bar)
     }

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -144,18 +144,17 @@ struct EventView: View {
                     let bar = make_actionbar_model(ev: event, damus: damus)
                     EventActionBar(damus_state: damus, event: event, bar: bar)
                 }
-
-                Divider()
-                    .padding([.top], 4)
             }
             .padding([.leading], 2)
+            .padding([.bottom], 4)
         }
         .contentShape(Rectangle())
         .background(event_validity_color(event.validity))
         .id(event.id)
         .frame(maxWidth: .infinity, minHeight: PFP_SIZE)
-        .padding([.bottom], 2)
+        .padding([.bottom], 5)
         .event_context_menu(event, privkey: damus.keypair.privkey)
+        .overlay(VStack{Divider()}, alignment: .bottom)
     }
 }
 


### PR DESCRIPTION
Tiny PR to distribute the action items evenly. Had a short moment yesterday to look at the code and this had been bugging me. No hard feelings if it's not at all what's needed right now.

**Before** and **after**:

<img src="https://user-images.githubusercontent.com/321787/209572019-73f95761-8876-4bd6-8791-c8f7d7891195.png" width=320 /> <img src="https://user-images.githubusercontent.com/321787/209572057-b4db85e9-6ab5-49d2-9857-c17cef8846db.PNG" width=320 />

