### PR TITLE
Removing Participants on a Thread Reply

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		E990020F2955F837003BBC5A /* EditMetadataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E990020E2955F837003BBC5A /* EditMetadataView.swift */; };
 		E9E4ED0B295867B900DD7078 /* ThreadV2View.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E4ED0A295867B900DD7078 /* ThreadV2View.swift */; };
 		F7F0BA25297892BD009531F3 /* SwipeToDismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F0BA24297892BD009531F3 /* SwipeToDismiss.swift */; };
+		F7F0BA272978E54D009531F3 /* ParicipantsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F0BA262978E54D009531F3 /* ParicipantsView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -368,6 +369,7 @@
 		E990020E2955F837003BBC5A /* EditMetadataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMetadataView.swift; sourceTree = "<group>"; };
 		E9E4ED0A295867B900DD7078 /* ThreadV2View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadV2View.swift; sourceTree = "<group>"; };
 		F7F0BA24297892BD009531F3 /* SwipeToDismiss.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeToDismiss.swift; sourceTree = "<group>"; };
+		F7F0BA262978E54D009531F3 /* ParicipantsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParicipantsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -538,6 +540,7 @@
 				4C06670028FC7C5900038D2A /* RelayView.swift */,
 				4C0A3F94280F6C78000448DE /* ReplyQuoteView.swift */,
 				4CACA9D4280C31E100D9BBE8 /* ReplyView.swift */,
+				F7F0BA262978E54D009531F3 /* ParicipantsView.swift */,
 				4C285C8D28399BFD008A31F1 /* SaveKeysView.swift */,
 				4C3AC7A628369BA200E1F516 /* SearchHomeView.swift */,
 				4C5C7E69284EDE2E00A22DF5 /* SearchResultsView.swift */,
@@ -900,6 +903,7 @@
 				4C0A3F8C280F5FCA000448DE /* ChatroomView.swift in Sources */,
 				4C477C9E282C3A4800033AA3 /* TipCounter.swift in Sources */,
 				647D9A8D2968520300A295DE /* SideMenuView.swift in Sources */,
+				F7F0BA272978E54D009531F3 /* ParicipantsView.swift in Sources */,
 				4C0A3F91280F6528000448DE /* ChatView.swift in Sources */,
 				4C216F362870A9A700040376 /* InputDismissKeyboard.swift in Sources */,
 				4C216F382871EDE300040376 /* DirectMessageModel.swift in Sources */,

--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -789,3 +789,21 @@ func inner_event_or_self(ev: NostrEvent) -> NostrEvent {
     
     return inner_ev
 }
+
+extension [ReferencedId] {
+    var pRefs: [ReferencedId] {
+        get {
+            self.filter { ref in
+                ref.key == "p"
+            }
+        }
+    }
+    
+    var eRefs: [ReferencedId] {
+        get {
+            self.filter { ref in
+                ref.key == "e"
+            }
+        }
+    }
+}

--- a/damus/Views/ParicipantsView.swift
+++ b/damus/Views/ParicipantsView.swift
@@ -11,66 +11,50 @@ struct ParticipantsView: View {
     
     let damus: DamusState
     
-    @Binding var participants: [ReferencedId]
-    @Binding var originalParticipants: [ReferencedId]
+    @Binding var references: [ReferencedId]
+    @Binding var originalReferences: [ReferencedId]
     
     var body: some View {
         VStack {
             Text("Edit participants")
             HStack {
                 Button {
-                    participants = []
+                    // Remove all "p" refs, keep "e" refs
+                    references = originalReferences.eRefs
                 } label: {
                     Text("Remove all")
                 }
                 Button {
-                    participants = originalParticipants
+                    references = originalReferences
                 } label: {
                     Text("Add all")
                 }
             }
-            ForEach(originalParticipants) { participant in
+            ForEach(originalReferences.pRefs) { participant in
                 HStack {
                     let pk = participant.ref_id
                     let prof = damus.profiles.lookup(id: pk)
                     Text(Profile.displayName(profile: prof, pubkey: pk))
                     Spacer()
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(participants.contains(participant) ? .purple : .gray)
+                        .foregroundColor(references.contains(participant) ? .purple : .gray)
                 }
                 .onTapGesture {
-                    if participants.contains(participant) {
-                        participants = participants.filter {
+                    if references.contains(participant) {
+                        references = references.filter {
                             $0 != participant
                         }
                     } else {
-                        participants.append(participant)
+                        if references.contains(participant) {
+                            // Don't add it twice
+                        } else {
+                            references.append(participant)                            
+                        }
                     }
                 }
             }
             Spacer()
         }
         .padding()
-    }
-}
-
-struct ParticipantView: View {
-    let damus: DamusState
-    let participant: ReferencedId
-    
-    @State var isParticipating: Bool = true
-    
-    var body: some View {
-        HStack {
-            let pk = participant.ref_id
-            let prof = damus.profiles.lookup(id: pk)
-            Text(Profile.displayName(profile: prof, pubkey: pk))
-            Spacer()
-            Image(systemName: "checkmark.circle.fill")
-                .foregroundColor(isParticipating ? .purple : .gray)
-        }
-        .onTapGesture {
-            isParticipating.toggle()
-        }
     }
 }

--- a/damus/Views/ParicipantsView.swift
+++ b/damus/Views/ParicipantsView.swift
@@ -16,23 +16,47 @@ struct ParticipantsView: View {
     
     var body: some View {
         VStack {
+            Text("Edit participants")
+            HStack {
+                Button {
+                    participants = []
+                } label: {
+                    Text("Remove all")
+                }
+                Button {
+                    participants = originalParticipants
+                } label: {
+                    Text("Add all")
+                }
+            }
             ForEach(originalParticipants) { participant in
-                ParticipantView(damus: damus, participant: participant) { participant, added in
-                    if added {
-                        participants.append(participant)
+                HStack {
+                    let pk = participant.ref_id
+                    let prof = damus.profiles.lookup(id: pk)
+                    Text(Profile.displayName(profile: prof, pubkey: pk))
+                    Spacer()
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(participants.contains(participant) ? .purple : .gray)
+                }
+                .onTapGesture {
+                    if participants.contains(participant) {
+                        participants = participants.filter {
+                            $0 != participant
+                        }
                     } else {
-                        participants = participants.filter { $0 != participant }
+                        participants.append(participant)
                     }
                 }
             }
+            Spacer()
         }
+        .padding()
     }
 }
 
 struct ParticipantView: View {
     let damus: DamusState
     let participant: ReferencedId
-    let onRemove: (ReferencedId, Bool) -> ()
     
     @State var isParticipating: Bool = true
     
@@ -47,7 +71,6 @@ struct ParticipantView: View {
         }
         .onTapGesture {
             isParticipating.toggle()
-            onRemove(participant, isParticipating)
         }
     }
 }

--- a/damus/Views/ParicipantsView.swift
+++ b/damus/Views/ParicipantsView.swift
@@ -1,0 +1,53 @@
+//
+//  ParicipantsView.swift
+//  damus
+//
+//  Created by Joel Klabo on 1/18/23.
+//
+
+import SwiftUI
+
+struct ParticipantsView: View {
+    
+    let damus: DamusState
+    
+    @Binding var participants: [ReferencedId]
+    @Binding var originalParticipants: [ReferencedId]
+    
+    var body: some View {
+        VStack {
+            ForEach(originalParticipants) { participant in
+                ParticipantView(damus: damus, participant: participant) { participant, added in
+                    if added {
+                        participants.append(participant)
+                    } else {
+                        participants = participants.filter { $0 != participant }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct ParticipantView: View {
+    let damus: DamusState
+    let participant: ReferencedId
+    let onRemove: (ReferencedId, Bool) -> ()
+    
+    @State var isParticipating: Bool = true
+    
+    var body: some View {
+        HStack {
+            let pk = participant.ref_id
+            let prof = damus.profiles.lookup(id: pk)
+            Text(Profile.displayName(profile: prof, pubkey: pk))
+            Spacer()
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(isParticipating ? .purple : .gray)
+        }
+        .onTapGesture {
+            isParticipating.toggle()
+            onRemove(participant, isParticipating)
+        }
+    }
+}

--- a/damus/Views/ParicipantsView.swift
+++ b/damus/Views/ParicipantsView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ParticipantsView: View {
     
-    let damus: DamusState
+    let damus_state: DamusState
     
     @Binding var references: [ReferencedId]
     @Binding var originalReferences: [ReferencedId]
@@ -31,12 +31,24 @@ struct ParticipantsView: View {
                 }
             }
             ForEach(originalReferences.pRefs) { participant in
+                let pubkey = participant.id
                 HStack {
-                    let pk = participant.ref_id
-                    let prof = damus.profiles.lookup(id: pk)
-                    Text(Profile.displayName(profile: prof, pubkey: pk))
+                    ProfilePicView(pubkey: pubkey, size: PFP_SIZE, highlight: .none, profiles: damus_state.profiles)
+                    
+                    VStack(alignment: .leading) {
+                        let profile = damus_state.profiles.lookup(id: pubkey)
+                        ProfileName(pubkey: pubkey, profile: profile, damus: damus_state, show_friend_confirmed: false, show_nip5_domain: false)
+                        if let about = profile?.about {
+                            Text(FollowUserView.markdown.process(about))
+                                .lineLimit(3)
+                                .font(.footnote)
+                        }
+                    }
+                    
                     Spacer()
+                    
                     Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 30))
                         .foregroundColor(references.contains(participant) ? .purple : .gray)
                 }
                 .onTapGesture {

--- a/damus/Views/ParicipantsView.swift
+++ b/damus/Views/ParicipantsView.swift
@@ -18,17 +18,22 @@ struct ParticipantsView: View {
         VStack {
             Text("Edit participants")
             HStack {
+                Spacer()
                 Button {
                     // Remove all "p" refs, keep "e" refs
                     references = originalReferences.eRefs
                 } label: {
                     Text("Remove all")
                 }
+                .buttonStyle(.borderedProminent)
+                Spacer()
                 Button {
                     references = originalReferences
                 } label: {
                     Text("Add all")
                 }
+                .buttonStyle(.borderedProminent)
+                Spacer()
             }
             ForEach(originalReferences.pRefs) { participant in
                 let pubkey = participant.id

--- a/damus/Views/ParicipantsView.swift
+++ b/damus/Views/ParicipantsView.swift
@@ -35,40 +35,42 @@ struct ParticipantsView: View {
                 .buttonStyle(.borderedProminent)
                 Spacer()
             }
-            ForEach(originalReferences.pRefs) { participant in
-                let pubkey = participant.id
-                HStack {
-                    ProfilePicView(pubkey: pubkey, size: PFP_SIZE, highlight: .none, profiles: damus_state.profiles)
-                    
-                    VStack(alignment: .leading) {
-                        let profile = damus_state.profiles.lookup(id: pubkey)
-                        ProfileName(pubkey: pubkey, profile: profile, damus: damus_state, show_friend_confirmed: false, show_nip5_domain: false)
-                        if let about = profile?.about {
-                            Text(FollowUserView.markdown.process(about))
-                                .lineLimit(3)
-                                .font(.footnote)
+            VStack {
+                ForEach(originalReferences.pRefs) { participant in
+                    let pubkey = participant.id
+                    HStack {
+                        ProfilePicView(pubkey: pubkey, size: PFP_SIZE, highlight: .none, profiles: damus_state.profiles)
+                        
+                        VStack(alignment: .leading) {
+                            let profile = damus_state.profiles.lookup(id: pubkey)
+                            ProfileName(pubkey: pubkey, profile: profile, damus: damus_state, show_friend_confirmed: false, show_nip5_domain: false)
+                            if let about = profile?.about {
+                                Text(FollowUserView.markdown.process(about))
+                                    .lineLimit(3)
+                                    .font(.footnote)
+                            }
                         }
+                        
+                        Spacer()
+                        
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 30))
+                            .foregroundColor(references.contains(participant) ? .purple : .gray)
                     }
-                    
-                    Spacer()
-                    
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 30))
-                        .foregroundColor(references.contains(participant) ? .purple : .gray)
-                }
-                .onTapGesture {
-                    if references.contains(participant) {
-                        references = references.filter {
-                            $0 != participant
-                        }
-                    } else {
+                    .onTapGesture {
                         if references.contains(participant) {
-                            // Don't add it twice
+                            references = references.filter {
+                                $0 != participant
+                            }
                         } else {
-                            references.append(participant)                            
+                            if references.contains(participant) {
+                                // Don't add it twice
+                            } else {
+                                references.append(participant)
+                            }
                         }
                     }
-                }
+                }                
             }
             Spacer()
         }

--- a/damus/Views/ReplyView.swift
+++ b/damus/Views/ReplyView.swift
@@ -18,11 +18,14 @@ struct ReplyView: View {
     let replying_to: NostrEvent
     let damus: DamusState
     
+    @State var originalParticipants: [ReferencedId] = []
+    @State var participants: [ReferencedId] = []
+        
     var body: some View {
         VStack {
             Text("Replying to:", comment: "Indicating that the user is replying to the following listed people.")
             HStack(alignment: .top) {
-                let names = all_referenced_pubkeys(replying_to)
+                let names = participants
                     .map { pubkey in
                         let pk = pubkey.ref_id
                         let prof = damus.profiles.lookup(id: pk)
@@ -34,12 +37,16 @@ struct ReplyView: View {
                     .font(.footnote)
             }
             ScrollView {
-                EventView(event: replying_to, highlight: .none, has_action_bar: false, damus: damus, show_friend_icon: true)                
+                EventView(event: replying_to, highlight: .none, has_action_bar: false, damus: damus, show_friend_icon: true)
+                ParticipantsView(damus: damus, participants: $participants, originalParticipants: $originalParticipants)
             }
-            PostView(replying_to: replying_to, references: gather_reply_ids(our_pubkey: damus.pubkey, from: replying_to))
+            PostView(replying_to: replying_to, references: participants)
+        }
+        .onAppear {
+            participants = all_referenced_pubkeys(replying_to)
+            originalParticipants = participants
         }
         .padding()
-        
     }
     
     
@@ -47,6 +54,6 @@ struct ReplyView: View {
 
 struct ReplyView_Previews: PreviewProvider {
     static var previews: some View {
-        ReplyView(replying_to: NostrEvent(content: "hi", pubkey: "pubkey"), damus: test_damus_state())
+        ReplyView(replying_to: NostrEvent(content: "hi", pubkey: "pubkey"), damus: test_damus_state(), participants: [])
     }
 }

--- a/damus/Views/ReplyView.swift
+++ b/damus/Views/ReplyView.swift
@@ -18,8 +18,8 @@ struct ReplyView: View {
     let replying_to: NostrEvent
     let damus: DamusState
     
-    @State var originalParticipants: [ReferencedId] = []
-    @State var participants: [ReferencedId] = []
+    @State var originalReferences: [ReferencedId] = []
+    @State var references: [ReferencedId] = []
     
     @State var participantsShown: Bool = false
         
@@ -27,7 +27,7 @@ struct ReplyView: View {
         VStack {
             Text("Replying to:", comment: "Indicating that the user is replying to the following listed people.")
             HStack(alignment: .top) {
-                let names = participants
+                let names = references.pRefs
                     .map { pubkey in
                         let pk = pubkey.ref_id
                         let prof = damus.profiles.lookup(id: pk)
@@ -42,16 +42,16 @@ struct ReplyView: View {
                 participantsShown.toggle()
             }
             .sheet(isPresented: $participantsShown) {
-                ParticipantsView(damus: damus, participants: $participants, originalParticipants: $originalParticipants)
+                ParticipantsView(damus: damus, references: $references, originalReferences: $originalReferences)
             }
             ScrollView {
                 EventView(event: replying_to, highlight: .none, has_action_bar: false, damus: damus, show_friend_icon: true)
             }
-            PostView(replying_to: replying_to, references: participants)
+            PostView(replying_to: replying_to, references: references)
         }
         .onAppear {
-            participants = all_referenced_pubkeys(replying_to)
-            originalParticipants = participants
+            references =  gather_reply_ids(our_pubkey: damus.pubkey, from: replying_to)
+            originalReferences = references
         }
         .padding()
     }
@@ -61,6 +61,6 @@ struct ReplyView: View {
 
 struct ReplyView_Previews: PreviewProvider {
     static var previews: some View {
-        ReplyView(replying_to: NostrEvent(content: "hi", pubkey: "pubkey"), damus: test_damus_state(), participants: [])
+        ReplyView(replying_to: NostrEvent(content: "hi", pubkey: "pubkey"), damus: test_damus_state(), references: [])
     }
 }

--- a/damus/Views/ReplyView.swift
+++ b/damus/Views/ReplyView.swift
@@ -20,6 +20,8 @@ struct ReplyView: View {
     
     @State var originalParticipants: [ReferencedId] = []
     @State var participants: [ReferencedId] = []
+    
+    @State var participantsShown: Bool = false
         
     var body: some View {
         VStack {
@@ -36,9 +38,14 @@ struct ReplyView: View {
                     .foregroundColor(.gray)
                     .font(.footnote)
             }
+            .onTapGesture {
+                participantsShown.toggle()
+            }
+            .sheet(isPresented: $participantsShown) {
+                ParticipantsView(damus: damus, participants: $participants, originalParticipants: $originalParticipants)
+            }
             ScrollView {
                 EventView(event: replying_to, highlight: .none, has_action_bar: false, damus: damus, show_friend_icon: true)
-                ParticipantsView(damus: damus, participants: $participants, originalParticipants: $originalParticipants)
             }
             PostView(replying_to: replying_to, references: participants)
         }

--- a/damus/Views/ReplyView.swift
+++ b/damus/Views/ReplyView.swift
@@ -42,7 +42,7 @@ struct ReplyView: View {
                 participantsShown.toggle()
             }
             .sheet(isPresented: $participantsShown) {
-                ParticipantsView(damus: damus, references: $references, originalReferences: $originalReferences)
+                ParticipantsView(damus_state: damus, references: $references, originalReferences: $originalReferences)
             }
             ScrollView {
                 EventView(event: replying_to, highlight: .none, has_action_bar: false, damus: damus, show_friend_icon: true)


### PR DESCRIPTION
Add a participants view to choose who not to notify on a post.

The screen is launched by tapping the replied to names at the top.

**Updated:**
![Simulator Screen Recording - iPhone 14 - 2023-01-19 at 16 23 41](https://user-images.githubusercontent.com/264977/213591259-70e21cb5-cef0-4a2c-8146-e1aa304b47c5.gif)


**Behavior when all participants are removed, not positive this is right:** (the "Really cool!" note had all participants removed)
<img width="400" alt="image" src="https://user-images.githubusercontent.com/264977/213590304-0bb784ee-efe0-4a1f-ae0d-6e2d41837934.png">