### PR TITLE
Swap order of Boost and Cancel alert buttons to conform to Apple's Hu…

### DIFF
--- a/damus/Views/EventActionBar.swift
+++ b/damus/Views/EventActionBar.swift
@@ -88,11 +88,11 @@ struct EventActionBar: View {
         }
         .padding(.top, 1)
         .alert("Boost", isPresented: $confirm_boost) {
-            Button("Boost") {
-                send_boost()
-            }
             Button("Cancel") {
                 confirm_boost = false
+            }
+            Button("Boost") {
+                send_boost()
             }
         } message: {
             Text("Are you sure you want to boost this post?")


### PR DESCRIPTION
…man Interface Guidelines

https://developer.apple.com/design/human-interface-guidelines/components/presentation/alerts#buttons

> Place buttons where people expect. In general, place the button people are most likely to choose on the trailing side in a row of buttons or at the top in a stack of buttons. Always place the default button on the trailing side of a row or at the top of a stack. Cancel buttons are typically on the leading side of a row or at the bottom of a stack.

The alert will look like this with the change:

![Simulator Screen Shot - iPhone 14 Pro - 2022-12-26 at 23 12 38](https://user-images.githubusercontent.com/963907/209605918-80ac1d88-3393-44b1-b5fc-de43ac7bb538.png)
