### PR TITLE
New feature: Image uploading/hosting

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		3169CAE6294E69C000EE4006 /* EmptyTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3169CAE5294E69C000EE4006 /* EmptyTimelineView.swift */; };
 		3169CAED294FCCFC00EE4006 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3169CAEC294FCCFC00EE4006 /* Constants.swift */; };
 		31D2E847295218AF006D67F8 /* Shimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D2E846295218AF006D67F8 /* Shimmer.swift */; };
+		397A94752967EE2400E2F080 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397A94742967EE2400E2F080 /* ImagePicker.swift */; };
+		397A94772967EE6400E2F080 /* ImageHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397A94762967EE6400E2F080 /* ImageHost.swift */; };
 		3A4325A82961E11400BFCD9D /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 3A4325AA2961E11400BFCD9D /* Localizable.stringsdict */; };
 		3ACBCB78295FE5C70037388A /* TimeAgoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACBCB77295FE5C70037388A /* TimeAgoTests.swift */; };
 		4C06670128FC7C5900038D2A /* RelayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C06670028FC7C5900038D2A /* RelayView.swift */; };
@@ -169,6 +171,8 @@
 		3169CAE5294E69C000EE4006 /* EmptyTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyTimelineView.swift; sourceTree = "<group>"; };
 		3169CAEC294FCCFC00EE4006 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = damus/Util/Constants.swift; sourceTree = SOURCE_ROOT; };
 		31D2E846295218AF006D67F8 /* Shimmer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shimmer.swift; sourceTree = "<group>"; };
+		397A94742967EE2400E2F080 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
+		397A94762967EE6400E2F080 /* ImageHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageHost.swift; sourceTree = "<group>"; };
 		3A4325A92961E11400BFCD9D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		3ACBCB77295FE5C70037388A /* TimeAgoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeAgoTests.swift; sourceTree = "<group>"; };
 		4C06670028FC7C5900038D2A /* RelayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayView.swift; sourceTree = "<group>"; };
@@ -462,6 +466,7 @@
 				4C99737A28C92A9200E53835 /* ChatroomMetadata.swift */,
 				BA693073295D649800ADDB87 /* UserSettingsStore.swift */,
 				4FE60CDC295E1C5E00105A1F /* Wallet.swift */,
+				397A94762967EE6400E2F080 /* ImageHost.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -566,6 +571,7 @@
 				4C06670528FCB08600038D2A /* ImageCarousel.swift */,
 				4C3EA67C28FFBBA200C48A62 /* InvoicesView.swift */,
 				4C3EA67E28FFC01D00C48A62 /* InvoiceView.swift */,
+				397A94742967EE2400E2F080 /* ImagePicker.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -810,6 +816,7 @@
 				4C75EFB728049D990006080F /* RelayPool.swift in Sources */,
 				4C3EA67728FF7A9800C48A62 /* talstr.c in Sources */,
 				4CE6DEE927F7A08100C66700 /* ContentView.swift in Sources */,
+				397A94772967EE6400E2F080 /* ImageHost.swift in Sources */,
 				4CEE2AF5280B29E600AB5EEF /* TimeAgo.swift in Sources */,
 				4C75EFAD28049CFB0006080F /* PostButton.swift in Sources */,
 				4CB55EF5295E679D007FD187 /* UserRelaysView.swift in Sources */,
@@ -894,6 +901,7 @@
 				4C06670E28FDEAA000038D2A /* utf8.c in Sources */,
 				4C3EA66D28FF782800C48A62 /* amount.c in Sources */,
 				4C3AC7A728369BA200E1F516 /* SearchHomeView.swift in Sources */,
+				397A94752967EE2400E2F080 /* ImagePicker.swift in Sources */,
 				4C363A922825FCF2006E126D /* ProfileUpdate.swift in Sources */,
 				4C0A3F95280F6C78000448DE /* ReplyQuoteView.swift in Sources */,
 				4C3BEFDA281DCA1400B3DE84 /* LikeCounter.swift in Sources */,

--- a/damus/Components/ImagePicker.swift
+++ b/damus/Components/ImagePicker.swift
@@ -1,0 +1,66 @@
+//
+//  ImagePicker.swift
+//  damus
+//
+//  Created by Michael Hall on 12/29/22.
+//
+
+import PhotosUI
+import SwiftUI
+
+struct ImagePicker: UIViewControllerRepresentable {
+    @Binding var image_data: Data?
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config = PHPickerConfiguration()
+        config.filter = .images
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {
+
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        let parent: ImagePicker
+
+        init(_ parent: ImagePicker) {
+            self.parent = parent
+        }
+
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            picker.dismiss(animated: true)
+
+            guard let provider = results.first?.itemProvider else { return }
+            
+            provider.loadDataRepresentation(forTypeIdentifier: "public.image") { (data, error) in
+                self.parent.image_data = data
+            }
+        }
+    }
+}
+
+extension Data {
+    private static let mimeTypeSignatures: [UInt8 : String] = [
+        0xFF : "image/jpeg",
+        0x89 : "image/png",
+        0x47 : "image/gif",
+        0x49 : "image/tiff",
+        0x4D : "image/tiff",
+        0x25 : "application/pdf",
+        0xD0 : "application/vnd",
+        0x46 : "text/plain",
+        ]
+
+    var mimeType: String {
+        var c: UInt8 = 0
+        copyBytes(to: &c, count: 1)
+        return Data.mimeTypeSignatures[c] ?? "application/octet-stream"
+    }
+}

--- a/damus/Models/ImageHost.swift
+++ b/damus/Models/ImageHost.swift
@@ -1,0 +1,108 @@
+//
+//  ImageHost.swift
+//  damus
+//
+//  Created by Michael Hall on 01/04/23.
+//
+
+import Foundation
+import UIKit
+
+enum ImageHost: String, CaseIterable, Identifiable {
+    var id: String { self.rawValue }
+    
+    struct Model: Identifiable, Hashable {
+        var id: String { self.tag }
+        var tag: String
+        var displayName : String
+        var uploadLink : String
+        var clientId : String?
+    }
+    
+// TODO: implement nostr.build
+//    case nostr_build
+    case nostrimg
+    
+    var model: Model {
+        switch self {
+// TODO: implement nostr.build
+//        case .nostr_build:
+//            return .init(tag: "nostr_build", displayName: NSLocalizedString("nostr.build", comment: "Dropdown option label for image host Nostr.Build."),
+//                         uploadLink: "https://nostr.build/api/upload", clientId: "")
+        case .nostrimg:
+            return .init(tag: "nostrimg", displayName: NSLocalizedString("nostrimg.com", comment: "Dropdown option label for image host Nostrimg."),
+                         uploadLink: "https://nostrimg.com/api/upload", clientId: "401e1e2049ba44114a5f59e60315eb0fb0fd12beee1f08deb8bde773995b896e")
+        }
+    }
+    
+    static var allModels: [Model] {
+        return Self.allCases.map { $0.model }
+    }
+    
+    func uploadImage(image_data: Data, completion: @escaping (Result<URL, Error>) -> Void) {
+        switch self {
+// TODO: implement nostr.build
+//        case .nostr_build:
+//
+//            return
+            
+        case .nostrimg:
+            // Make API call to Nostrimg to upload image
+            let url = URL(string: self.model.uploadLink)
+
+            // generate boundary string using a unique per-app string
+            let boundary = UUID().uuidString
+
+            let session = URLSession.shared
+
+            // Set the URLRequest to POST and to the specified URL
+            var urlRequest = URLRequest(url: url!)
+            urlRequest.httpMethod = "POST"
+            
+            // Set the Authorization header with the Client-ID
+            urlRequest.setValue("Client-ID \(self.model.clientId!)", forHTTPHeaderField: "Authorization")
+
+            // Set Content-Type Header to multipart/form-data, this is equivalent to submitting form data with file upload in a web browser
+            // And the boundary is also set here
+            urlRequest.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+            
+            
+            var bodyData = Data()
+            // Add the image data to the raw http request data
+            bodyData.append("\r\n--\(boundary)\r\n".data(using: .utf8)!)
+            bodyData.append("Content-Disposition: form-data; name=\"\("image")\"; filename=\"\("image." + image_data.mimeType.split(separator: "/")[1])\"\r\n".data(using: .utf8)!)
+            bodyData.append("Content-Type: \(image_data.mimeType)\r\n\r\n".data(using: .utf8)!)
+            bodyData.append(image_data)
+            bodyData.append("\r\n--\(boundary)--\r\n".data(using: .utf8)!)
+            
+            
+            // Send a POST request to the URL, with the data we created earlier
+            var result: Result<URL, Error>!
+            session.uploadTask(with: urlRequest, from: bodyData, completionHandler: { responseData, response, error in
+                if error == nil {
+                    do {
+                        let jsonData = try JSONSerialization.jsonObject(with: responseData!, options: .allowFragments)
+                        if let json = jsonData as? [String: Any] {
+                            if let image_url = json["imageUrl"] as? String {
+                                result = .success(URL(string: image_url)!)
+                            } else {
+                                result = .failure(ImageHostError.imageURLError)
+                            }
+                        } else {
+                            result = .failure(ImageHostError.jsonParseError)
+                        }
+                    } catch {
+                        result = .failure(error)
+                    }
+                    completion(result)
+                }
+            }).resume()
+            return
+        }
+    }
+}
+
+enum ImageHostError: Error {
+    case jsonParseError
+    case imageURLError
+}

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -19,6 +19,12 @@ class UserSettingsStore: ObservableObject {
             UserDefaults.standard.set(show_wallet_selector, forKey: "show_wallet_selector")
         }
     }
+    
+    @Published var default_image_host: ImageHost {
+        didSet {
+            UserDefaults.standard.set(default_image_host.rawValue, forKey: "default_image_host")
+        }
+    }
 
     init() {
         if let defaultWalletName = UserDefaults.standard.string(forKey: "default_wallet"),
@@ -26,6 +32,12 @@ class UserSettingsStore: ObservableObject {
             self.default_wallet = default_wallet
         } else {
             self.default_wallet = .system_default_wallet
+        }
+        if let defaultImageHostName = UserDefaults.standard.string(forKey: "default_image_host"),
+           let default_image_host = ImageHost(rawValue: defaultImageHostName) {
+            self.default_image_host = default_image_host
+        } else {
+            self.default_image_host = .nostrimg
         }
         self.show_wallet_selector = UserDefaults.standard.object(forKey: "show_wallet_selector") as? Bool ?? true
     }

--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -114,6 +114,16 @@ struct ConfigView: View {
                     }
                 }
                 
+                Section("Default Image Host") {
+                    Picker("Select image host",
+                           selection: $user_settings.default_image_host) {
+                        ForEach(ImageHost.allCases, id: \.self) { image_host in
+                            Text(image_host.model.displayName)
+                                .tag(image_host.model.tag)
+                        }
+                    }
+                }
+                
                 Section("Clear Cache") {
                     Button("Clear") {
                         KingfisherManager.shared.cache.clearMemoryCache()

--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -6,6 +6,8 @@
 //
 
 import SwiftUI
+import Foundation
+import Kingfisher
 
 enum NostrPostResult {
     case post(NostrPost)
@@ -16,6 +18,22 @@ let POST_PLACEHOLDER = NSLocalizedString("Type your post here...", comment: "Tex
 
 struct PostView: View {
     @State var post: String = ""
+    
+    @State var image_host_error: Error?
+    @State var show_image_host_error = false
+    @State var showing_image_picker = false
+    @State var image: Image?
+    @State var image_data: Data?
+    @State var image_url: URL?
+    @State var showSelectImageHostView: Bool = false
+    @State var is_posting: Bool = false {
+        didSet {
+            if is_posting {
+                send_post()
+            }
+        }
+    }
+    @ObservedObject var user_settings = UserSettingsStore()
 
     let replying_to: NostrEvent?
     @FocusState var focus: Bool
@@ -41,6 +59,7 @@ struct PostView: View {
         if replying_to?.known_kind == .chat {
             kind = .chat
         }
+        if let image_url = image_url { post += " " + image_url.absoluteString }
         let content = self.post.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
         let new_post = NostrPost(content: content, references: references, kind: kind)
 
@@ -49,7 +68,44 @@ struct PostView: View {
     }
 
     var is_post_empty: Bool {
-        return post.allSatisfy { $0.isWhitespace }
+        return post.allSatisfy { $0.isWhitespace } && image_data == nil
+    }
+    
+    var can_post: Bool {
+        if is_post_empty { return false }
+        if image_data != nil && image_url == nil { return false }
+        return true
+    }
+    
+    func choose_image() {
+        showing_image_picker = true
+    }
+    
+    func load_image() {
+        guard let uiimage = UIImage(data: image_data!) else { return }
+        self.image = Image(uiImage: uiimage)
+    }
+    
+    func upload_image() {
+        self.image_url = nil
+        if let image_data = image_data {
+            let image_host = user_settings.default_image_host
+            image_host.uploadImage(image_data: image_data) { result in
+                switch result {
+                    case .success(let image_url):
+                        // do something with the json data
+                        self.image_url = image_url
+                    case .failure(let error):
+                        // handle the error
+                        self.image_host_error = error
+                        self.show_image_host_error = true
+                        self.image = nil
+                        self.image_data = nil
+                        self.image_url = nil
+                        print(error)
+                }
+            }
+        }
     }
 
     var body: some View {
@@ -62,10 +118,16 @@ struct PostView: View {
 
                 Spacer()
 
-                if !is_post_empty {
-                    Button("Post") {
-                        self.send_post()
+                if can_post {
+                    if self.is_posting {
+                        ProgressView()
+                    } else {
+                        Button("Post") {
+                            self.is_posting = true
+                        }
                     }
+                } else if image_data != nil && image_url == nil {
+                    ProgressView()
                 }
             }
             .padding([.top, .bottom], 4)
@@ -82,6 +144,46 @@ struct PostView: View {
                         .allowsHitTesting(false)
                 }
             }
+            .frame(maxHeight: 250)
+            
+            if image != nil || image_url != nil {
+                ZStack {
+                    image?
+                        .resizable()
+                    if self.image_url != nil {
+                        KFAnimatedImage(self.image_url)
+                            .onSuccess({ result in
+                                self.image = nil
+                            })
+                    }
+                }
+                .scaledToFit()
+                .frame(maxHeight: 100)
+            }
+            
+            if replying_to == nil {
+                Divider()
+                HStack {
+                    Button(action: {
+                        self.choose_image()
+                    }) {
+                        Image(systemName: "photo")
+                            .foregroundColor(.primary)
+                    }
+                    .onChange(of: image_data) { _ in
+                        if image_data != nil {
+                            load_image()
+                            upload_image()
+                        }
+                    }
+                    .sheet(isPresented: $showing_image_picker) {
+                        ImagePicker(image_data: $image_data)
+                    }
+                    Spacer()
+                }
+                .padding([.top, .bottom], 4)
+                Spacer()
+            }
         }
         .onAppear() {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -89,6 +191,9 @@ struct PostView: View {
             }
         }
         .padding()
+        .alert(isPresented: $show_image_host_error) {
+            Alert(title: Text("Sorry"), message: Text("There was a problem uploading your image."), dismissButton: .default(Text("OK")))
+        }
     }
 }
 


### PR DESCRIPTION
Hi all,

I've developed a feature for users to add images to their posts in-app. It works by sending the chosen image to an image host API (right now nostrimg.com is the only option) and appending the returned image URL to the end of the post.

It is flexible so that new APIs can easily be added simply by filling in some settings and implementing the uploadImage() function for the API. All of the API code can be found in Models/ImageHost.swift.

Also included in the PR is the ability for users to set a default image host in the config view.

I have also written an ImagePicker view which can be reused for other purposes in the app such as setting profile pic.

I had a hard time getting the layout to work well for the ReplyView, so for I've only enabled image uploading when creating top-level posts, but this can easily be changed by removing a couple lines of code.

Supports every image format I tested, including gifs. (It seems like the PHPickerViewController just converts still images to JPEG. It did that for webp, heif, png, etc.)

Other hosts worth looking into: nostr.build, imgur

Apologies if I did anything horribly wrong, I'm very new to iOS dev 😝
![IMG_5610](https://user-images.githubusercontent.com/40177960/210941897-baae576e-0bc2-477f-99b5-61fe5f43e73c.PNG)
![IMG_5611](https://user-images.githubusercontent.com/40177960/210941906-8867a7a2-6c20-46db-a4c4-e0f010936ec0.PNG)
