### PR TITLE
Allow Saving Images to Library

### DIFF
--- a/damus/Components/ImageCarousel.swift
+++ b/damus/Components/ImageCarousel.swift
@@ -49,6 +49,11 @@ struct ImageContextMenuModifier: ViewModifier {
                 } label: {
                     Label("Copy Image", systemImage: "photo.on.rectangle")
                 }
+                Button {
+                    UIImageWriteToSavedPhotosAlbum(someImage, nil, nil, nil)
+                } label: {
+                    Label("Save Image", systemImage: "square.and.arrow.down")
+                }
             }
             Button {
                 showShareSheet = true

--- a/damus/Info.plist
+++ b/damus/Info.plist
@@ -15,6 +15,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>&quot;Granting Damus access to your photo library allows you to save photos.</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>river</string>


### PR DESCRIPTION
Had to add a usage description to the `Info.plist`:
`Granting Yammer access to your photo library allows you to share photos.`

![Simulator Screen Recording - iPhone 14 Pro - 2023-01-05 at 13 08 39](https://user-images.githubusercontent.com/264977/210880314-6dc495a3-8fd4-433f-9183-8b722b708b5e.gif)
