### PR TITLE
Prevent absurdly large sidebar on Mac or iPad

### DIFF
--- a/damus/Views/SideMenuView.swift
+++ b/damus/Views/SideMenuView.swift
@@ -16,7 +16,7 @@ struct SideMenuView: View {
     
     @Environment(\.colorScheme) var colorScheme
     
-    var sideBarWidth = UIScreen.main.bounds.size.width * 0.65
+    var sideBarWidth = min(UIScreen.main.bounds.size.width * 0.65, 400.0)
     
     func fillColor() -> Color {
         colorScheme == .light ? Color("DamusWhite") : Color("DamusBlack")


### PR DESCRIPTION
Issue: Drawer is graphically buggy on macOS
Ensures sidebar is no wider than 400 points
Closes #317

On Mac:

https://user-images.githubusercontent.com/350257/212803237-1219b242-0f18-4bae-8aef-11a779f13b2c.mov

On iPad:

https://user-images.githubusercontent.com/350257/212803484-a3c64af2-45e7-478c-9a9c-9b16af692f02.mp4


