### PR TITLE
Avoid showing wrong alert message when trying to re-post from Pubkey user

### DIFF
--- a/damus/Models/DamusState.swift
+++ b/damus/Models/DamusState.swift
@@ -22,6 +22,11 @@ struct DamusState {
     var pubkey: String {
         return keypair.pubkey
     }
+
+    var is_privkey_user: Bool {
+        keypair.privkey != nil
+    }
+
     
     static var empty: DamusState {
         return DamusState.init(pool: RelayPool(), keypair: Keypair(pubkey: "", privkey: ""), likes: EventCounter(our_pubkey: ""), boosts: EventCounter(our_pubkey: ""), contacts: Contacts(our_pubkey: ""), tips: TipCounter(our_pubkey: ""), profiles: Profiles(), dms: DirectMessagesModel(), previews: PreviewCache())

--- a/damus/Views/ActionBar/EventActionBar.swift
+++ b/damus/Views/ActionBar/EventActionBar.swift
@@ -41,7 +41,7 @@ struct EventActionBar: View {
                 EventActionButton(img: "arrow.2.squarepath", col: bar.boosted ? Color.green : nil) {
                     if bar.boosted {
                         notify(.delete, bar.our_boost)
-                    } else {
+                    } else if damus_state.is_privkey_user {
                         self.confirm_boost = true
                     }
                 }.overlay {


### PR DESCRIPTION
Avoid showing wrong alert message when trying to re-post from Pubkey user.
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-16 at 21 16 43](https://user-images.githubusercontent.com/120697811/212796921-bd346aee-9c43-4616-aa4e-31192b96f777.png)
