### PR TITLE
Always check `SecRandomCopyBytes` return value

### DIFF
--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -446,11 +446,13 @@ func hex_encode(_ data: Data) -> String {
 
 
 func random_bytes(count: Int) -> Data {
-    var data = Data(count: count)
-    _ = data.withUnsafeMutableBytes { mutableBytes in
-        SecRandomCopyBytes(kSecRandomDefault, count, mutableBytes.baseAddress!)
+    var bytes = [UInt8](repeating: 0, count: count)
+    guard
+        SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess
+    else {
+        fatalError("can't copy secure random data")
     }
-    return data
+    return Data(bytes)
 }
 
 func refid_to_tag(_ ref: ReferencedId) -> [String] {

--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -446,13 +446,13 @@ func hex_encode(_ data: Data) -> String {
 
 
 func random_bytes(count: Int) -> Data {
-    var bytes = [UInt8](repeating: 0, count: count)
+    var bytes = [Int8](repeating: 0, count: count)
     guard
         SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess
     else {
         fatalError("can't copy secure random data")
     }
-    return Data(bytes)
+    return Data(bytes: bytes, count: count)
 }
 
 func refid_to_tag(_ ref: ReferencedId) -> [String] {


### PR DESCRIPTION
From https://developer.apple.com/documentation/security/1399291-secrandomcopybytes

> Always test the returned status to make sure that the array has been updated with new, random data before trying to use the values