### PR TITLE
Fix padding on TabBar view

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -228,7 +228,7 @@ struct ContentView: View {
             }
 
             TabBar(new_events: $home.new_events, selected: $selected_timeline, action: switch_timeline)
-                .padding()
+                .padding(.bottom)
         }
         .onAppear() {
             self.connect()


### PR DESCRIPTION
Ideally, the TabBar should be refactored to use TabView and tabItems so that it follow the safe area properly. This should be sufficient temporary fix for the time being.

**Old Devices**

Before             |  After
:-------------------------:|:-------------------------:
![Screenshot 2022-12-29 at 2 03 22 PM](https://user-images.githubusercontent.com/19398259/209999160-e13dd56e-8db2-4f55-961c-874745b9ac88.png) |  ![Screenshot 2022-12-29 at 2 07 50 PM](https://user-images.githubusercontent.com/19398259/209999223-9fd8a0ab-7ce9-47e0-94bd-9410499099c8.png)

**Modern Devices**

Before             |  After
:-------------------------:|:-------------------------:
![IMG_4484](https://user-images.githubusercontent.com/19398259/209999869-91ea32ee-a7d5-4f45-bc38-63d5e0650784.PNG) |  ![IMG_4485](https://user-images.githubusercontent.com/19398259/209999920-18ca1350-489a-4100-aec0-ee81fe679734.PNG)


