### PR TITLE
Bump pfp/banner animated fize size limit to 5MiB/20MiB

### DIFF
--- a/damus/Views/BannerImageView.swift
+++ b/damus/Views/BannerImageView.swift
@@ -18,7 +18,7 @@ struct InnerBannerImageView: View {
         self.imageModel = KFImageModel(
             url: url,
             fallbackUrl: nil,
-            maxByteSize: 5000000,
+            maxByteSize: 20_971_520, // 20 MiB
             downsampleSize: CGSize(width: 750, height: 250)
         )
     }

--- a/damus/Views/ProfilePicView.swift
+++ b/damus/Views/ProfilePicView.swift
@@ -46,7 +46,7 @@ struct InnerProfilePicView: View {
         self.imageModel = KFImageModel(
             url: url,
             fallbackUrl: fallbackUrl,
-            maxByteSize: 1000000,
+            maxByteSize: 5_242_880, // 5Mib
             downsampleSize: CGSize(width: 200, height: 200)
         )
     }


### PR DESCRIPTION
Since users are unhappy.

cc @OlegAba 

Changelog-Changed: Bump pfp/banner animated fize size limit to 5MiB/20MiB