### PR TITLE
Fix text truncation in CarouselItemView

### DIFF
--- a/damus/Views/CarouselView.swift
+++ b/damus/Views/CarouselView.swift
@@ -55,6 +55,7 @@ struct CarouselItemView: View {
                 .font(.title2)
                 .foregroundColor(Color.white)
                 .padding([.leading,.trailing], 50.0)
+                .minimumScaleFactor(0.5)
         }
     }
 }


### PR DESCRIPTION
Text in CarouselItemView would be truncated in small screen devices, eg. iPhone SE. 
This PR sets `minimumScaleFactor` to  fit text into available space, following UI style in [ProfileView/EditButton](https://github.com/damus-io/damus/blob/e40cc9a50a06ac9cecf7cecbd96ef5790b4d76e6/damus/Views/ProfileView.swift#L94). 

Before             |  After
:-------------------------:|:-------------------------:
![Before](https://user-images.githubusercontent.com/2510864/216230021-87f8dda5-40c9-4018-b9f7-cb466f9c8187.png)  |  ![After](https://user-images.githubusercontent.com/2510864/216230042-f4c9f9b6-0108-4e5c-aa1c-46bf6ae40ffa.png)
