### PR TITLE
Tweak icons size on TabBar

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -175,7 +175,7 @@ struct ContentView: View {
                 if selected_timeline == .home {
                     Image("damus-home")
                     .resizable()
-                    .frame(width:30,height:30)
+                    .frame(width:30, height:30)
                     .shadow(color: Color("DamusPurple"), radius: 2)
                 } else {
                     Text("Global")

--- a/damus/Views/MainTabView.swift
+++ b/damus/Views/MainTabView.swift
@@ -60,7 +60,7 @@ struct TabButton: View {
             isSidebarVisible = false
         }) {
             Image(systemName: selected == timeline ? "\(imageName).fill" : imageName)
-                .font(.system(size: fontSize, weight: .thin))
+                .font(.system(size: fontSize, weight: .regular))
                 .contentShape(Rectangle())
                 .frame(maxWidth: .infinity, minHeight: 30.0)
         }
@@ -83,7 +83,7 @@ struct TabBar: View {
                 TabButton(
                     timeline: .home,
                     imageName: "house",
-                    fontSize: 24,
+                    fontSize: 17,
                     selected: $selected,
                     new_events: $new_events,
                     isSidebarVisible: $isSidebarVisible,
@@ -92,7 +92,7 @@ struct TabBar: View {
                 TabButton(
                     timeline: .dms,
                     imageName: "bubble.left.and.bubble.right",
-                    fontSize: 23,
+                    fontSize: 16,
                     selected: $selected,
                     new_events: $new_events,
                     isSidebarVisible: $isSidebarVisible,
@@ -101,7 +101,7 @@ struct TabBar: View {
                 TabButton(
                     timeline: .search,
                     imageName: "magnifyingglass.circle",
-                    fontSize: 27,
+                    fontSize: 19,
                     selected: $selected,
                     new_events: $new_events,
                     isSidebarVisible: $isSidebarVisible,
@@ -110,7 +110,7 @@ struct TabBar: View {
                 TabButton(
                     timeline: .notifications,
                     imageName: "bell",
-                    fontSize: 25,
+                    fontSize: 18,
                     selected: $selected,
                     new_events: $new_events,
                     isSidebarVisible: $isSidebarVisible,

--- a/damus/Views/MainTabView.swift
+++ b/damus/Views/MainTabView.swift
@@ -30,7 +30,8 @@ func timeline_bit(_ timeline: Timeline) -> Int {
     
 struct TabButton: View {
     let timeline: Timeline
-    let img: String
+    let imageName: String
+    let fontSize: CGFloat
     @Binding var selected: Timeline?
     @Binding var new_events: NewEventsBits
     @Binding var isSidebarVisible: Bool
@@ -58,7 +59,8 @@ struct TabButton: View {
             new_events = NewEventsBits(prev: new_events, unsetting: timeline)
             isSidebarVisible = false
         }) {
-            Label("", systemImage: selected == timeline ? "\(img).fill" : img)
+            Image(systemName: selected == timeline ? "\(imageName).fill" : imageName)
+                .font(.system(size: fontSize, weight: .thin))
                 .contentShape(Rectangle())
                 .frame(maxWidth: .infinity, minHeight: 30.0)
         }
@@ -78,10 +80,42 @@ struct TabBar: View {
         VStack {
             Divider()
             HStack {
-                TabButton(timeline: .home, img: "house", selected: $selected, new_events: $new_events, isSidebarVisible: $isSidebarVisible, action: action).keyboardShortcut("1")
-                TabButton(timeline: .dms, img: "bubble.left.and.bubble.right", selected: $selected, new_events: $new_events, isSidebarVisible: $isSidebarVisible, action: action).keyboardShortcut("2")
-                TabButton(timeline: .search, img: "magnifyingglass.circle", selected: $selected, new_events: $new_events, isSidebarVisible: $isSidebarVisible, action: action).keyboardShortcut("3")
-                TabButton(timeline: .notifications, img: "bell", selected: $selected, new_events: $new_events, isSidebarVisible: $isSidebarVisible, action: action).keyboardShortcut("4")
+                TabButton(
+                    timeline: .home,
+                    imageName: "house",
+                    fontSize: 24,
+                    selected: $selected,
+                    new_events: $new_events,
+                    isSidebarVisible: $isSidebarVisible,
+                    action: action
+                ).keyboardShortcut("1")
+                TabButton(
+                    timeline: .dms,
+                    imageName: "bubble.left.and.bubble.right",
+                    fontSize: 23,
+                    selected: $selected,
+                    new_events: $new_events,
+                    isSidebarVisible: $isSidebarVisible,
+                    action: action
+                ).keyboardShortcut("2")
+                TabButton(
+                    timeline: .search,
+                    imageName: "magnifyingglass.circle",
+                    fontSize: 27,
+                    selected: $selected,
+                    new_events: $new_events,
+                    isSidebarVisible: $isSidebarVisible,
+                    action: action
+                ).keyboardShortcut("3")
+                TabButton(
+                    timeline: .notifications,
+                    imageName: "bell",
+                    fontSize: 25,
+                    selected: $selected,
+                    new_events: $new_events,
+                    isSidebarVisible: $isSidebarVisible,
+                    action: action
+                ).keyboardShortcut("4")
             }
         }
     }


### PR DESCRIPTION
Before vs After

<img src=https://user-images.githubusercontent.com/360470/212446140-649abb3f-af82-480a-b612-92dc2de9792e.png width=45% /> <==> <img src=https://user-images.githubusercontent.com/360470/213327891-14f9a94d-375b-4fe7-8b79-635b4ae5d75d.png width=45% />

Slightly increase `Search` icon size
