### PR TITLE
Added In before component - displays when a user first created an event

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		4CEE2AF9280B2EAC00AB5EEF /* PowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEE2AF8280B2EAC00AB5EEF /* PowView.swift */; };
 		4CEE2B02280B39E800AB5EEF /* EventActionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEE2B01280B39E800AB5EEF /* EventActionBar.swift */; };
 		4FE60CDD295E1C5E00105A1F /* Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE60CDC295E1C5E00105A1F /* Wallet.swift */; };
+		5C513FBE2980E0750072348F /* InBefore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C513FBD2980E0750072348F /* InBefore.swift */; };
 		6439E014296790CF0020672B /* ProfileZoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6439E013296790CF0020672B /* ProfileZoomView.swift */; };
 		647D9A8D2968520300A295DE /* SideMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647D9A8C2968520300A295DE /* SideMenuView.swift */; };
 		64FBD06F296255C400D9D3B2 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FBD06E296255C400D9D3B2 /* Theme.swift */; };
@@ -386,6 +387,7 @@
 		4CEE2AF8280B2EAC00AB5EEF /* PowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowView.swift; sourceTree = "<group>"; };
 		4CEE2B01280B39E800AB5EEF /* EventActionBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventActionBar.swift; sourceTree = "<group>"; };
 		4FE60CDC295E1C5E00105A1F /* Wallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallet.swift; sourceTree = "<group>"; };
+		5C513FBD2980E0750072348F /* InBefore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InBefore.swift; sourceTree = "<group>"; };
 		6439E013296790CF0020672B /* ProfileZoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileZoomView.swift; sourceTree = "<group>"; };
 		647D9A8C2968520300A295DE /* SideMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuView.swift; sourceTree = "<group>"; };
 		64FBD06E296255C400D9D3B2 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
@@ -672,6 +674,7 @@
 				4CB8838C296F710400DC99E7 /* Reposted.swift */,
 				4CBCA92F297DB57F00EC6B2F /* WebsiteLink.swift */,
 				4CC7AAEC297F0B9E00430951 /* Highlight.swift */,
+				5C513FBD2980E0750072348F /* InBefore.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -947,6 +950,7 @@
 				4C75EFB92804A2740006080F /* EventView.swift in Sources */,
 				4C7FF7D52823313F009601DB /* Mentions.swift in Sources */,
 				4C633350283D40E500B1C9C3 /* HomeModel.swift in Sources */,
+				5C513FBE2980E0750072348F /* InBefore.swift in Sources */,
 				4C987B57283FD07F0042CE38 /* FollowersModel.swift in Sources */,
 				4C363A9028247A1D006E126D /* NostrLink.swift in Sources */,
 				4C0A3F8C280F5FCA000448DE /* ChatroomView.swift in Sources */,

--- a/damus/Components/InBefore.swift
+++ b/damus/Components/InBefore.swift
@@ -1,0 +1,41 @@
+//
+//  InBefore.swift
+//  damus
+//
+//  Created by eric on 1/24/23.
+//
+
+import SwiftUI
+
+struct InBefore: View {
+    @Binding var events: [NostrEvent]
+
+    var body: some View {
+        HStack {
+            Image(systemName: "calendar")
+                .foregroundColor(.gray)
+                .font(.footnote)
+            
+            Text(in_before_text(events: events))
+                    .font(.footnote)
+                    .foregroundColor(.gray)
+        }
+    }
+    
+    func in_before_text(events: [NostrEvent]) -> String {
+        let dateFormatter = DateFormatter()
+        let currentDate = Int64(Date().timeIntervalSince1970)
+        let oldestEvent = Date(timeIntervalSince1970: TimeInterval(events.last?.created_at ?? currentDate))
+        dateFormatter.dateFormat = "LLLL"
+        let monthString = dateFormatter.string(from: oldestEvent)
+        dateFormatter.dateFormat = "yyyy"
+        let yearString = dateFormatter.string(from: oldestEvent)
+        return "In before \(monthString) \(yearString)"
+    }
+}
+
+struct InBefore_Previews: PreviewProvider {
+    static var previews: some View {
+        InBefore(events: .constant(Constants.EXAMPLE_EVENTS))
+    }
+}

--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -284,6 +284,8 @@ struct ProfileView: View {
                     WebsiteLink(url: url)
                 }
                 
+                InBefore(events: $profile.events)
+                
                 Divider()
                 
                 HStack {


### PR DESCRIPTION
This PR adds the "In before" component to the ProfileView. It is displaying the month and year of the user's first event, since there is no real way of knowing when a user joined nostr. The name "In before" is technically accurate since the user joined before that event and also has been widely posted on nostr as a meme at this point.

<img src="https://user-images.githubusercontent.com/14004132/214477521-dce3b2a4-9cf2-499f-85bf-67f194ab5fd3.png" width="350">    <img src="https://user-images.githubusercontent.com/14004132/214477518-29e2eec4-b1a1-40d8-a645-8c1bb459e39d.png" width="350">   
