### PR TITLE
Icons for hardclick menu event view

### DIFF
--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -324,19 +324,19 @@ extension View {
             Button {
                 UIPasteboard.general.string = bech32_pubkey(pubkey) ?? pubkey
             } label: {
-                Label(NSLocalizedString("Copy User ID", comment: "Context menu option for copying the ID of the user who created the note."), systemImage: "tag")
+                Label(NSLocalizedString("Copy User ID", comment: "Context menu option for copying the ID of the user who created the note."), systemImage: "person")
             }
 
             Button {
                 UIPasteboard.general.string = bech32_note_id(event.id) ?? event.id
             } label: {
-                Label(NSLocalizedString("Copy Note ID", comment: "Context menu option for copying the ID of the note."), systemImage: "tag")
+                Label(NSLocalizedString("Copy Note ID", comment: "Context menu option for copying the ID of the note."), systemImage: "note.text")
             }
 
             Button {
                 UIPasteboard.general.string = event_to_json(ev: event)
             } label: {
-                Label(NSLocalizedString("Copy Note JSON", comment: "Context menu option for copying the JSON text from the note."), systemImage: "note")
+                Label(NSLocalizedString("Copy Note JSON", comment: "Context menu option for copying the JSON text from the note."), systemImage: "magnifyingglass")
             }
 
             Button {

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -336,7 +336,7 @@ extension View {
             Button {
                 UIPasteboard.general.string = event_to_json(ev: event)
             } label: {
-                Label(NSLocalizedString("Copy Note JSON", comment: "Context menu option for copying the JSON text from the note."), systemImage: "magnifyingglass")
+                Label(NSLocalizedString("Copy Note JSON", comment: "Context menu option for copying the JSON text from the note."), systemImage: "j.square.on.square")
             }
 
             Button {


### PR DESCRIPTION
I was constantly confused having the two tags for user ID and note ID
so i changed the icons to clear up the confusion
the feedback i received from others was the j square version (right) is the preferable icon for copy JSON
if i did this correct you should see two commits so you can choose if you prefer the magnifying glass (left)


![Screenshot 2023-01-15 162237](https://user-images.githubusercontent.com/56426913/212580331-e53a6c91-d62d-4f60-bf21-c9b4c4fa2019.png)

