### PR TITLE
Adding a relay. We have been running servers for years for MMO games.…

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -17,6 +17,7 @@ var BOOTSTRAP_RELAYS = [
     "wss://nostr.oxtr.dev",
     "wss://nostr.v0l.io",
     "wss://brb.io",
+    "wss://nostr.mom"
 ]
 
 struct TimestampedProfile {


### PR DESCRIPTION
Adding a relay. We have been running servers for years for MMO games. We think seriously in this relay operation.
Bare metal - dedicated fast server. 12 cores, 64GB, nvme, ...