### PR TITLE
Fix Jack's padding issue

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -103,7 +103,7 @@ struct ContentView: View {
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
         }
-        .safeAreaInset(edge: .top) {
+        .safeAreaInset(edge: .top, spacing: 0) {
             VStack(spacing: 0) {
                 FiltersView
                     //.frame(maxWidth: 275)

--- a/damus/Views/TimelineView.swift
+++ b/damus/Views/TimelineView.swift
@@ -52,6 +52,7 @@ struct InnerTimelineView: View {
             }
         }
         .padding(.horizontal)
+        .padding(.top,10)
     }
 }
 


### PR DESCRIPTION
A simple resolution to Jack's padding issue at the top of the homepage.

There is now no gap here (between `Divider` and the timeline):

![image](https://user-images.githubusercontent.com/5950171/212560762-666fb072-8b4f-43df-ab47-73d48b37e56d.png)
