### PR TITLE
fix for seeing 2 "add post" buttons when swiping

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -93,15 +93,23 @@ struct ContentView: View {
 
     var PostingTimelineView: some View {
         VStack {
-            TabView(selection: $filter_state) {
-                contentTimelineView(filter: FilterState.posts.filter)
-                    .tag(FilterState.posts)
-                    .id(FilterState.posts)
-                contentTimelineView(filter: FilterState.posts_and_replies.filter)
-                    .tag(FilterState.posts_and_replies)
-                    .id(FilterState.posts_and_replies)
+            ZStack {
+                TabView(selection: $filter_state) {
+                    contentTimelineView(filter: FilterState.posts.filter)
+                        .tag(FilterState.posts)
+                        .id(FilterState.posts)
+                    contentTimelineView(filter: FilterState.posts_and_replies.filter)
+                        .tag(FilterState.posts_and_replies)
+                        .id(FilterState.posts_and_replies)
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                
+                if privkey != nil {
+                    PostButtonContainer(userSettings: user_settings) {
+                        self.active_sheet = .post
+                    }
+                }
             }
-            .tabViewStyle(.page(indexDisplayMode: .never))
         }
         .safeAreaInset(edge: .top, spacing: 0) {
             VStack(spacing: 0) {
@@ -119,11 +127,6 @@ struct ContentView: View {
         ZStack {
             if let damus = self.damus_state {
                 TimelineView(events: $home.events, loading: $home.loading, damus: damus, show_friend_icon: false, filter: filter)
-            }
-            if privkey != nil {
-                PostButtonContainer(userSettings: user_settings) {
-                    self.active_sheet = .post
-                }
             }
         }
     }

--- a/damusTests/DMTests.swift
+++ b/damusTests/DMTests.swift
@@ -50,7 +50,8 @@ final class DMTests: XCTestCase {
     
     func testDMSortOrder() throws {
         let notif = NewEventsBits()
-        let model = DirectMessagesModel()
+        let pubkey = "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"
+        let model = DirectMessagesModel(our_pubkey: pubkey)
         
         let now = Int64(Date().timeIntervalSince1970)
         


### PR DESCRIPTION
#### Note `this PR also fixes a broken test`
move the postButtonContainer view to avoid having 2 buttons on screen when swiping tabs

Before 

https://user-images.githubusercontent.com/1885323/213920452-439e91c1-b78e-4b5b-a1e9-dfe22f911ee1.mov

After

https://user-images.githubusercontent.com/1885323/213920461-199dbcc3-a62e-4528-8413-9e0127b7ffee.mov


