### PR TITLE
Fix empty our_pubkey in DirectMessagesModel

### DIFF
--- a/damus/Models/DirectMessagesModel.swift
+++ b/damus/Models/DirectMessagesModel.swift
@@ -10,7 +10,7 @@ import Foundation
 class DirectMessagesModel: ObservableObject {
     @Published var dms: [(String, DirectMessageModel)] = []
     @Published var loading: Bool = false
-    let our_pubkey: String
+    var our_pubkey: String
     
     init(our_pubkey: String) {
         self.our_pubkey = our_pubkey

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -31,7 +31,11 @@ struct NewEventsBits {
 }
 
 class HomeModel: ObservableObject {
-    var damus_state: DamusState
+    var damus_state: DamusState {
+        didSet {
+            dms.our_pubkey = damus_state.pubkey
+        }
+    }
 
     var has_event: [String: Set<String>] = [:]
     var deleted_events: Set<String> = Set()


### PR DESCRIPTION
The PR is for solving https://github.com/damus-io/damus/issues/556

Root cause:
1. `dms` is created with empty pub key in [HomeModel](https://github.com/damus-io/damus/blob/9ab03034a2ffc6abfd454f165598d768a3e99db6/damus/Models/HomeModel.swift#L58)
2. After that, its pub key is never updated even when `damus_state` is updated in [ContentView](https://github.com/damus-io/damus/blob/9ab03034a2ffc6abfd454f165598d768a3e99db6/damus/ContentView.swift#L581)
3. The empty pub key of `DirectMessagesModel` is used to init a new [DirectMessageModel](https://github.com/damus-io/damus/blob/9ab03034a2ffc6abfd454f165598d768a3e99db6/damus/Models/DirectMessagesModel.swift#L32), so the pub key of newly created `DirectMessageModel` is also empty
4. As a result, `determine_is_request` in [DirectMessageModel](https://github.com/damus-io/damus/blob/9ab03034a2ffc6abfd454f165598d768a3e99db6/damus/Models/DirectMessageModel.swift#L22) will always return `true` because `our_pubkey` is empty. 
5. It causes newly created conversations show in the `Requests` list, instead of `DMs` list

Input is welcome. 