### PR TITLE
Fix profile edit button text to not wrap

### DIFF
--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -92,6 +92,7 @@ struct EditButton: View {
                         .stroke(borderColor(), lineWidth: 1)
                 }
                 .minimumScaleFactor(0.5)
+                .lineLimit(1)
         }
     }
     


### PR DESCRIPTION
Occurs when accessibility text settings for font size are set to the smallest.

Before:
![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-03 at 00 02 18](https://user-images.githubusercontent.com/963907/216516573-7e44da3e-236c-44ed-91f5-34ed276d44a7.png)

After:
![Simulator Screen Shot - iPhone SE (3rd generation) - 2023-02-03 at 00 01 39](https://user-images.githubusercontent.com/963907/216516519-fbf840e5-9a65-438f-b43a-76e6d12c24b9.png)
