### PR TITLE
Add nostr.lu.ke to bootstrap relays

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -17,6 +17,7 @@ var BOOTSTRAP_RELAYS = [
     "wss://nos.lol",
     "wss://relay.current.fyi",
     "wss://brb.io",
+    "wss://nostr.lu.ke",
 ]
 
 struct TimestampedProfile {


### PR DESCRIPTION
Is there any criteria that needs to be met to be added as a bootstrap relay?

FWIW I've run an Electrum server for years that is hardcoded into most Electrum wallets and serves thousands of concurrent users:

https://github.com/search?q=bitcoin.lu.ke&type=code
https://github.com/search?q=bitcoin.lukechilds.co&type=code

Nostr relay is running on the same beefy bare metal server, happy to serve the Nostr community 🤙