### PR TITLE
Hide the NIP-05 Domain in Follow List

### DIFF
--- a/damus/Views/FollowingView.swift
+++ b/damus/Views/FollowingView.swift
@@ -24,7 +24,7 @@ struct FollowUserView: View {
             
                 VStack(alignment: .leading) {
                     let profile = damus_state.profiles.lookup(id: target.pubkey)
-                    ProfileName(pubkey: target.pubkey, profile: profile, damus: damus_state, show_friend_confirmed: false)
+                    ProfileName(pubkey: target.pubkey, profile: profile, damus: damus_state, show_friend_confirmed: false, show_nip5_domain: false)
                     if let about = profile?.about {
                         Text(FollowUserView.markdown.process(about))
                             .lineLimit(3)

--- a/damus/Views/ProfileName.swift
+++ b/damus/Views/ProfileName.swift
@@ -30,26 +30,29 @@ struct ProfileName: View {
     let prefix: String
     
     let show_friend_confirmed: Bool
+    let show_nip5_domain: Bool
     
     @State var display_name: String?
     @State var nip05: NIP05?
     
     @Environment(\.openURL) var openURL
-    
-    init(pubkey: String, profile: Profile?, damus: DamusState, show_friend_confirmed: Bool) {
+
+    init(pubkey: String, profile: Profile?, damus: DamusState, show_friend_confirmed: Bool, show_nip5_domain: Bool = true) {
         self.pubkey = pubkey
         self.profile = profile
         self.prefix = ""
         self.show_friend_confirmed = show_friend_confirmed
+        self.show_nip5_domain = show_nip5_domain
         self.damus_state = damus
     }
     
-    init(pubkey: String, profile: Profile?, prefix: String, damus: DamusState, show_friend_confirmed: Bool) {
+    init(pubkey: String, profile: Profile?, prefix: String, damus: DamusState, show_friend_confirmed: Bool, show_nip5_domain: Bool = true) {
         self.pubkey = pubkey
         self.profile = profile
         self.prefix = prefix
         self.damus_state = damus
         self.show_friend_confirmed = show_friend_confirmed
+        self.show_nip5_domain = show_nip5_domain
     }
     
     var friend_icon: String? {
@@ -72,13 +75,16 @@ struct ProfileName: View {
             if let nip05 = current_nip05 {
                 Image(systemName: "checkmark.seal.fill")
                     .foregroundColor(nip05_color)
-                Text(nip05.host)
-                    .foregroundColor(nip05_color)
-                    .onTapGesture {
-                        if let nip5url = nip05.siteUrl {
-                            openURL(nip5url)
+                
+                if show_nip5_domain {
+                    Text(nip05.host)
+                        .foregroundColor(nip05_color)
+                        .onTapGesture {
+                            if let nip5url = nip05.siteUrl {
+                                openURL(nip5url)
+                            }
                         }
-                    }
+                }
             }
             if let friend = friend_icon, current_nip05 == nil {
                 Image(systemName: friend)


### PR DESCRIPTION
Seemed to be always breaking the layout so I figured you can go to their profile if you want to check the actaul domain, check mark is probably enough in follow list. Might make sense for the Boosted view as well.

| Before      | After |
| ----------- | ----------- |
|  ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-05 at 19 22 07](https://user-images.githubusercontent.com/264977/210923741-d15873c7-0452-46fb-b30b-ee8af37a6b7a.png)    |  ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-05 at 19 21 45](https://user-images.githubusercontent.com/264977/210923768-1ea74c3a-449e-498b-8f6c-c151de7bf8e8.png)  |
