### PR TITLE
User can customize their reaction icon appearing on Reactions screen

### DIFF
--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -560,7 +560,7 @@ func make_like_event(pubkey: String, privkey: String, liked: NostrEvent) -> Nost
     var tags: [[String]] = liked.tags.filter { tag in tag.count >= 2 && (tag[0] == "e" || tag[0] == "p") }
     tags.append(["e", liked.id])
     tags.append(["p", liked.pubkey])
-    let ev = NostrEvent(content: "🤙", pubkey: pubkey, kind: 7, tags: tags)
+    let ev = NostrEvent(content: get_saved_reaction_icon(), pubkey: pubkey, kind: 7, tags: tags)
     ev.calculate_id()
     ev.sign(privkey: privkey)
 
@@ -788,4 +788,8 @@ func inner_event_or_self(ev: NostrEvent) -> NostrEvent {
     }
     
     return inner_ev
+}
+
+func get_saved_reaction_icon() -> String {
+    return UserDefaults.standard.string(forKey: "reaction_icon") ?? "🤙"
 }

--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -7,6 +7,7 @@
 import AVFoundation
 import SwiftUI
 import Kingfisher
+import Combine
 
 struct ConfigView: View {
     let state: DamusState
@@ -16,10 +17,13 @@ struct ConfigView: View {
     @State var new_relay: String = ""
     @State var show_privkey: Bool = false
     @State var privkey: String
+    @State var reaction_icon: String = get_saved_reaction_icon()
     @State var privkey_copied: Bool = false
     @State var pubkey_copied: Bool = false
     @State var relays: [RelayDescriptor]
     @EnvironmentObject var user_settings: UserSettingsStore
+
+    let reaction_char_limit: Int = 1
     
     let generator = UIImpactFeedbackGenerator(style: .light)
     
@@ -121,6 +125,12 @@ struct ConfigView: View {
                         .toggleStyle(.switch)
                 }
 
+                Section(NSLocalizedString("Custom Reaction", comment: "Allows user to change the reaction emoji on Reactions screen")) {
+
+                    TextField(NSLocalizedString("Customize your reaction", comment: "Allows user to change the reaction emoji on Reactions screen"), text: $reaction_icon)
+
+                }.onReceive(Just(reaction_icon)) { _ in limitText(reaction_char_limit) }
+
                 Section(NSLocalizedString("Clear Cache", comment: "Section title for clearing cached data.")) {
                     Button(NSLocalizedString("Clear", comment: "Button for clearing cached data.")) {
                         KingfisherManager.shared.cache.clearMemoryCache()
@@ -193,6 +203,23 @@ struct ConfigView: View {
         .onReceive(handle_notify(.relays_changed)) { _ in
             self.relays = state.pool.descriptors
         }
+        .onDisappear{
+            save_reaction_icon()
+        }
+    }
+
+    //Function to keep reaction characters length in limit
+    func limitText(_ upper: Int) {
+        if reaction_icon.count > upper {
+            reaction_icon = String(reaction_icon.prefix(upper))
+        }
+    }
+
+    func save_reaction_icon() {
+        if reaction_icon.isEmpty {
+            reaction_icon = "🤙"
+        }
+        UserDefaults.standard.set(reaction_icon, forKey: "reaction_icon")
     }
 }
 


### PR DESCRIPTION
This change allows the user to customize their reaction icon appearing on Reactions screen from Damus.

**Screenshot of the customize option added on Settings:**
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-16 at 10 30 38](https://user-images.githubusercontent.com/120697811/212714697-fdfeac68-00fe-4e7f-8758-7ce8660e77c0.png)

**Reactions screen:**
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-16 at 10 26 38](https://user-images.githubusercontent.com/120697811/212714223-796d174e-d5f5-4874-96da-b1bdf6dc5f76.png)
