### PR TITLE
Fix pluralization of Zaps

### DIFF
--- a/damus/Views/ActionBar/EventDetailBar.swift
+++ b/damus/Views/ActionBar/EventDetailBar.swift
@@ -29,7 +29,7 @@ struct EventDetailBar: View {
             }
             
             if bar.zaps > 0 {
-                Text("\(Text("\(bar.zaps)", comment: "Number of zap payments on a post.").font(.body.bold())) \(Text(String(format: NSLocalizedString("Zaps", comment: "Part of a larger sentence to describe how many zap payments there are on a post."), bar.boosts)).foregroundColor(.gray))", comment: "Sentence composed of 2 variables to describe how many zap payments there are on a post. In source English, the first variable is the number of zap payments, and the second variable is 'Zap' or 'Zaps'.")
+                Text("\(Text("\(bar.zaps)", comment: "Number of zap payments on a post.").font(.body.bold())) \(Text(String(format: NSLocalizedString("zaps_count", comment: "Part of a larger sentence to describe how many zap payments there are on a post."), bar.boosts)).foregroundColor(.gray))", comment: "Sentence composed of 2 variables to describe how many zap payments there are on a post. In source English, the first variable is the number of zap payments, and the second variable is 'Zap' or 'Zaps'.")
             }
         }
     }


### PR DESCRIPTION
https://github.com/damus-io/damus/commit/9e2e8595e8b168d2e86e06a69216d41f53f3b10a#diff-548f04cd57f663aa1e8b4ddc8e21af44ea6ae1f2c360a0a82b8135aa5ca94fcfR32 broke pluralization of the word Zaps.

This change reverts it back to reading from `Localizable.stringsdict` for key `zaps_count`:
https://github.com/damus-io/damus/blob/7d3d23def33177dcf5ff14d753a972f410871dbe/damus/en-US.lproj/Localizable.stringsdict#L137