### PR TITLE
Added copy relay action

### DIFF
--- a/damus/Views/RelayView.swift
+++ b/damus/Views/RelayView.swift
@@ -48,9 +48,19 @@ struct RelayView: View {
             }
         }
         .contextMenu {
+            CopyAction(relay: relay)
+            
             if let privkey = state.keypair.privkey {
                 RemoveAction(privkey: privkey)
             }
+        }
+    }
+    
+    func CopyAction(relay: String) -> some View {
+        Button {
+            UIPasteboard.general.setValue(relay, forPasteboardType: "public.plain-text")
+        } label: {
+            Label("Copy relay", systemImage: "doc.on.doc")
         }
     }
     
@@ -72,11 +82,6 @@ struct RelayView: View {
         }
         .tint(.red)
     }
-    
-}
-
-fileprivate func remove_action() {
-    
 }
 
 struct RelayView_Previews: PreviewProvider {


### PR DESCRIPTION
Added #152 to allow user to copy a relay after a long press (in the same context menu as delete relay)

Preview:
![simulator_screenshot_DF2C5085-D7B6-4647-970D-74A388F1788A](https://user-images.githubusercontent.com/9567098/210154843-dba3aad4-93e7-460d-8230-b75e7ce63890.png)
