### PR TITLE
Fix determine_is_request logic

### DIFF
--- a/damus/Models/DirectMessageModel.swift
+++ b/damus/Models/DirectMessageModel.swift
@@ -19,7 +19,7 @@ class DirectMessageModel: ObservableObject {
     
     func determine_is_request() -> Bool {
         for event in events {
-            if event.pubkey == our_pubkey {
+            if event.pubkey != our_pubkey {
                 return false
             }
         }


### PR DESCRIPTION
Based on description in [DirectMessagesView.swift](https://github.com/damus-io/damus/blob/0563ec8bf86585a7bc0246c25af1d1af0c992b52/damus/Views/DirectMessagesView.swift#L70): 

```
Text("DMs", comment: "Picker option for DM selector for seeing only DMs that have been responded to. DM is the English abbreviation for Direct Message.")
    .tag(DMType.friend)
Text("Requests", comment: "Picker option for DM selector for seeing only message requests (DMs that someone else sent the user which has not been responded to yet). DM is the English abbreviation for Direct Message.")
    .tag(DMType.rando)
```

The return value of `determine_is_request` should be: 
`true`: if all of the events(messages) are coming from the user(`our_pubkey`)
`false`: if one of the events is not coming from the user