### PR TITLE
Tab Bar Padding Issue

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -229,6 +229,7 @@ struct ContentView: View {
             }
 
             TabBar(new_events: $home.new_events, selected: $selected_timeline, action: switch_timeline)
+                .padding()
         }
         .onAppear() {
             self.connect()


### PR DESCRIPTION
Some users were messaging me saying the tab bar is awkward on their device's layout (older phones like the iPhone 7 or SE). This PR just adds a bit of padding on the tab bar to resolve that.

<img width="754" alt="Screenshot 2022-12-27 at 8 16 21 AM" src="https://user-images.githubusercontent.com/30542196/209686649-711a1b90-aa5d-4cc6-bdaf-f99c4b107284.png">
