### PR TITLE
Add universal link for Cash App lightning payments

### DIFF
--- a/damus/Info.plist
+++ b/damus/Info.plist
@@ -24,7 +24,6 @@
 		<string>zeusln</string>
 		<string>zebedee</string>
 		<string>lightning</string>
-		<string>squarecash</string>
 		<string>phoenix</string>
 		<string>lnlink</string>
 		<string>strike</string>

--- a/damus/Models/Wallet.swift
+++ b/damus/Models/Wallet.swift
@@ -45,7 +45,7 @@ enum Wallet: String, CaseIterable, Identifiable {
             return .init(index: 0, tag: "strike", displayName: NSLocalizedString("Strike", comment: "Dropdown option label for Lightning wallet, Strike."), link: "strike:",
                          appStoreLink: "https://apps.apple.com/us/app/strike-bitcoin-payments/id1488724463", image: "strike")
         case .cashapp:
-            return .init(index: 1, tag: "cashapp", displayName: NSLocalizedString("Cash App", comment: "Dropdown option label for Lightning wallet, Cash App."), link: "squarecash://",
+            return .init(index: 1, tag: "cashapp", displayName: NSLocalizedString("Cash App", comment: "Dropdown option label for Lightning wallet, Cash App."), link: "https://cash.app/launch/lightning/",
                          appStoreLink: "https://apps.apple.com/us/app/cash-app/id711923939", image: "cashapp")
         case .muun:
             return .init(index: 2, tag: "muun", displayName: NSLocalizedString("Muun", comment: "Dropdown option label for Lightning wallet, Muun."), link: "muun:", appStoreLink: "https://apps.apple.com/us/app/muun-wallet/id1482037683", image: "muun")


### PR DESCRIPTION
Lightning invoices can now be paid via universal link in Cash App. This updates the the wallet dropdown option so it will start the lightning payment process in Cash App.

(I work at Cash App)

https://user-images.githubusercontent.com/228954/215883490-b27041ec-3bdc-4501-94bc-b9d40305585d.mp4

