### PR TITLE
Show images reposted by yourself or people you follow

### DIFF
--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -175,7 +175,7 @@ struct EventView: View {
                         Reposted(damus: damus, pubkey: event.pubkey, profile: prof)
                     }
                     .buttonStyle(PlainButtonStyle())
-                    TextEvent(inner_ev, pubkey: inner_ev.pubkey)
+                    TextEvent(inner_ev, pubkey: inner_ev.pubkey, booster_pubkey: event.pubkey)
                         .padding([.top], 1)
                 }
             } else {
@@ -185,7 +185,7 @@ struct EventView: View {
         }
     }
 
-    func TextEvent(_ event: NostrEvent, pubkey: String) -> some View {
+    func TextEvent(_ event: NostrEvent, pubkey: String, booster_pubkey: String = "") -> some View {
         let content = event.get_content(damus.keypair.privkey)
         
         return HStack(alignment: .top) {
@@ -232,7 +232,7 @@ struct EventView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                let should_show_img = should_show_images(contacts: damus.contacts, ev: event, our_pubkey: damus.pubkey)
+                let should_show_img = should_show_images(contacts: damus.contacts, ev: event, our_pubkey: damus.pubkey, booster_pubkey: booster_pubkey)
                 
                 NoteContentView(privkey: damus.keypair.privkey, event: event, profiles: damus.profiles, previews: damus.previews, show_images: should_show_img, artifacts: .just_content(content), size: self.size)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -276,11 +276,14 @@ struct EventView: View {
 }
 
 // blame the porn bots for this code
-func should_show_images(contacts: Contacts, ev: NostrEvent, our_pubkey: String) -> Bool {
+func should_show_images(contacts: Contacts, ev: NostrEvent, our_pubkey: String, booster_pubkey: String = "") -> Bool {
     if ev.pubkey == our_pubkey {
         return true
     }
     if contacts.is_in_friendosphere(ev.pubkey) {
+        return true
+    }
+    if contacts.is_in_friendosphere(booster_pubkey) {
         return true
     }
     return false


### PR DESCRIPTION
Currently, when someone you follow reposts a note with an image, that image is blurred. The same is true when you repost a note with an image from someone you don't follow, that image will also be blurred to you.

This PR changes that so anytime someone you follow reposts a note with an image, that image will no longer be blurred, the thought being that you trust the people you follow. 

<img src="https://user-images.githubusercontent.com/14004132/212494625-0424bcd1-5d49-4a9c-b2fd-60d27c406e25.png" width="300"> <img src="https://user-images.githubusercontent.com/14004132/212494622-eedb2d61-c32f-4582-a3ad-811e7dd84b41.png" width="300"> 
