### PR TITLE
hide-profile-edit-button-for-pubkey-user

### DIFF
--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -234,7 +234,7 @@ struct ProfileView: View {
                             target: profile.get_follow_target(),
                             follow_state: damus_state.contacts.follow_state(profile.pubkey)
                         )
-                    } else {
+                    } else if damus_state.keypair.privkey != nil {
                         NavigationLink(destination: EditMetadataView(damus_state: damus_state)) {
                             EditButton(damus_state: damus_state)
                         }


### PR DESCRIPTION
The merged changes from this PR https://github.com/damus-io/damus/pull/215 were accidentally misplaced later.