### PR TITLE
Expanding NIP 05 identifier

### DIFF
--- a/damus/Views/ProfileName.swift
+++ b/damus/Views/ProfileName.swift
@@ -7,6 +7,11 @@
 
 import SwiftUI
 
+let LINEAR_GRADIENT = LinearGradient(gradient: Gradient(colors: [
+    Color("DamusPurple"),
+    Color("DamusBlue")
+]), startPoint: .topTrailing, endPoint: .bottomTrailing)
+
 func get_friend_icon(contacts: Contacts, pubkey: String, show_confirmed: Bool) -> String? {
     if !show_confirmed {
         return nil
@@ -33,6 +38,10 @@ struct ProfileName: View {
     
     @State var display_name: String?
     @State var nip05: NIP05?
+    
+    @Environment(\.colorScheme) var colorScheme
+    
+    @State var isNIPCollapsed = false
     
     init(pubkey: String, profile: Profile?, damus: DamusState, show_friend_confirmed: Bool) {
         self.pubkey = pubkey
@@ -62,21 +71,52 @@ struct ProfileName: View {
         return get_nip05_color(pubkey: pubkey, contacts: damus_state.contacts)
     }
     
+    func nip05fillColor() -> Color {
+        colorScheme == .light ? Color("DamusLightGrey") : Color("DamusDarkGrey")
+    }
+    
     var body: some View {
+        
         HStack(spacing: 2) {
+            
             Text(prefix + String(display_name ?? Profile.displayName(profile: profile, pubkey: pubkey)))
                 .font(.body)
                 .fontWeight(prefix == "@" ? .none : .bold)
+            
             if let nip05 = current_nip05 {
-                Image(systemName: "checkmark.seal.fill")
-                    .foregroundColor(nip05_color)
-                Text(nip05.host)
-                    .foregroundColor(nip05_color)
+                ZStack(alignment: .leading) {
+                    Image(systemName: "checkmark.seal.fill")
+                        .foregroundColor(nip05_color)
+                        .onTapGesture {
+                            withAnimation {
+                                self.isNIPCollapsed.toggle()
+                            }
+                        }
+                    if !isNIPCollapsed {
+                        Text(nip05.host)
+                            .foregroundColor(nip05_color)
+                            //.font(.footnote)
+                            .scaledToFit()
+                        
+                        RoundedRectangle(cornerRadius: 24)
+                            .padding(.leading, 5)
+                            .frame(height:20)
+                            .foregroundColor(nip05fillColor())
+                            //.overlay(
+                            //
+                            //)
+                            //.transition(.push(from: .leading))
+                            .frame(width: isNIPCollapsed ? 0 : nil) // Was hoping for more of a slide out TBH
+                            .clipped()
+                    }
+                }
             }
+            /*
             if let friend = friend_icon, current_nip05 == nil {
                 Image(systemName: friend)
                     .foregroundColor(.gray)
             }
+            */
         }
         .onReceive(handle_notify(.profile_updated)) { notif in
             let update = notif.object as! ProfileUpdate

--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -364,10 +364,12 @@ struct ProfileView_Previews: PreviewProvider {
 
 
 func test_damus_state() -> DamusState {
+    // Damus (non-NIP-05 verfied)
     let pubkey = "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"
+    
     let damus = DamusState(pool: RelayPool(), keypair: Keypair(pubkey: pubkey, privkey: "privkey"), likes: EventCounter(our_pubkey: pubkey), boosts: EventCounter(our_pubkey: pubkey), contacts: Contacts(our_pubkey: pubkey), tips: TipCounter(our_pubkey: pubkey), profiles: Profiles(), dms: DirectMessagesModel(), previews: PreviewCache())
     
-    let prof = Profile(name: "damus", display_name: "damus", about: "iOS app!", picture: "https://damus.io/img/logo.png", website: "https://damus.io", lud06: nil, lud16: "jb55@sendsats.lol", nip05: "damus.io")
+    let prof = Profile(name: "damus", display_name: "damus", about: "iOS app!", picture: "https://damus.io/img/logo.png", website: "https://damus.io", lud06: nil, lud16: "jb55@sendsats.lol", nip05: "damus@damus.io")
     let tsprof = TimestampedProfile(profile: prof, timestamp: 0)
     damus.profiles.add(id: pubkey, profile: tsprof)
     return damus

--- a/damus/damusApp.swift
+++ b/damus/damusApp.swift
@@ -7,17 +7,13 @@
 
 import SwiftUI
 
-
 @main
 struct damusApp: App {
     var body: some Scene {
         WindowGroup {
             MainView()
         }
-        
     }
-    
-
 }
 
 struct MainView: View {


### PR DESCRIPTION
Hi @jb55,

Would you be interested in an expanding (animated) NIP-05 identifier that we hide when not needed?

![image](https://user-images.githubusercontent.com/5950171/211178682-530eb874-2fb8-4242-8edd-cae6961c13bb.png)

Also added a touch of gradient to add that badge feel:

![image](https://user-images.githubusercontent.com/5950171/211178675-63217c8f-ba3a-439a-af7d-b2dc35b3639a.png)

**Will refactor code a little and tweak sizes / colour etc. if interested in it**