### PR TITLE
Make Event in Reply View Scrollable

### DIFF
--- a/damus/Views/ReplyView.swift
+++ b/damus/Views/ReplyView.swift
@@ -33,7 +33,9 @@ struct ReplyView: View {
                     .foregroundColor(.gray)
                     .font(.footnote)
             }
-            EventView(event: replying_to, highlight: .none, has_action_bar: false, damus: damus, show_friend_icon: true)
+            ScrollView {
+                EventView(event: replying_to, highlight: .none, has_action_bar: false, damus: damus, show_friend_icon: true)                
+            }
             PostView(replying_to: replying_to, references: gather_reply_ids(our_pubkey: damus.pubkey, from: replying_to))
         }
         .padding()


### PR DESCRIPTION
Embed event content in a scroll view when replying so it doesn't collapse the UI

Before:
![Simulator Screen Recording - iPhone 14 Pro - 2023-01-04 at 14 40 50](https://user-images.githubusercontent.com/264977/210663696-3053a8c9-3e3b-4c4b-b074-74b349d3317b.gif)

After:
![Simulator Screen Recording - iPhone 14 Pro - 2023-01-04 at 14 38 25](https://user-images.githubusercontent.com/264977/210663514-6c5a7cf7-afaa-4fbe-a3b4-41f599cb313e.gif)
