### PR TITLE
Hide Recommended Relays Section if Empty

### DIFF
--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -70,9 +70,11 @@ struct ConfigView: View {
                     }
                 }
                 
-                Section("Recommended Relays") {
-                    List(recommended, id: \.url) { r in
-                        RecommendedRelayView(damus: state, relay: r.url.absoluteString)
+                if recommended.count > 0 {
+                    Section("Recommended Relays") {
+                        List(recommended, id: \.url) { r in
+                            RecommendedRelayView(damus: state, relay: r.url.absoluteString)
+                        }
                     }
                 }
                 


### PR DESCRIPTION
If you've already added all the recommended relays, hide that section when it's empty:

| Before      | After |
| ----------- | ----------- |
|  ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-08 at 21 47 41](https://user-images.githubusercontent.com/264977/211247646-9d13d2dd-6547-41e8-bcb6-8c439574f29f.png) |  ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-08 at 21 47 51](https://user-images.githubusercontent.com/264977/211247663-a04579a0-c959-4735-813c-875394fd9eaa.png) |
