### PR TITLE
Fix Markdown Parsing in Profile

### DIFF
--- a/damus/Util/Markdown.swift
+++ b/damus/Util/Markdown.swift
@@ -8,13 +8,6 @@
 import Foundation
 
 public struct Markdown {
-    private let detector = try! NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
-
-    /// Ensure the specified URL has a scheme by prepending "https://" if it's absent.
-    static func withScheme(_ url: any StringProtocol) -> any StringProtocol {
-        return url.contains("://") ? url : "https://" + url
-    }
-
     /// Parse a string with markdown into an `AttributedString`, if possible, or else return it as regular text.
     public static func parse(content: String) -> AttributedString {
         let md_opts: AttributedString.MarkdownParsingOptions =
@@ -27,21 +20,5 @@ public struct Markdown {
         } else {
             return AttributedString(stringLiteral: content)
         }
-    }
-
-    /// Process the input text and add markdown for any embedded URLs.
-    public func process(_ input: String) -> AttributedString {
-        let matches = detector.matches(in: input, options: [], range: NSRange(location: 0, length: input.utf16.count))
-        var output = input
-        // Start with the last match, because replacing the first would invalidate all subsequent indices
-        for match in matches.reversed() {
-            guard let range = Range(match.range, in: input)
-                , let url = match.url else { continue }
-            let text = input[range]
-            // Use the absoluteString from the matched URL, except when it defaults to http (since we default to https)
-            let uri = url.scheme == "http" ? Markdown.withScheme(text) : url.absoluteString
-            output.replaceSubrange(range, with: "[\(text)](\(uri))")
-        }
-        return Markdown.parse(content: output)
     }
 }

--- a/damus/Views/FollowingView.swift
+++ b/damus/Views/FollowingView.swift
@@ -11,8 +11,6 @@ struct FollowUserView: View {
     let target: FollowTarget
     let damus_state: DamusState
 
-    static let markdown = Markdown()
-
     var body: some View {
         HStack {
             let pmodel = ProfileModel(pubkey: target.pubkey, damus: damus_state)
@@ -26,7 +24,7 @@ struct FollowUserView: View {
                     let profile = damus_state.profiles.lookup(id: target.pubkey)
                     ProfileName(pubkey: target.pubkey, profile: profile, damus: damus_state, show_friend_confirmed: false)
                     if let about = profile?.about {
-                        Text(FollowUserView.markdown.process(about))
+                        Text(Markdown.parse(content: about))
                             .lineLimit(3)
                             .font(.footnote)
                     }

--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -164,8 +164,6 @@ struct ProfileView: View {
                 .environmentObject(user_settings)
         }
     }
-
-    static let markdown = Markdown()
     
     var ShareButton: some View {
         Button(action: {
@@ -246,10 +244,9 @@ struct ProfileView: View {
                 }
                                
                 ProfileNameView(pubkey: profile.pubkey, profile: data, damus: damus_state)
-                    //.padding(.bottom)
                     .padding(.top,-(pfp_size/2.0))
                 
-                Text(ProfileView.markdown.process(data?.about ?? ""))
+                Text(Markdown.parse(content: data?.about ?? ""))
                     .font(.subheadline)
                 
                 Divider()
@@ -298,7 +295,6 @@ struct ProfileView: View {
                 }
             }
             .padding(.horizontal,18)
-            //.offset(y:120)
             .padding(.top,150)
         }
     }

--- a/damusTests/MarkdownTests.swift
+++ b/damusTests/MarkdownTests.swift
@@ -21,44 +21,32 @@ class MarkdownTests: XCTestCase {
     }
 
     func test_convert_link() throws {
-        let helper = Markdown()
-        let md = helper.process("prologue https://nostr.build epilogue")
+        let md = Markdown.parse(content: "prologue https://nostr.build epilogue")
         let expected = try AttributedString(markdown: "prologue [https://nostr.build](https://nostr.build) epilogue", options: md_opts)
         XCTAssertEqual(md, expected)
     }
-
-    func test_convert_link_no_scheme() throws {
-        let helper = Markdown()
-        let md = helper.process("prologue damus.io epilogue")
-        let expected = try AttributedString(markdown: "prologue [damus.io](https://damus.io) epilogue", options: md_opts)
+    
+    func test_no_convert_markdown_link() throws {
+        let md = Markdown.parse(content: "prologue [link](https://nostr.build) epilogue")
+        let expected = try AttributedString(markdown: "prologue [link](https://nostr.build) epilogue", options: md_opts)
         XCTAssertEqual(md, expected)
     }
-
-    func test_convert_links() throws {
-        let helper = Markdown()
-        let md = helper.process("prologue damus.io https://nostr.build epilogue")
-        let expected = try AttributedString(markdown: "prologue [damus.io](https://damus.io) [https://nostr.build](https://nostr.build) epilogue", options: md_opts)
+    
+    func test_no_convert_with_emoji() throws {
+        let md = Markdown.parse(content: "test link w/ emoji ❤️ in a [string](https://nostr.build)")
+        let expected = try AttributedString(markdown: "test link w/ emoji ❤️ in a [string](https://nostr.build)", options: md_opts)
         XCTAssertEqual(md, expected)
     }
 
     func test_convert_http() throws {
-        let helper = Markdown()
-        let md = helper.process("prologue http://example.com epilogue")
+        let md = Markdown.parse(content: "prologue http://example.com epilogue")
         let expected = try AttributedString(markdown: "prologue [http://example.com](http://example.com) epilogue", options: md_opts)
         XCTAssertEqual(md, expected)
     }
 
     func test_convert_mailto() throws {
-        let helper = Markdown()
-        let md = helper.process("prologue test@example.com epilogue")
+        let md = Markdown.parse(content: "prologue test@example.com epilogue")
         let expected = try AttributedString(markdown: "prologue [test@example.com](mailto:test@example.com) epilogue", options: md_opts)
-        XCTAssertEqual(md, expected)
-    }
-
-    func test_convert_mailto_implicit() throws {
-        let helper = Markdown()
-        let md = helper.process("prologue mailto:test@example.com epilogue")
-        let expected = try AttributedString(markdown: "prologue [mailto:test@example.com](mailto:test@example.com) epilogue", options: md_opts)
         XCTAssertEqual(md, expected)
     }
 


### PR DESCRIPTION
It looks like we added some code to add markdown for email addresses (`mailto:`) and links without `https://` but that also make explicit markdown links not work because it tried to add markdown inside the parenthesis of the markdown link.

This allows you to use markdown links in the profile and would require you to use markdown if you want to something like `damus.io` to appear as a link. But, I think that's probably expected. I may be misunderstanding the purpose here but everything seems to work for me except the links like `damus.io` but I think people can just use markdown for that?

FYI @lionello 