### PR TITLE
Corrected the plurality of Reposts, Reactions, Tips, Followers, Relays

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		64FBD06F296255C400D9D3B2 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FBD06E296255C400D9D3B2 /* Theme.swift */; };
 		6C7DE41F2955169800E66263 /* Vault in Frameworks */ = {isa = PBXBuildFile; productRef = 6C7DE41E2955169800E66263 /* Vault */; };
 		9609F058296E220800069BF3 /* BannerImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609F057296E220800069BF3 /* BannerImageView.swift */; };
+		9C5E27792973983B001E7320 /* Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5E27782973983A001E7320 /* Utility.swift */; };
 		BA693074295D649800ADDB87 /* UserSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA693073295D649800ADDB87 /* UserSettingsStore.swift */; };
 		BAB68BED29543FA3007BA466 /* SelectWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */; };
 		DD597CBD2963D85A00C64D32 /* MarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD597CBC2963D85A00C64D32 /* MarkdownTests.swift */; };
@@ -349,6 +350,7 @@
 		647D9A8C2968520300A295DE /* SideMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuView.swift; sourceTree = "<group>"; };
 		64FBD06E296255C400D9D3B2 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		9609F057296E220800069BF3 /* BannerImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerImageView.swift; sourceTree = "<group>"; };
+		9C5E27782973983A001E7320 /* Utility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utility.swift; sourceTree = "<group>"; };
 		BA693073295D649800ADDB87 /* UserSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsStore.swift; sourceTree = "<group>"; };
 		BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectWalletView.swift; sourceTree = "<group>"; };
 		DD597CBC2963D85A00C64D32 /* MarkdownTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkdownTests.swift; sourceTree = "<group>"; };
@@ -575,6 +577,7 @@
 				4C3A1D3629637E0500558C0F /* PreviewCache.swift */,
 				64FBD06E296255C400D9D3B2 /* Theme.swift */,
 				4CB8838529656C8B00DC99E7 /* NIP05.swift */,
+				9C5E27782973983A001E7320 /* Utility.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -930,6 +933,7 @@
 				4CE6DF1627F8DEBF00C66700 /* RelayConnection.swift in Sources */,
 				4C3BEFD6281D995700B3DE84 /* ActionBarModel.swift in Sources */,
 				4C363AA428296DEE006E126D /* SearchModel.swift in Sources */,
+				9C5E27792973983B001E7320 /* Utility.swift in Sources */,
 				4CEE2AF3280B25C500AB5EEF /* ProfilePicView.swift in Sources */,
 				4CEE2AF9280B2EAC00AB5EEF /* PowView.swift in Sources */,
 				3165648B295B70D500C64604 /* LinkView.swift in Sources */,
@@ -977,6 +981,7 @@
 				DD597CBD2963D85A00C64D32 /* MarkdownTests.swift in Sources */,
 				4C3EA67B28FF7B3900C48A62 /* InvoiceTests.swift in Sources */,
 				4C363A9E2828A822006E126D /* ReplyTests.swift in Sources */,
+				9C5E277A2973983B001E7320 /* Utility.swift in Sources */,
 				4C363AA02828A8DD006E126D /* LikeTests.swift in Sources */,
 				4C90BD1C283AC38E008EE7EF /* Bech32Tests.swift in Sources */,
 				4CE6DEF827F7A08200C66700 /* damusTests.swift in Sources */,

--- a/damus/Util/Utility.swift
+++ b/damus/Util/Utility.swift
@@ -1,0 +1,31 @@
+//
+//  Utility.swift
+//  damus
+//
+//  Created by Swift on 1/14/23.
+//
+
+import SwiftUI
+
+extension String {
+
+    /// Conform plurality of word based on the count
+    /// - Parameter count: Generic type count
+    /// - Returns: String appended with 's' if necessary
+    func conformPlurality<T>(count: T) -> String {
+        var string = self
+        if let value = count as? Int,
+            value != 1 {
+            string.append("s")
+        } else if let stringValue = count as? String,
+                  let value = Int(stringValue),
+                    value != 1 {
+            string.append("s")
+        }
+        return string
+    }
+
+    func conformPlurality<T>(count: T) -> LocalizedStringKey {
+        LocalizedStringKey(self.conformPlurality(count: count))
+    }
+}

--- a/damus/Views/ActionBar/EventDetailBar.swift
+++ b/damus/Views/ActionBar/EventDetailBar.swift
@@ -17,7 +17,7 @@ struct EventDetailBar: View {
             if bar.boosts > 0 {
                 Text("\(bar.boosts)")
                     .font(.body.bold())
-                Text("Reposts")
+                Text("Repost".conformPlurality(count: bar.boosts))
                     .foregroundColor(.gray)
             }
 
@@ -25,7 +25,7 @@ struct EventDetailBar: View {
                 NavigationLink(destination: ReactionsView(damus_state: state, model: ReactionsModel(state: state, target: target))) {
                     Text("\(bar.likes)")
                         .font(.body.bold())
-                    Text("Reactions")
+                    Text("Reaction".conformPlurality(count: bar.likes))
                         .foregroundColor(.gray)
                 }
                 .buttonStyle(PlainButtonStyle())
@@ -34,7 +34,7 @@ struct EventDetailBar: View {
             if bar.tips > 0 {
                 Text("\(bar.tips)")
                     .font(.body.bold())
-                Text("Tips")
+                Text("Tip".conformPlurality(count: bar.tips))
                     .foregroundColor(.gray)
             }
         }

--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -282,7 +282,7 @@ struct ProfileView: View {
                     
                     if let relays = profile.relays {
                         NavigationLink(destination: UserRelaysView(state: damus_state, pubkey: profile.pubkey, relays: Array(relays.keys).sorted())) {
-                            Text("\(Text("\(relays.keys.count)", comment: "Number of relay servers a user is connected.").font(.subheadline.weight(.medium))) \(Text("Relays", comment: "Part of a larger sentence to describe how many relay servers a user is connected.").font(.subheadline).foregroundColor(.gray))", comment: "Sentence composed of 2 variables to describe how many relay servers a user is connected. In source English, the first variable is the number of relay servers, and the second variable is 'Relays'.")
+                            Text("\(Text("\(relays.keys.count)", comment: "Number of relay servers a user is connected.").font(.subheadline.weight(.medium))) \(Text("Relay".conformPlurality(count: relays.keys.count), comment: "Part of a larger sentence to describe how many relay servers a user is connected.").font(.subheadline).foregroundColor(.gray))", comment: "Sentence composed of 2 variables to describe how many relay servers a user is connected. In source English, the first variable is the number of relay servers, and the second variable is 'Relays'.")
                         }
                         .buttonStyle(PlainButtonStyle())
                     }
@@ -302,7 +302,7 @@ struct ProfileView: View {
                     .font(.subheadline)
                     .foregroundColor(.gray)
             } else {
-                Text("\(Text("\(followers.count_display)", comment: "Number of people following a user.").font(.subheadline.weight(.medium))) \(Text("Followers", comment: "Part of a larger sentence to describe how many people are following a user.").font(.subheadline).foregroundColor(.gray))", comment: "Sentence composed of 2 variables to describe how many people are following a user. In source English, the first variable is the number of followers, and the second variable is 'Followers'.")
+                Text("\(Text("\(followers.count_display)", comment: "Number of people following a user.").font(.subheadline.weight(.medium))) \(Text("Follower".conformPlurality(count: followers.count_display), comment: "Part of a larger sentence to describe how many people are following a user.").font(.subheadline).foregroundColor(.gray))", comment: "Sentence composed of 2 variables to describe how many people are following a user. In source English, the first variable is the number of followers, and the second variable is 'Followers'.")
             }
         }
     }


### PR DESCRIPTION
Corrected the plurality of words for Reposts, Reactions, Tips, Followers, and Relays based on their count.

**Sample example for Repost:**
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-14 at 23 06 40](https://user-images.githubusercontent.com/120697811/212525163-b9b68e6a-c60e-430e-87c9-6a9cf3b3fc8e.png)
