### PR TITLE
Fix large file crash, add SVG support, add Base64 image support

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -147,6 +147,9 @@
 		647D9A8D2968520300A295DE /* SideMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647D9A8C2968520300A295DE /* SideMenuView.swift */; };
 		64FBD06F296255C400D9D3B2 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FBD06E296255C400D9D3B2 /* Theme.swift */; };
 		6C7DE41F2955169800E66263 /* Vault in Frameworks */ = {isa = PBXBuildFile; productRef = 6C7DE41E2955169800E66263 /* Vault */; };
+		7C45AE6D297352F90031D7BC /* SVGKit in Frameworks */ = {isa = PBXBuildFile; productRef = 7C45AE6C297352F90031D7BC /* SVGKit */; };
+		7C45AE6F297352F90031D7BC /* SVGKitSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 7C45AE6E297352F90031D7BC /* SVGKitSwift */; };
+		7C45AE71297353390031D7BC /* KFImageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C45AE70297353390031D7BC /* KFImageModel.swift */; };
 		9609F058296E220800069BF3 /* BannerImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609F057296E220800069BF3 /* BannerImageView.swift */; };
 		BA693074295D649800ADDB87 /* UserSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA693073295D649800ADDB87 /* UserSettingsStore.swift */; };
 		BAB68BED29543FA3007BA466 /* SelectWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */; };
@@ -348,6 +351,7 @@
 		4FE60CDC295E1C5E00105A1F /* Wallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallet.swift; sourceTree = "<group>"; };
 		647D9A8C2968520300A295DE /* SideMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuView.swift; sourceTree = "<group>"; };
 		64FBD06E296255C400D9D3B2 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		7C45AE70297353390031D7BC /* KFImageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KFImageModel.swift; sourceTree = "<group>"; };
 		9609F057296E220800069BF3 /* BannerImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerImageView.swift; sourceTree = "<group>"; };
 		BA693073295D649800ADDB87 /* UserSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsStore.swift; sourceTree = "<group>"; };
 		BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectWalletView.swift; sourceTree = "<group>"; };
@@ -361,6 +365,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7C45AE6F297352F90031D7BC /* SVGKitSwift in Frameworks */,
+				7C45AE6D297352F90031D7BC /* SVGKit in Frameworks */,
 				4C06670428FC7EC500038D2A /* Kingfisher in Frameworks */,
 				6C7DE41F2955169800E66263 /* Vault in Frameworks */,
 				4CE6DF1227F7A2B300C66700 /* Starscream in Frameworks */,
@@ -480,6 +486,7 @@
 				BA693073295D649800ADDB87 /* UserSettingsStore.swift */,
 				4FE60CDC295E1C5E00105A1F /* Wallet.swift */,
 				4CB88392296F798300DC99E7 /* ReactionsModel.swift */,
+				7C45AE70297353390031D7BC /* KFImageModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -712,6 +719,8 @@
 				4C649880286E0EE300EAE2B3 /* secp256k1 */,
 				4C06670328FC7EC500038D2A /* Kingfisher */,
 				6C7DE41E2955169800E66263 /* Vault */,
+				7C45AE6C297352F90031D7BC /* SVGKit */,
+				7C45AE6E297352F90031D7BC /* SVGKitSwift */,
 			);
 			productName = damus;
 			productReference = 4CE6DEE327F7A08100C66700 /* damus.app */;
@@ -792,6 +801,7 @@
 				4C64987F286E0EE300EAE2B3 /* XCRemoteSwiftPackageReference "secp256k1" */,
 				4C06670228FC7EC500038D2A /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				6C7DE41D2955169800E66263 /* XCRemoteSwiftPackageReference "Vault" */,
+				7C45AE6B297352F90031D7BC /* XCRemoteSwiftPackageReference "SVGKit" */,
 			);
 			productRefGroup = 4CE6DEE427F7A08100C66700 /* Products */;
 			projectDirPath = "";
@@ -891,6 +901,7 @@
 				4C3EA67F28FFC01D00C48A62 /* InvoiceView.swift in Sources */,
 				4CEE2B02280B39E800AB5EEF /* EventActionBar.swift in Sources */,
 				4C3BEFE0281DE1ED00B3DE84 /* DamusState.swift in Sources */,
+				7C45AE71297353390031D7BC /* KFImageModel.swift in Sources */,
 				4C0A3F8F280F640A000448DE /* ThreadModel.swift in Sources */,
 				4C3AC79F2833115300E1F516 /* FollowButtonView.swift in Sources */,
 				4C3BEFD22819DB9B00B3DE84 /* ProfileModel.swift in Sources */,
@@ -1150,12 +1161,13 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"damus/Preview Content\"";
-				DEVELOPMENT_TEAM = XK7H4JAB3D;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = damus/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Damus;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "\"Granting Damus access to your photo library allows you to save photos.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -1190,12 +1202,13 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 6;
 				DEVELOPMENT_ASSET_PATHS = "\"damus/Preview Content\"";
-				DEVELOPMENT_TEAM = XK7H4JAB3D;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = damus/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Damus;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.social-networking";
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "\"Granting Damus access to your photo library allows you to save photos.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -1369,6 +1382,14 @@
 				minimumVersion = 1.0.0;
 			};
 		};
+		7C45AE6B297352F90031D7BC /* XCRemoteSwiftPackageReference "SVGKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SVGKit/SVGKit";
+			requirement = {
+				kind = revision;
+				revision = e1f13e27b1e4c0ffe20e7d8d3984bf49c2a584d0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1391,6 +1412,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6C7DE41D2955169800E66263 /* XCRemoteSwiftPackageReference "Vault" */;
 			productName = Vault;
+		};
+		7C45AE6C297352F90031D7BC /* SVGKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7C45AE6B297352F90031D7BC /* XCRemoteSwiftPackageReference "SVGKit" */;
+			productName = SVGKit;
+		};
+		7C45AE6E297352F90031D7BC /* SVGKitSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7C45AE6B297352F90031D7BC /* XCRemoteSwiftPackageReference "SVGKit" */;
+			productName = SVGKitSwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -27,6 +27,14 @@
       }
     },
     {
+      "identity" : "svgkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SVGKit/SVGKit",
+      "state" : {
+        "revision" : "e1f13e27b1e4c0ffe20e7d8d3984bf49c2a584d0"
+      }
+    },
+    {
       "identity" : "vault",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SparrowTek/Vault",

--- a/damus/Info.plist
+++ b/damus/Info.plist
@@ -15,8 +15,6 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>&quot;Granting Damus access to your photo library allows you to save photos.</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>river</string>

--- a/damus/Models/KFImageModel.swift
+++ b/damus/Models/KFImageModel.swift
@@ -1,0 +1,108 @@
+//
+//  KFImageModel.swift
+//  damus
+//
+//  Created by Oleg Abalonski on 1/11/23.
+//
+
+import Foundation
+import Kingfisher
+import SVGKit
+
+class KFImageModel: ObservableObject {
+    
+    let url: URL?
+    let fallbackUrl: URL?
+    let processor: ImageProcessor
+    let serializer: CacheSerializer
+    
+    @Published var refreshID = ""
+    
+    init(url: URL?, fallbackUrl: URL?, maxByteSize: Int, downsampleSize: CGSize) {
+        self.url = url
+        self.fallbackUrl = fallbackUrl
+        self.processor = CustomImageProcessor(maxSize: maxByteSize, downsampleSize: downsampleSize)
+        self.serializer = CustomCacheSerializer(maxSize: maxByteSize, downsampleSize: downsampleSize)
+    }
+    
+    func refresh() -> Void {
+        DispatchQueue.main.async {
+            self.refreshID = UUID().uuidString
+        }
+    }
+    
+    func cache(_ image: UIImage, forKey key: String) -> Void {
+        KingfisherManager.shared.cache.store(image, forKey: key, processorIdentifier: processor.identifier) { _ in
+            self.refresh()
+        }
+    }
+    
+    func downloadFailed() -> Void {
+        guard let url = url, let fallbackUrl = fallbackUrl else { return }
+        
+        DispatchQueue.global(qos: .background).async {
+            KingfisherManager.shared.downloader.downloadImage(with: fallbackUrl) { result in
+                
+                var fallbackImage: UIImage {
+                    switch result {
+                    case .success(let imageLoadingResult):
+                        return imageLoadingResult.image
+                    case .failure(let error):
+                        print(error)
+                        return UIImage()
+                    }
+                }
+                
+                self.cache(fallbackImage, forKey: url.absoluteString)
+            }
+        }
+    }
+}
+
+struct CustomImageProcessor: ImageProcessor {
+    
+    let maxSize: Int
+    let downsampleSize: CGSize
+    
+    let identifier = "com.damus.customimageprocessor"
+    
+    func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
+        
+        switch item {
+        case .image(_):
+            // This case will never run
+            return DefaultImageProcessor.default.process(item: item, options: options)
+        case .data(let data):
+            
+            // Handle large image size
+            if data.count > maxSize {
+                return KingfisherWrapper.downsampledImage(data: data, to: downsampleSize, scale: options.scaleFactor)
+            }
+            
+            // Handle SVG image
+            if let svgImage = SVGKImage(data: data), let image = svgImage.uiImage {
+                return image.kf.scaled(to: options.scaleFactor)
+            }
+            
+            return DefaultImageProcessor.default.process(item: item, options: options)
+        }
+    }
+}
+
+struct CustomCacheSerializer: CacheSerializer {
+    
+    let maxSize: Int
+    let downsampleSize: CGSize
+
+    func data(with image: Kingfisher.KFCrossPlatformImage, original: Data?) -> Data? {
+        return DefaultCacheSerializer.default.data(with: image, original: original)
+    }
+
+    func image(with data: Data, options: Kingfisher.KingfisherParsedOptionsInfo) -> Kingfisher.KFCrossPlatformImage? {
+        if data.count > maxSize {
+            return KingfisherWrapper.downsampledImage(data: data, to: downsampleSize, scale: options.scaleFactor)
+        }
+
+        return DefaultCacheSerializer.default.image(with: data, options: options)
+    }
+}


### PR DESCRIPTION
This PR introduces the following changes:

1. Image file size will now be handled first in `CustomImageProcessor`. The `LargeImageProcessor` was being appended before, causing the file size check to happen after the default processor. A large file would crash the app as it would be loaded before downsampling could occur. Unfortunately, we will lose the compression that the default processor provided - many `GIFs` will be above the `1MB` size limit and not animate now. 

How to reproduce crash:
- Visit account `npub1krzjm6vekx7mcwtyx9zx30dshg2xukwkd0jnr0h6xd3hp5njzmxsc4r5ru`
- Wait for profile pic to load

2. Added support for SVG image processing. Not sure if we want to add a dependency for this feature. Let me know if you want this removed.

Before             |  After
:-------------------------:|:-------------------------:
 ![IMG_4568](https://user-images.githubusercontent.com/19398259/211344829-26302aba-c40d-44cb-8dd4-1bc89c3b4769.jpg) | ![IMG_4602](https://user-images.githubusercontent.com/19398259/211933218-2bda2f49-58df-4fd1-9314-171a974932fe.jpg)

3. Added support for Base64 png/jpg images

Before             |  After
:-------------------------:|:-------------------------:
![IMG_4604](https://user-images.githubusercontent.com/19398259/211933947-e9186c77-b19d-4b23-a868-04bf2bd408aa.jpg) | ![IMG_4603](https://user-images.githubusercontent.com/19398259/211933911-e26f85ad-d4e9-4936-b8b8-337fbf4122ac.jpg)

4. Moved KingFisher logic to a separate file. Not sure if this an optional design. Any feedback is welcome.