### PR TITLE
Fix author attribution to the actual translators in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-- Added arabic and portugese translations (William Casarin)
+- Added Arabic and Portuguese translations (Barodane, Antonio Chagas)
 - Add QRCode view for sharing your pubkey (ericholguin)
 - Added nostr: uri handling (William Casarin)
 
@@ -29,7 +29,7 @@
 ### Added
 
 - Reposts view (Terry Yiu)
-- Translations for it_IT, it_CH, fr_FR, de_DE, de_AT and lv_LV (William Casarin)
+- Translations for it_IT, it_CH, fr_FR, de_DE, de_AT and lv_LV (Nicolò Carcagnì, Solobalbo, Gregor, Peter Gerstbach, SYX)
 - Added ability to block users (William Casarin)
 - Added a way to report content (William Casarin)
 - Stretchable profile cover header (Swift)
@@ -56,7 +56,7 @@
 
 - Show website on profiles (William Casarin)
 - Add the ability to choose participants when replying (Joel Klabo)
-- Translations for de_AT, de_DE, tr_TR, fr_FR (William Casarin)
+- Translations for de_AT, de_DE, tr_TR, fr_FR (Gregor, Peter Gerstbach, Taylan Benli, Solobalbo)
 - Add DM Message Requests (William Casarin)
 
 
@@ -76,7 +76,7 @@
 
 - Drastically improved image viewer (OlegAba)
 - Added pinch to zoom on images (Swift)
-- Add Latin American Spanish translations (William Casarin)
+- Add Latin American Spanish translations (Nicolás Valencia)
 - Added SVG profile picture support (OlegAba)
 
 


### PR DESCRIPTION
Transifex integration doesn't propagate this information to GitHub unfortunately.