### PR TITLE
Use ImageView for Profile Pictures

### DIFF
--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -212,7 +212,10 @@ struct ProfileView: View {
                             is_zoomed.toggle()
                         }
                         .fullScreenCover(isPresented: $is_zoomed) {
-                            ProfileZoomView(pubkey: profile.pubkey, profiles: damus_state.profiles)                        }
+                            let pictureURLString = damus_state.profiles.lookup(id: profile.pubkey)?.picture
+                            let url = get_profile_url(picture: pictureURLString, pubkey: profile.pubkey, profiles: damus_state.profiles)
+                            ImageView(urls: [url])
+                        }
                         .offset(y: -(pfp_size/2.0)) // Increase if set a frame
                     
                     Spacer()


### PR DESCRIPTION
Should we just be consistent and use `ImageView` for profile pictures? @scoder1747 

![Simulator Screen Recording - iPhone 14 - 2023-01-20 at 15 12 30](https://user-images.githubusercontent.com/264977/213821538-d44b64c7-5173-4899-bbd9-d3f25fbf0dc1.gif)
