### PR TITLE
Fix post button moving after selecting from search result

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -88,7 +88,7 @@ struct ContentView: View {
                         self.active_sheet = .post
                     }
                 }
-            }
+            }.ignoresSafeArea(.keyboard, edges: .bottom)
         }
         .safeAreaInset(edge: .top) {
             VStack(spacing: 0) {


### PR DESCRIPTION
**Current behavior:**
Post button moves to the middle of screen and blocks gestures below view after selecting from search result

**Steps to reproduce:**
1. Go to search and type a name
2. Select a result
3. Go back to home

**Before:**

https://user-images.githubusercontent.com/19398259/209764383-6fabb95f-3789-4eff-b023-59e23ccbae74.mov

**After:**

https://user-images.githubusercontent.com/19398259/209764516-9d4d7013-2563-416a-a219-c7c5663db220.mov

