### PR TITLE
Beautify new post button

### DIFF
--- a/damus/Assets.xcassets/Colors/DamusBlue.colorset/Contents.json
+++ b/damus/Assets.xcassets/Colors/DamusBlue.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x4D",
+          "red" : "0x4B"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0x4D",
+          "red" : "0x4B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/damus/Assets.xcassets/Colors/DamusPurple.colorset/Contents.json
+++ b/damus/Assets.xcassets/Colors/DamusPurple.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC5",
+          "green" : "0x43",
+          "red" : "0xCC"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xC5",
+          "green" : "0x43",
+          "red" : "0xCC"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/damus/Views/PostButton.swift
+++ b/damus/Views/PostButton.swift
@@ -8,16 +8,33 @@
 import Foundation
 import SwiftUI
 
+let BUTTON_SIZE: CGFloat = 60
+let LINEAR_GRADIENT = LinearGradient(gradient: Gradient(colors: [
+    Color("DamusPurple"),
+    Color("DamusBlue")
+]), startPoint: .topTrailing, endPoint: .bottomTrailing)
+
 func PostButton(action: @escaping () -> ()) -> some View {
+
     return Button(action: action, label: {
-        Text("+")
-            .font(.system(.largeTitle))
-            .frame(width: 57, height: 50)
-            .foregroundColor(Color.white)
-            .padding(.bottom, 7)
+        ZStack(alignment: .center) {
+            Circle()
+                .stroke(LINEAR_GRADIENT, lineWidth: 2)
+                .frame(width: BUTTON_SIZE, height: BUTTON_SIZE)
+                .rotationEffect(.degrees(45))
+                 
+            Circle()
+                .fill(LINEAR_GRADIENT)
+                .frame(width: BUTTON_SIZE - 8, height: BUTTON_SIZE - 8)
+                .rotationEffect(.degrees(45))
+
+            Text("+")
+                .font(.system(.largeTitle))
+                .foregroundColor(Color.white)
+                .padding(.bottom, 7)
+                .frame(width: BUTTON_SIZE, height: BUTTON_SIZE)
+        }
     })
-    .background(Color.accentColor)
-    .cornerRadius(38.5)
     .padding()
     .shadow(color: Color.black.opacity(0.3),
             radius: 3,
@@ -36,4 +53,3 @@ func PostButtonContainer(action: @escaping () -> ()) -> some View {
         }
     }
 }
-    


### PR DESCRIPTION
Minor amendment to the post button (achieved using shapes and text rather than images).

![image](https://user-images.githubusercontent.com/5950171/210611399-5a21d41f-fead-4334-b62a-cde79ce10fde.png)

FYI It would be good to fix why this isn't appearing in the preview mode of the app.

ChangeLog-Changed: Updated new post button to gradient color (@npub1jutptdc2m8kgjmudtws095qk2tcale0eemvp4j2xnjnl4nh6669slrf04x)