### PR TITLE
Make autocompletion case insensitive

### DIFF
--- a/damus/Views/Posting/UserSearch.swift
+++ b/damus/Views/Posting/UserSearch.swift
@@ -77,7 +77,7 @@ func search_users(profiles: Profiles, tags: [[String]], search: String) -> [Sear
         
         let profile = profiles.lookup(id: pubkey)
         
-        guard ((petname?.hasPrefix(search) ?? false) || (profile?.name?.hasPrefix(search) ?? false)) else {
+        guard ((petname?.lowercased().hasPrefix(search.lowercased()) ?? false) || (profile?.name?.lowercased().hasPrefix(search.lowercased()) ?? false)) else {
             return
         }
         


### PR DESCRIPTION
This is my attempt at fixing #539.

**The problem:**

Before this commit, if I am trying to mention @bitkarrot on Nostr, autocompletion doesn't work because her name is capitalized on her Nostr profile.


**The solution**

After this commit, search strings and names are converted to lowercase when looking for matches so that typing "@bitkarrot" also suggests (capital B) "Bitkarrot"

**Behavior before:**

![IMG_3056](https://user-images.githubusercontent.com/597182/217469270-7ef75d0c-cebb-4061-b04f-22d37a24bf24.PNG)
![IMG_3057](https://user-images.githubusercontent.com/597182/217469290-b8369f2f-44db-4f8c-ac9a-50371ae8a7cb.PNG)

**Behavior after:**

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-08 at 15 55 41](https://user-images.githubusercontent.com/597182/217469393-1987b436-8c47-49ea-b7a5-bd9aa223df5f.png)
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-08 at 15 55 48](https://user-images.githubusercontent.com/597182/217469406-b5ea9422-bbd9-483d-bb91-af9e226553ea.png)


