### PR TITLE
Swap order of Logout and Cancel alert buttons

### DIFF
--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -102,11 +102,11 @@ struct ConfigView: View {
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.large)
         .alert("Logout", isPresented: $confirm_logout) {
-            Button("Logout") {
-                notify(.logout, ())
-            }
             Button("Cancel") {
                 confirm_logout = false
+            }
+            Button("Logout") {
+                notify(.logout, ())
             }
         } message: {
             Text("Make sure your nsec account key is saved before you logout or you will lose access to this account")


### PR DESCRIPTION
To conform to Apple's Human Interface Guidelines

https://developer.apple.com/design/human-interface-guidelines/components/presentation/alerts#buttons

> Place buttons where people expect. In general, place the button people are most likely to choose on the trailing side in a row of buttons or at the top in a stack of buttons. Always place the default button on the trailing side of a row or at the top of a stack. Cancel buttons are typically on the leading side of a row or at the bottom of a stack.

Similar to https://github.com/damus-io/damus/pull/155

The alert will look like this with the change:

![Simulator Screen Shot - iPhone 14 Pro - 2022-12-27 at 08 45 13](https://user-images.githubusercontent.com/963907/209668785-682827ac-b559-494a-b55e-bcab81bdc622.png)
