### PR TITLE
Add new recommended relay

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -17,6 +17,7 @@ var BOOTSTRAP_RELAYS = [
     "wss://nostr.oxtr.dev",
     "wss://nostr.v0l.io",
     "wss://brb.io",
+    "wss://global.relay.red",
 ]
 
 struct TimestampedProfile {


### PR DESCRIPTION
Add wss://global.relay.red as recommended relay. Strong machine in data center with fast up/down-link. 

Nostream relay v1.17.2

All stats of the relay publicly available here: https://stats.relay.red/public-dashboards/28db4cb6c9004703bf804988aacfdb1a?orgId=1&refresh=5s

