### PR TITLE
Fix Expanding Profile Picture

### DIFF
--- a/damus/Views/ProfilePicView.swift
+++ b/damus/Views/ProfilePicView.swift
@@ -33,8 +33,6 @@ func pfp_line_width(_ h: Highlight) -> CGFloat {
 }
 
 struct InnerProfilePicView: View {
-    @Environment(\.redactionReasons) private var reasons
-
     let url: URL?
     let pubkey: String
     let size: CGFloat

--- a/damus/Views/ProfilePicView.swift
+++ b/damus/Views/ProfilePicView.swift
@@ -54,21 +54,17 @@ struct InnerProfilePicView: View {
 
     var body: some View {
         Group {
-            if reasons.isEmpty {
-                KFAnimatedImage(url)
-                    .configure { view in
-                        view.framePreloadCount = 1
-                    }
-                    .placeholder { _ in
-                        Placeholder
-                    }
-                    .cacheOriginalImage()
-                    .scaleFactor(UIScreen.main.scale)
-                    .loadDiskFileSynchronously()
-                    .fade(duration: 0.1)
-            } else {
-                KFImage(url)
-            }
+            KFAnimatedImage(url)
+                .configure { view in
+                    view.framePreloadCount = 1
+                }
+                .placeholder { _ in
+                    Placeholder
+                }
+                .cacheOriginalImage()
+                .scaleFactor(UIScreen.main.scale)
+                .loadDiskFileSynchronously()
+                .fade(duration: 0.1)
         }
         .frame(width: size, height: size)
         .clipShape(Circle())


### PR DESCRIPTION
This fixes the issue with the profile picture expanding when the app is going to multitasking (inactive state).

Fixes: #142 

We were checking the `redactionReasons` to determine which profile picture we should show. When you enter the `inactive` state by switching apps etc. The `readactionReasons` are populated so we would fall into the else statement there. I think normally you would show a placeholder or something similar. But, we were just showing the profile picture (non-animated version) and it didn't have any of the sizing modifiers on it. 

If responding to redaction is important we could reintroduce the if/else and show a placeholder there but I don't think it makes sense if we aren't hiding any information.

Profile pictures with fix:
![Simulator Screen Recording - iPhone 14 Pro - 2022-12-31 at 14 06 52](https://user-images.githubusercontent.com/264977/210156517-19d10f44-dda9-4881-b436-038573a1f308.gif)

