### PR TITLE
Nostr Event Attachments UI Adjustments

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3165648B295B70D500C64604 /* LinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3165648A295B70D500C64604 /* LinkView.swift */; };
 		3169CAE6294E69C000EE4006 /* EmptyTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3169CAE5294E69C000EE4006 /* EmptyTimelineView.swift */; };
 		3169CAED294FCCFC00EE4006 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3169CAEC294FCCFC00EE4006 /* Constants.swift */; };
 		31D2E847295218AF006D67F8 /* Shimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D2E846295218AF006D67F8 /* Shimmer.swift */; };
@@ -151,6 +152,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3165648A295B70D500C64604 /* LinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkView.swift; sourceTree = "<group>"; };
 		3169CAE5294E69C000EE4006 /* EmptyTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTimelineView.swift; sourceTree = "<group>"; };
 		3169CAEC294FCCFC00EE4006 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = damus/Util/Constants.swift; sourceTree = SOURCE_ROOT; };
 		31D2E846295218AF006D67F8 /* Shimmer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shimmer.swift; sourceTree = "<group>"; };
@@ -514,6 +516,7 @@
 				4C90BD19283AA67F008EE7EF /* Bech32.swift */,
 				4C216F352870A9A700040376 /* InputDismissKeyboard.swift */,
 				3169CAEC294FCCFC00EE4006 /* Constants.swift */,
+				3165648A295B70D500C64604 /* LinkView.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -834,6 +837,7 @@
 				4C363AA428296DEE006E126D /* SearchModel.swift in Sources */,
 				4CEE2AF3280B25C500AB5EEF /* ProfilePicView.swift in Sources */,
 				4CEE2AF9280B2EAC00AB5EEF /* PowView.swift in Sources */,
+				3165648B295B70D500C64604 /* LinkView.swift in Sources */,
 				4C3BEFD42819DE8F00B3DE84 /* NostrKind.swift in Sources */,
 				4C3EA66028FF5E7700C48A62 /* node_id.c in Sources */,
 				4CE6DEE727F7A08100C66700 /* damusApp.swift in Sources */,

--- a/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -40,8 +40,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SparrowTek/Vault",
       "state" : {
-        "revision" : "87db56c3c8b6421c65b0745f73e08b0dc56f79d4",
-        "version" : "1.0.3"
+        "revision" : "f5707fac23f4a17b3e5ed32dd444f502773615ae",
+        "version" : "1.0.2"
       }
     }
   ],

--- a/damus/Components/ImageCarousel.swift
+++ b/damus/Components/ImageCarousel.swift
@@ -136,6 +136,11 @@ struct ImageCarousel: View {
                                 Text(url.absoluteString)
                             }
                             .id(url.absoluteString)
+                            .contextMenu {
+                                Button("Copy Image") {
+                                    UIPasteboard.general.string = url.absoluteString
+                                }
+                            }
                     }
             }
         }

--- a/damus/Components/InvoiceView.swift
+++ b/damus/Components/InvoiceView.swift
@@ -8,24 +8,34 @@
 import SwiftUI
 
 struct InvoiceView: View {
+    
+    @Environment(\.colorScheme) var colorScheme
+    
     let invoice: Invoice
     
     var PayButton: some View {
-        Button("Pay") {
+        Button {
             guard let url = URL(string: "lightning:" + invoice.string) else {
                 return
             }
             UIApplication.shared.open(url)
+        } label: {
+            RoundedRectangle(cornerRadius: 20)
+                .foregroundColor(colorScheme == .light ? .black : .white)
+                .overlay {
+                    Text("Pay")
+                        .fontWeight(.medium)
+                        .foregroundColor(colorScheme == .light ? .white : .black)
+                }
         }
-        .buttonStyle(.bordered)
     }
     
     var body: some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 20)
+            RoundedRectangle(cornerRadius: 10)
                 .foregroundColor(.secondary.opacity(0.1))
             
-            VStack(alignment: .trailing, spacing: 12) {
+            VStack(alignment: .leading, spacing: 12) {
                 HStack {
                     Label("", systemImage: "bolt.fill")
                         .foregroundColor(.orange)

--- a/damus/Util/LinkView.swift
+++ b/damus/Util/LinkView.swift
@@ -1,0 +1,39 @@
+//
+//  LinkView.swift
+//  damus
+//
+//  Created by Sam DuBois on 12/27/22.
+//
+
+import SwiftUI
+import LinkPresentation
+
+class CustomLinkView: LPLinkView {
+    override var intrinsicContentSize: CGSize { CGSize(width: 0, height: super.intrinsicContentSize.height) }
+}
+
+struct LinkViewRepresentable: UIViewRepresentable {
+ 
+    typealias UIViewType = CustomLinkView
+    
+    var metadata: LPLinkMetadata?
+    var url: URL?
+ 
+    func makeUIView(context: Context) -> CustomLinkView {
+        
+        if let metadata {
+            let linkView = CustomLinkView(metadata: metadata)
+            return linkView
+        }
+        
+        if let url {
+            let linkView = CustomLinkView(url: url)
+            return linkView
+        }
+        
+        return CustomLinkView()
+    }
+ 
+    func updateUIView(_ uiView: CustomLinkView, context: Context) {
+    }
+}

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -6,14 +6,16 @@
 //
 
 import SwiftUI
+import LinkPresentation
 
 struct NoteArtifacts {
     let content: String
     let images: [URL]
     let invoices: [Invoice]
+    let links: [URL]
     
     static func just_content(_ content: String) -> NoteArtifacts {
-        NoteArtifacts(content: content, images: [], invoices: [])
+        NoteArtifacts(content: content, images: [], invoices: [], links: [])
     }
 }
 
@@ -21,6 +23,7 @@ func render_note_content(ev: NostrEvent, profiles: Profiles, privkey: String?) -
     let blocks = ev.blocks(privkey)
     var invoices: [Invoice] = []
     var img_urls: [URL] = []
+    var link_urls: [URL] = []
     let txt = blocks.reduce("") { str, block in
         switch block {
         case .mention(let m):
@@ -33,14 +36,20 @@ func render_note_content(ev: NostrEvent, profiles: Profiles, privkey: String?) -
             invoices.append(invoice)
             return str
         case .url(let url):
+            
+            // Handle Image URLs
             if is_image_url(url) {
+                // Append Image
                 img_urls.append(url)
+            } else {
+                link_urls.append(url)
             }
-            return str + url.absoluteString
+            
+            return str
         }
     }
     
-    return NoteArtifacts(content: txt, images: img_urls, invoices: invoices)
+    return NoteArtifacts(content: txt, images: img_urls, invoices: invoices, links: link_urls)
 }
 
 func is_image_url(_ url: URL) -> Bool {
@@ -57,6 +66,8 @@ struct NoteContentView: View {
     
     @State var artifacts: NoteArtifacts
     
+    @State var metaData: [LPLinkMetadata] = []
+    
     func MainContent() -> some View {
         let md_opts: AttributedString.MarkdownParsingOptions =
             .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
@@ -71,10 +82,34 @@ struct NoteContentView: View {
             }
             if show_images && artifacts.images.count > 0 {
                 ImageCarousel(urls: artifacts.images)
+            } else if !show_images && artifacts.images.count > 0 {
+                ImageCarousel(urls: artifacts.images)
+                    .blur(radius: 10)
+                    .overlay {
+                        Rectangle()
+                            .opacity(0.50)
+                    }
+                    .cornerRadius(10)
             }
             if artifacts.invoices.count > 0 {
                 InvoicesView(invoices: artifacts.invoices)
-                    .frame(width: 200)
+            }
+            
+            ForEach(artifacts.links, id:\.self) { link in
+                LinkViewRepresentable(url: link)
+                    .frame(height: 50)
+            }
+        }
+    }
+    
+    func getMetaData() async {
+        let provider = LPMetadataProvider()
+        
+        if artifacts.links.count > 0 {
+            if let metaData = try? await provider.startFetchingMetadata(for: artifacts.links.first!) {
+                DispatchQueue.main.async {
+                    self.metaData.append(metaData)
+                }
             }
         }
     }
@@ -125,7 +160,7 @@ struct NoteContentView_Previews: PreviewProvider {
     static var previews: some View {
         let state = test_damus_state()
         let content = "hi there https://jb55.com/s/Oct12-150217.png 5739a762ef6124dd.jpg"
-        let artifacts = NoteArtifacts(content: content, images: [], invoices: [])
+        let artifacts = NoteArtifacts(content: content, images: [], invoices: [], links: [])
         NoteContentView(privkey: "", event: NostrEvent(content: content, pubkey: "pk"), profiles: state.profiles, show_images: true, artifacts: artifacts)
     }
 }


### PR DESCRIPTION
This PR adds some UI fixes to:
- Blur and opaque non-friend images rather than only display the link (A happy medium for now I think)
- Remove URLs in content text when image is displayed
- Show non-image URLs as clickable link views (more to be done)
- Adjustments to the Pay button on invoices.

Small little adjustments. Want to eventually add metadata for links so they can be a bit more colorful. Still working on that. Let me know what you guys think!

<img width="369" alt="Screenshot 2022-12-27 at 12 41 55 PM" src="https://user-images.githubusercontent.com/30542196/209715440-49da72a1-f117-4fcf-804d-9989cde91985.png">
<img width="362" alt="Screenshot 2022-12-27 at 12 41 36 PM" src="https://user-images.githubusercontent.com/30542196/209715471-ddee0772-708c-4c47-a9b7-4c3788381734.png">
<img width="367" alt="Screenshot 2022-12-27 at 12 40 59 PM" src="https://user-images.githubusercontent.com/30542196/209715482-e2457682-f0d6-45b7-b69b-167bed36d2f5.png">
