### PR TITLE
Allow Tests to Be Run Manually

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -2,6 +2,7 @@ name: Run Test Suite
 run-name: Testing ${{ github.ref }} by @${{ github.actor }}
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "master"


### PR DESCRIPTION
This allows you to be able to re-run the tests by clicking a button. In case of a false failure of some kind. Otherwise you have to push a new change for them to run again.