### PR TITLE
Add nostr-pub.semisol.dev as a bootstrap relay

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -17,6 +17,7 @@ var BOOTSTRAP_RELAYS = [
     "wss://nos.lol",
     "wss://relay.current.fyi",
     "wss://brb.io",
+    "wss://nostr-pub.semisol.dev",
 ]
 
 struct TimestampedProfile {


### PR DESCRIPTION
Performance is good from testing. Resources aren't being maxed out (yet.)

Hosted with Hetzner in the EU