### PR TITLE
Allow copying text in bio

### DIFF
--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -298,7 +298,7 @@ struct ProfileView: View {
                     .padding(.top,-(pfp_size/2.0))
                 
                 Text(ProfileView.markdown.process(data?.about ?? ""))
-                    .font(.subheadline)
+                    .font(.subheadline).textSelection(.enabled)
                 
                 if let url = data?.website_url {
                     WebsiteLink(url: url)


### PR DESCRIPTION
It's often useful to be able to copy text from a person's bio such as pubkeys of other accounts.

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-02 at 14 19 09](https://user-images.githubusercontent.com/43693074/216462372-d0c3a451-6f50-4492-8f8f-e9937a1bed23.png)
