### PR TITLE
Avoid showing wrong alert message for pub-key login user.

### DIFF
--- a/damus/Views/SideMenuView.swift
+++ b/damus/Views/SideMenuView.swift
@@ -135,7 +135,11 @@ struct SideMenuView: View {
                     
                     Button(action: {
                         //ConfigView(state: damus_state)
-                        confirm_logout = true
+                        if damus_state.keypair.privkey == nil {
+                            notify(.logout, ())
+                        } else {
+                            confirm_logout = true
+                        }
                     }, label: {
                         Label("Sign out", systemImage: "pip.exit")
                             .font(.title3)


### PR DESCRIPTION
Avoid showing wrong alert message for pub-key login user.

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-13 at 17 23 17](https://user-images.githubusercontent.com/120697811/212430994-9c6a4709-ca59-4320-95b4-b07c713bd9c1.png)
