### PR TITLE
SaveKeyView: remove inconsistency rendering Text upon Copy-tap

### DIFF
--- a/damus/Views/SaveKeysView.swift
+++ b/damus/Views/SaveKeysView.swift
@@ -147,20 +147,23 @@ struct SaveKeyView: View {
     
     var body: some View {
         HStack {
-            Button(action: copy_text) {
-                Label("", systemImage: is_copied ? "checkmark.circle.fill" : "doc.on.doc")
-                    .foregroundColor(is_copied ? .green : .white)
-                    .background {
-                        if is_copied {
-                            Circle()
-                                .foregroundColor(.white)
-                                .frame(width: 25, height: 25, alignment: .center)
-                                .padding(.leading, -8)
-                                .padding(.top, 1)
-                        } else {
-                            EmptyView()
+            Spacer()
+            VStack {
+                spacerBlock(width: 10, height: 1)
+                Button(action: copy_text) {
+                    Label("", systemImage: is_copied ? "checkmark.circle.fill" : "doc.on.doc")
+                        .foregroundColor(is_copied ? .green : .white)
+                        .background {
+                            if is_copied {
+                                Circle()
+                                    .foregroundColor(.white)
+                                    .frame(width: 25, height: 25, alignment: .center)
+                                    .padding(.leading, -8)
+                                    .padding(.top, 1)
+                            } else { EmptyView() }
                         }
-                    }
+                }
+                spacerBlock(width: 10, height: 1)
             }
           
             Text(text)
@@ -174,7 +177,16 @@ struct SaveKeyView: View {
                 .onTapGesture {
                     copy_text()
                 }
+            
+            spacerBlock(width: 1, height: 10)
         }
+    }
+    
+    @ViewBuilder private func spacerBlock(width: CGFloat, height: CGFloat) -> some View {
+        let spacerIsTransparent = true
+        let opacity = spacerIsTransparent ? 0 : 1
+        Color.orange.opacity(Double(opacity))
+            .frame(width: width, height: height)
     }
 }
 

--- a/damus/Views/SaveKeysView.swift
+++ b/damus/Views/SaveKeysView.swift
@@ -137,6 +137,7 @@ struct SaveKeysView: View {
 }
 
 struct SaveKeyView: View {
+    let minor = CGFloat(0), major = CGFloat(20) /// spacer-block dimensions - 'major' sets key Text's aspect ratio
     let text: String
     @Binding var is_copied: Bool
     
@@ -149,7 +150,7 @@ struct SaveKeyView: View {
         HStack {
             Spacer()
             VStack {
-                spacerBlock(width: 10, height: 1)
+                spacerBlock(width: 10, height: minor)
                 Button(action: copy_text) {
                     Label("", systemImage: is_copied ? "checkmark.circle.fill" : "doc.on.doc")
                         .foregroundColor(is_copied ? .green : .white)
@@ -179,14 +180,12 @@ struct SaveKeyView: View {
                     copy_text()
                 }
             
-            spacerBlock(width: 1, height: 10)
+            spacerBlock(width: major, height: minor)
         }
     }
     
     @ViewBuilder private func spacerBlock(width: CGFloat, height: CGFloat) -> some View {
-        let isTransparent = false
-        let opacity = isTransparent ? 0 : 1
-        Color.orange.opacity(Double(opacity))
+        Color.orange.opacity(Double(1))
             .frame(width: width, height: height)
     }
 }

--- a/damus/Views/SaveKeysView.swift
+++ b/damus/Views/SaveKeysView.swift
@@ -163,7 +163,6 @@ struct SaveKeyView: View {
                             } else { EmptyView() }
                         }
                 }
-                spacerBlock(width: 10, height: 1)
             }
           
             Text(text)
@@ -183,8 +182,8 @@ struct SaveKeyView: View {
     }
     
     @ViewBuilder private func spacerBlock(width: CGFloat, height: CGFloat) -> some View {
-        let spacerIsTransparent = true
-        let opacity = spacerIsTransparent ? 0 : 1
+        let isTransparent = true
+        let opacity = isTransparent ? 0 : 1
         Color.orange.opacity(Double(opacity))
             .frame(width: width, height: height)
     }

--- a/damus/Views/SaveKeysView.swift
+++ b/damus/Views/SaveKeysView.swift
@@ -160,7 +160,9 @@ struct SaveKeyView: View {
                                     .frame(width: 25, height: 25, alignment: .center)
                                     .padding(.leading, -8)
                                     .padding(.top, 1)
-                            } else { EmptyView() }
+                            } else {
+                                EmptyView()
+                            }
                         }
                 }
             }
@@ -182,7 +184,7 @@ struct SaveKeyView: View {
     }
     
     @ViewBuilder private func spacerBlock(width: CGFloat, height: CGFloat) -> some View {
-        let isTransparent = true
+        let isTransparent = false
         let opacity = isTransparent ? 0 : 1
         Color.orange.opacity(Double(opacity))
             .frame(width: width, height: height)

--- a/damus/Views/SaveKeysView.swift
+++ b/damus/Views/SaveKeysView.swift
@@ -137,7 +137,7 @@ struct SaveKeysView: View {
 }
 
 struct SaveKeyView: View {
-    let minor = CGFloat(0), major = CGFloat(20) /// spacer-block dimensions - 'major' sets key Text's aspect ratio
+    let minor = CGFloat(0), major = CGFloat(0) /// spacer-block dimensions - 'major' sets key Text's aspect ratio
     let text: String
     @Binding var is_copied: Bool
     

--- a/damus/Views/SaveKeysView.swift
+++ b/damus/Views/SaveKeysView.swift
@@ -137,7 +137,6 @@ struct SaveKeysView: View {
 }
 
 struct SaveKeyView: View {
-    let minor = CGFloat(0), major = CGFloat(0) /// spacer-block dimensions - 'major' sets key Text's aspect ratio
     let text: String
     @Binding var is_copied: Bool
     
@@ -150,7 +149,7 @@ struct SaveKeyView: View {
         HStack {
             Spacer()
             VStack {
-                spacerBlock(width: 10, height: minor)
+                spacerBlock(width: 0, height: 0)
                 Button(action: copy_text) {
                     Label("", systemImage: is_copied ? "checkmark.circle.fill" : "doc.on.doc")
                         .foregroundColor(is_copied ? .green : .white)
@@ -180,12 +179,12 @@ struct SaveKeyView: View {
                     copy_text()
                 }
             
-            spacerBlock(width: major, height: minor)
+            spacerBlock(width: 0, height: 0) /// set a 'width' > 0 here to vary key Text's aspect ratio
         }
     }
     
     @ViewBuilder private func spacerBlock(width: CGFloat, height: CGFloat) -> some View {
-        Color.orange.opacity(Double(1))
+        Color.orange.opacity(1)
             .frame(width: width, height: height)
     }
 }


### PR DESCRIPTION
Remove slight visual inconsistency after tap-to-copy actions, arising from SwiftUI's rendering keys' Text 
(Text's frame was changing on re-rendering due to button's differently sized SFSymbols)

#### Change:
-in struct `SaveKeyView`, group the key Text with 2 invisible spacer-blocks (1 vertical, 1 horizontal)
-also allows adjusting Text dimensions to taste by setting `width` of horizontal spacer-block

 #### Demos:
(~3 sec. videos; click to view in new tabs)
 | Before | After |
 | ------ | ----- |
 | <img src="https://user-images.githubusercontent.com/47217795/210102003-06b5529d-a468-4324-8b13-a4726e78bb57.mp4" width=400> | <img src="https://user-images.githubusercontent.com/47217795/210114485-64e5aa92-29c8-46f0-8dc3-8cbbb730833d.mp4" width=400> |

**Screenshots**

 #### Before
 | pre-copy-pubkey | post-copy-pubkey | post-copy-privkey |
 | ------ | ----- | ----- |
 | <img src="https://user-images.githubusercontent.com/47217795/210040379-7b4a2b1a-0ee3-4c5d-a974-966f6e283e1b.png" width=300> | <img src="https://user-images.githubusercontent.com/47217795/210040540-7255ec85-f878-48b5-82ef-2bef73fd7736.png" width=300> | <img src="https://user-images.githubusercontent.com/47217795/210040643-7521996a-8b38-48c6-aa8f-7365ea784e2f.png" width=300> |

 #### After
 | pre-copy-pubkey | post-copy-pubkey | post-copy-privkey |
 | ------ | ----- | ----- |
 | <img src="https://user-images.githubusercontent.com/47217795/210040813-e8885ad5-6e39-4eec-9b90-3bd26b040414.png" width=300> | <img src="https://user-images.githubusercontent.com/47217795/210040869-d0711f62-3d99-43e3-8c21-8a7132680a62.png" width=300> | <img src="https://user-images.githubusercontent.com/47217795/210040898-6350a01a-4e66-4858-9fe8-0e51dc0b4e33.png" width=300> |

 #### Maintainer mentions:
- @jb55 



