### PR TITLE
Add Valera relays to bootstrap list

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -17,6 +17,7 @@ var BOOTSTRAP_RELAYS = [
     "wss://nos.lol",
     "wss://relay.current.fyi",
     "wss://brb.io",
+    "wss://relay.valera.co"
 ]
 
 struct TimestampedProfile {


### PR DESCRIPTION
Following up on #471, here is Valera's relay network. These are anycasted on our server infrastructure, and run [nostr-rs-relay](https://git.sr.ht/~gheartsfield/nostr-rs-relay).