### PR TITLE
Fix issue where boosted post causes duplicate thread

### DIFF
--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -22,7 +22,11 @@ struct ThreadV2 {
             return !event.content.isEmpty
         }
         self.childEvents = self.childEvents.filter { event in
-            return !event.content.isEmpty
+            let check_tags = event.tags.filter { tag in
+                return tag[0] == "e" && event.content.contains(tag[1])
+            }
+            
+            return check_tags.isEmpty && !event.content.isEmpty
         }
         
         // sort events by publication date


### PR DESCRIPTION
Signed-off-by: Nitesh Balusu <niteshbalusu@icloud.com>

Fixed the issue where every boost is showing up as part of the thread.