### PR TITLE
Update Unit Test Script

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,4 +14,4 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v1
     - name: Running Tests
-      run: xcodebuild test -scheme damus -project damus.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.0' | xcpretty && exit ${PIPESTATUS[0]}
+      run: xcodebuild test -scheme damus -project damus.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2' | xcpretty && exit ${PIPESTATUS[0]}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,4 +14,4 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v1
     - name: Running Tests
-      run: xcodebuild test -scheme damus -project damus.xcodeproj -destination 'platform=iOS Simulator,name=Any iOS Device,OS=16.2' | xcpretty && exit ${PIPESTATUS[0]}
+      run: xcodebuild test -scheme damus -project damus.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2' | xcpretty && exit ${PIPESTATUS[0]}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,4 +14,4 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v1
     - name: Running Tests
-      run: xcodebuild test -scheme damus -project damus.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2'
+      run: xcodebuild test -scheme damus -project damus.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.0'

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,4 +14,4 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v1
     - name: Running Tests
-      run: xcodebuild test -scheme damus -project damus.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2' | xcpretty && exit ${PIPESTATUS[0]}
+      run: xcodebuild test -scheme damus -project damus.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2'

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,4 +14,4 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v1
     - name: Running Tests
-      run: xcodebuild test -scheme damus -project damus.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 14,OS=16.2' | xcpretty && exit ${PIPESTATUS[0]}
+      run: xcodebuild test -scheme damus -project damus.xcodeproj -destination 'platform=iOS Simulator,name=Any iOS Device,OS=16.2' | xcpretty && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
We've been testing with iOS 16.0 and it looks like they updated their simulators and now we need to use 16.2