### PR TITLE
feat(ci): Publish PR notifications to Nostr

### DIFF
--- a/.github/workflows/pr-to-nostr.yaml
+++ b/.github/workflows/pr-to-nostr.yaml
@@ -1,0 +1,29 @@
+name: Nostr PR Notifier
+on: 
+  pull_request:
+    types: [opened, reopened]
+jobs:
+  Notify:
+    runs-on: ubuntu-latest
+    env:
+      # Set in Github repo > Settings > Secrets and Variables
+      NOSTR_KEY: ${{ secrets.NOSTR_KEY }}
+      # Event vars
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.19.0'
+      - run: go install github.com/fiatjaf/noscl@latest
+      - run: which noscl
+      - run: noscl setprivate $NOSTR_KEY
+      - run: noscl relay add wss://relay.damus.io
+      - run: noscl relay add wss://brb.io
+      - run: noscl relay add wss://relay.nostr.info
+      - run: |
+         msg=$(printf "Pull request opened by $PR_AUTHOR\n$PR_TITLE\n$PR_URL") \
+         && noscl publish "$msg"


### PR DESCRIPTION
Sends pull request notifications to Nostr using Github Workflows and noscl.

To setup, you'll need to add a `NOSTR_KEY` private key secret to this repository's Settings:
```
Settings tab > Secrets and Variables
```

- Test PR: https://github.com/bndw/nostrpr/pull/5
- Resulting post to Nostr:
![image](https://user-images.githubusercontent.com/4248167/211611890-1ee0ab2d-2457-4206-8702-d9d2e320ad0c.png)
