### PR TITLE
Fix detection of email addresses in profiles

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		6C7DE41F2955169800E66263 /* Vault in Frameworks */ = {isa = PBXBuildFile; productRef = 6C7DE41E2955169800E66263 /* Vault */; };
 		BA693074295D649800ADDB87 /* UserSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA693073295D649800ADDB87 /* UserSettingsStore.swift */; };
 		BAB68BED29543FA3007BA466 /* SelectWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */; };
+		DD597CBD2963D85A00C64D32 /* MarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD597CBC2963D85A00C64D32 /* MarkdownTests.swift */; };
 		E990020F2955F837003BBC5A /* EditMetadataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E990020E2955F837003BBC5A /* EditMetadataView.swift */; };
 		E9E4ED0B295867B900DD7078 /* ThreadV2View.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E4ED0A295867B900DD7078 /* ThreadV2View.swift */; };
 /* End PBXBuildFile section */
@@ -329,6 +330,7 @@
 		4FE60CDC295E1C5E00105A1F /* Wallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallet.swift; sourceTree = "<group>"; };
 		BA693073295D649800ADDB87 /* UserSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsStore.swift; sourceTree = "<group>"; };
 		BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectWalletView.swift; sourceTree = "<group>"; };
+		DD597CBC2963D85A00C64D32 /* MarkdownTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkdownTests.swift; sourceTree = "<group>"; };
 		E990020E2955F837003BBC5A /* EditMetadataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMetadataView.swift; sourceTree = "<group>"; };
 		E9E4ED0A295867B900DD7078 /* ThreadV2View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadV2View.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -614,6 +616,7 @@
 		4CE6DEF627F7A08200C66700 /* damusTests */ = {
 			isa = PBXGroup;
 			children = (
+				DD597CBC2963D85A00C64D32 /* MarkdownTests.swift */,
 				4C90BD1B283AC38E008EE7EF /* Bech32Tests.swift */,
 				4C363A9F2828A8DD006E126D /* LikeTests.swift */,
 				4C363A9D2828A822006E126D /* ReplyTests.swift */,
@@ -914,6 +917,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3ACBCB78295FE5C70037388A /* TimeAgoTests.swift in Sources */,
+				DD597CBD2963D85A00C64D32 /* MarkdownTests.swift in Sources */,
 				4C3EA67B28FF7B3900C48A62 /* InvoiceTests.swift in Sources */,
 				4C363A9E2828A822006E126D /* ReplyTests.swift in Sources */,
 				4C363AA02828A8DD006E126D /* LikeTests.swift in Sources */,

--- a/damus/Util/Markdown.swift
+++ b/damus/Util/Markdown.swift
@@ -15,8 +15,8 @@ public struct Markdown {
         return url.contains("://") ? url : "https://" + url
     }
 
+    /// Parse a string with markdown into an `AttributedString`, if possible, or else return it as regular text.
     public static func parse(content: String) -> AttributedString {
-        // Similar to the parsing in NoteContentView
         let md_opts: AttributedString.MarkdownParsingOptions =
             .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
 
@@ -33,9 +33,12 @@ public struct Markdown {
         var output = input
         // Start with the last match, because replacing the first would invalidate all subsequent indices
         for match in matches.reversed() {
-            guard let range = Range(match.range, in: input) else { continue }
-            let url = input[range]
-            output.replaceSubrange(range, with: "[\(url)](\(Markdown.withScheme(url)))")
+            guard let range = Range(match.range, in: input)
+                , let url = match.url else { continue }
+            let text = input[range]
+            // Use the absoluteString from the matched URL, except when it defaults to http (since we default to https)
+            let uri = url.scheme == "http" ? Markdown.withScheme(text) : url.absoluteString
+            output.replaceSubrange(range, with: "[\(text)](\(uri))")
         }
         // TODO: escape unintentional markdown
         return Markdown.parse(content: output)

--- a/damusTests/MarkdownTests.swift
+++ b/damusTests/MarkdownTests.swift
@@ -40,4 +40,26 @@ class MarkdownTests: XCTestCase {
         let expected = try AttributedString(markdown: "prologue [damus.io](https://damus.io) [https://nostr.build](https://nostr.build) epilogue", options: md_opts)
         XCTAssertEqual(md, expected)
     }
+
+    func test_convert_http() throws {
+        let helper = Markdown()
+        let md = helper.process("prologue http://example.com epilogue")
+        let expected = try AttributedString(markdown: "prologue [http://example.com](http://example.com) epilogue", options: md_opts)
+        XCTAssertEqual(md, expected)
+    }
+
+    func test_convert_mailto() throws {
+        let helper = Markdown()
+        let md = helper.process("prologue test@example.com epilogue")
+        let expected = try AttributedString(markdown: "prologue [test@example.com](mailto:test@example.com) epilogue", options: md_opts)
+        XCTAssertEqual(md, expected)
+    }
+
+    func test_convert_mailto_implicit() throws {
+        let helper = Markdown()
+        let md = helper.process("prologue mailto:test@example.com epilogue")
+        let expected = try AttributedString(markdown: "prologue [mailto:test@example.com](mailto:test@example.com) epilogue", options: md_opts)
+        XCTAssertEqual(md, expected)
+    }
+
 }


### PR DESCRIPTION
This fixes the logic added in 6f5f86114b0948cac286f2b1594e8f3f831e9032 by supporting email addresses (and any other schemes.) The `NSDataDetector` adds the right scheme for us, but unfortunately it defaults to `http` for URLs without scheme.

Signed-off-by: Lionello Lunesu <lio+git@lunesu.com>