### PR TITLE
Changelog-Fixed: Scroll to bottom when new DM received

### DIFF
--- a/damus/Views/DMChatView.swift
+++ b/damus/Views/DMChatView.swift
@@ -27,6 +27,10 @@ struct DMChatView: View {
             }
             .onAppear {
                 scroller.scrollTo("endblock")
+            }.onChange(of: dms.events.count) { _ in
+                withAnimation {
+                    scroller.scrollTo("endblock")
+                }
             }
         }
     }


### PR DESCRIPTION
This scrolls the DM view to the bottom when a new message is received (or sent).

This fixes issue [241](https://github.com/damus-io/damus/issues/241)

Changelog-Fixed: Scroll to bottom when new DM received