### PR TITLE
Fix for notes ending in `@`

### DIFF
--- a/damus/Util/Parser.swift
+++ b/damus/Util/Parser.swift
@@ -97,6 +97,12 @@ func parse_digit(_ p: Parser) -> Int? {
 func parse_hex_char(_ p: Parser) -> Character? {
     let ind = p.str.index(p.str.startIndex, offsetBy: p.pos)
     
+    // Check that we're within the bounds of p.str's length
+    if p.pos >= p.str.count {
+        return nil
+    }
+
+    
     if let c = p.str[ind].unicodeScalars.first {
         // hex chars
         let d = c.value


### PR DESCRIPTION
As reported by @BTCapsule, when a note is created ending in a `@` the app crashes.