### PR TITLE
Refactor image processor and add clear cache button in settings

### DIFF
--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -6,6 +6,7 @@
 //
 import AVFoundation
 import SwiftUI
+import Kingfisher
 
 struct ConfigView: View {
     let state: DamusState
@@ -110,6 +111,14 @@ struct ConfigView: View {
                             Text(wallet.model.displayName)
                                 .tag(wallet.model.tag)
                         }
+                    }
+                }
+                
+                Section("Clear Cache") {
+                    Button("Clear") {
+                        KingfisherManager.shared.cache.clearMemoryCache()
+                        KingfisherManager.shared.cache.clearDiskCache()
+                        KingfisherManager.shared.cache.cleanExpiredDiskCache()
                     }
                 }
                 

--- a/damus/Views/ProfilePicView.swift
+++ b/damus/Views/ProfilePicView.swift
@@ -62,7 +62,6 @@ struct InnerProfilePicView: View {
                 .placeholder { _ in
                     Placeholder
                 }
-                .cacheOriginalImage()
                 .scaleFactor(UIScreen.main.scale)
                 .loadDiskFileSynchronously()
                 .fade(duration: 0.1)
@@ -112,17 +111,20 @@ struct LargeImageProcessor: ImageProcessor {
     let downsampleSize = CGSize(width: 200, height: 200)
     
     func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
-        let downsamplingImageProcessor = DownsamplingImageProcessor(size: downsampleSize)
         
         switch item {
         case .image(let image):
-            if image.cacheCost > maxSize {
-                return downsamplingImageProcessor.process(item: item, options: options)
+            guard let data = image.kf.data(format: .unknown) else {
+                return nil
+            }
+            
+            if data.count > maxSize {
+                return KingfisherWrapper.downsampledImage(data: data, to: downsampleSize, scale: options.scaleFactor)
             }
             return image
         case .data(let data):
             if data.count > maxSize {
-                return downsamplingImageProcessor.process(item: item, options: options)
+                return KingfisherWrapper.downsampledImage(data: data, to: downsampleSize, scale: options.scaleFactor)
             }
             return KFCrossPlatformImage(data: data)
         }


### PR DESCRIPTION
1. Replaced the processor with a wrapper for downsampling image. Returning the processor would append it's identifier instead of the LargeImageProcessor identifier. 
2. Some users were reporting that their image would not animate even after scaling the size. This happens because they use the same url for the new image - the url is used as the key for caching. The clear cache button should solve this.