### PR TITLE
Add keyboard shortcuts to switch main views and post

### DIFF
--- a/damus/Views/MainTabView.swift
+++ b/damus/Views/MainTabView.swift
@@ -76,14 +76,11 @@ struct TabBar: View {
         VStack {
             Divider()
             HStack {
-                TabButton(timeline: .home, img: "house", selected: $selected, new_events: $new_events, action: action)
-                TabButton(timeline: .dms, img: "bubble.left.and.bubble.right", selected: $selected, new_events: $new_events, action: action)
-                TabButton(timeline: .search, img: "magnifyingglass.circle", selected: $selected, new_events: $new_events, action: action)
-                TabButton(timeline: .notifications, img: "bell", selected: $selected, new_events: $new_events, action: action)
+                TabButton(timeline: .home, img: "house", selected: $selected, new_events: $new_events, action: action).keyboardShortcut("1")
+                TabButton(timeline: .dms, img: "bubble.left.and.bubble.right", selected: $selected, new_events: $new_events, action: action).keyboardShortcut("2")
+                TabButton(timeline: .search, img: "magnifyingglass.circle", selected: $selected, new_events: $new_events, action: action).keyboardShortcut("3")
+                TabButton(timeline: .notifications, img: "bell", selected: $selected, new_events: $new_events, action: action).keyboardShortcut("4")
             }
         }
     }
 }
-
-
-

--- a/damus/Views/PostButton.swift
+++ b/damus/Views/PostButton.swift
@@ -23,6 +23,7 @@ func PostButton(action: @escaping () -> ()) -> some View {
             radius: 3,
             x: 3,
             y: 3)
+    .keyboardShortcut("n", modifiers: [.command, .shift])
 }
 
 func PostButtonContainer(action: @escaping () -> ()) -> some View {


### PR DESCRIPTION
I added several keyboard shortcuts so users can switch between the main views of "Home", "DMs", "Search", and "Notifications" with the shortcuts "CMD+1", "CMD+2" etc.. Those shortcuts made the most sense to me but they're definitely up for discussion.

Those were first since they're the easiest to add. I'm going to work on getting
a refresh ("CMD+SHIFT+N" or "CMD+R") shortcut and a "CMD+N" shortcut for a new
post.