### PR TITLE
Remove wlvs.space relay, add eden.nostr.land

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -11,7 +11,7 @@ import Kingfisher
 
 var BOOTSTRAP_RELAYS = [
     "wss://relay.damus.io",
-    "wss://nostr-relay.wlvs.space",
+    "wss://eden.nostr.land",
     "wss://nostr.fmt.wiz.biz",
     "wss://relay.nostr.bg",
     "wss://nostr.oxtr.dev",


### PR DESCRIPTION
Phasing out nostr-relay.wlvs.space in favor of eden.nostr.land. Eden relay is load balanced by geographical proximity and can handle more clients.