### PR TITLE
Allow profile edit button text to scale down when translation is too long

### DIFF
--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -91,6 +91,7 @@ struct EditButton: View {
                     RoundedRectangle(cornerRadius: 24)
                         .stroke(borderColor(), lineWidth: 1)
                 }
+                .minimumScaleFactor(0.5)
         }
     }
     


### PR DESCRIPTION
Before:
![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-01-30 at 00 00 11](https://user-images.githubusercontent.com/963907/215391684-ca519032-d153-49fd-bea6-0105df11d54f.png)

After:
![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-01-30 at 00 00 36](https://user-images.githubusercontent.com/963907/215391695-500daaaa-373d-4250-a7f2-b4a2033a9571.png)
