### PR TITLE
add accessibility labels to EventActionBar

### DIFF
--- a/damus/Components/ZapButton.swift
+++ b/damus/Components/ZapButton.swift
@@ -107,6 +107,7 @@ struct ZapButton: View {
                     send_zap()
                 }
             }
+            .accessibilityLabel(NSLocalizedString("Zap", comment: "Accessibility label for zap button"))
             
             Text("\(bar.zap_total > 0 ? "\(format_msats_abbrev(bar.zap_total))" : "")")
                 .offset(x: 22)

--- a/damus/Views/ActionBar/EventActionBar.swift
+++ b/damus/Views/ActionBar/EventActionBar.swift
@@ -47,6 +47,7 @@ struct EventActionBar: View {
                 EventActionButton(img: "bubble.left", col: nil) {
                     notify(.reply, event)
                 }
+                .accessibilityLabel(NSLocalizedString("Reply", comment: "Accessibility label for reply button"))
             }
             Spacer()
             ZStack {
@@ -58,6 +59,7 @@ struct EventActionBar: View {
                         self.confirm_boost = true
                     }
                 }
+                .accessibilityLabel(NSLocalizedString("Boosts", comment: "Accessibility label for boosts button"))
                 Text("\(bar.boosts > 0 ? "\(bar.boosts)" : "")")
                     .offset(x: 18)
                     .font(.footnote.weight(.medium))
@@ -89,6 +91,7 @@ struct EventActionBar: View {
             EventActionButton(img: "square.and.arrow.up", col: Color.gray) {
                 show_share_sheet = true
             }
+            .accessibilityLabel(NSLocalizedString("Share", comment: "Button to share a post"))
         }
         .sheet(isPresented: $show_share_sheet) {
             if let note_id = bech32_note_id(event.id) {
@@ -166,6 +169,7 @@ struct LikeButton: View {
             Image(liked ? "shaka-full" : "shaka-line")
                 .foregroundColor(liked ? .accentColor : .gray)
         }
+        .accessibilityLabel(NSLocalizedString("Like", comment: "Accessibility Label for Like button"))
     }
 }
 


### PR DESCRIPTION
Added the first few accessibility labels to Damus. These labels help iOS' VoiceOver to know how to communicate to vision-impaired users.

Prior to this change, in VoiceOver mode, the device would say "Button" for all of the buttons on the EventActionBar, except for the like button, which would say "shaka-line" (to a user who has no idea what that means). After this change, it will say "Share button", "Like button", etc.