### PR TITLE
Make DMs only take up 80% of screen width to match iMessages

### DIFF
--- a/damus/Views/DMView.swift
+++ b/damus/Views/DMView.swift
@@ -10,25 +10,28 @@ import SwiftUI
 struct DMView: View {
     let event: NostrEvent
     let damus_state: DamusState
-    
+
     var is_ours: Bool {
         event.pubkey == damus_state.pubkey
     }
-    
+
     var body: some View {
         HStack {
             if is_ours {
-                Spacer()
+                Spacer(minLength: UIScreen.main.bounds.width * 0.2)
             }
-            
+
             let should_show_img = should_show_images(contacts: damus_state.contacts, ev: event, our_pubkey: damus_state.pubkey)
-            
+
             NoteContentView(privkey: damus_state.keypair.privkey, event: event, profiles: damus_state.profiles, previews: damus_state.previews, show_images: should_show_img, artifacts: .just_content(event.get_content(damus_state.keypair.privkey)), size: .normal)
                 .foregroundColor(is_ours ? Color.white : Color.primary)
                 .padding(10)
                 .background(is_ours ? Color.accentColor : Color.secondary.opacity(0.15))
                 .cornerRadius(8.0)
                 .tint(is_ours ? Color.white : Color.accentColor)
+            if !is_ours {
+                Spacer(minLength: UIScreen.main.bounds.width * 0.2)
+            }
         }
     }
 }


### PR DESCRIPTION
DMs now take up only 80% of the available screen width so it looks much more like iMessages. Simply added spacers at each end of the message depending on who's message it was.
<img width="261" alt="Screenshot 2023-01-07 at 7 54 04 PM" src="https://user-images.githubusercontent.com/93488695/211177216-c977761a-5624-49b9-ac8b-ac5233eb3776.png">