### PR TITLE
Fix tab views moving up after selecting from search result

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -113,7 +113,6 @@ struct ContentView: View {
             }
             .background(colorScheme == .dark ? Color.black : Color.white)
         }
-        .ignoresSafeArea(.keyboard)
     }
     
     func contentTimelineView(filter: (@escaping (NostrEvent) -> Bool)) -> some View {
@@ -188,8 +187,8 @@ struct ContentView: View {
                     Text("", comment: "Toolbar label for unknown views. This label would be displayed only if a new timeline view is added but a toolbar label was not explicitly assigned to it yet.")
                 }
             }
-             
         }
+        .ignoresSafeArea(.keyboard)
     }
     
     var MaybeSearchView: some View {


### PR DESCRIPTION
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/19398259/212811563-8f423008-57f7-4687-866e-6c938845b3f4.mov) | ![](https://user-images.githubusercontent.com/19398259/212811592-3d4ab672-7991-4199-8d58-6b0d7c16563a.mov)




