### PR TITLE
Make text in logout warning a NSLocalized string

### DIFF
--- a/damus/Views/SideMenuView.swift
+++ b/damus/Views/SideMenuView.swift
@@ -165,7 +165,7 @@ struct SideMenuView: View {
                     notify(.logout, ())
                 }
             } message: {
-                Text("Make sure your nsec account key is saved before you logout or you will lose access to this account", comment: "Reminder message in alert to get customer to verify that their private security account key is saved saved before logging out.")
+                Text(NSLocalizedString("Make sure your nsec account key is saved before you logout or you will lose access to this account", comment: "Reminder message in alert to get customer to verify that their private security account key is saved saved before logging out."))
             }
 
             Spacer()


### PR DESCRIPTION
The text in an alert about saving your private key before logging out was plain text and not a localized string.