### PR TITLE
Add password autofill on account login and creation

### DIFF
--- a/damus/Util/InputDismissKeyboard.swift
+++ b/damus/Util/InputDismissKeyboard.swift
@@ -29,7 +29,7 @@ public struct DismissKeyboardOnTap: ViewModifier {
 
 }
 
-func end_editing() {
+public func end_editing() {
     UIApplication.shared.connectedScenes
       .filter {$0.activationState == .foregroundActive}
       .map {$0 as? UIWindowScene}

--- a/damus/Views/LoginView.swift
+++ b/damus/Views/LoginView.swift
@@ -275,6 +275,7 @@ struct KeyInput: View {
             .autocapitalization(.none)
             .foregroundColor(.white)
             .font(.body.monospaced())
+            .textContentType(.password)
     }
 }
 

--- a/damus/damus.entitlements
+++ b/damus/damus.entitlements
@@ -7,6 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:damus.io</string>
+		<string>webcredentials:damus.io</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>


### PR DESCRIPTION
![Simulator Screen Recording - iPhone 14 Pro - 2023-02-08 at 23 44 26](https://user-images.githubusercontent.com/963907/217720546-b814ef25-2f13-4481-ac69-0f41b86464af.gif)

@jb55 You would need to add to the existing https://damus.io/.well-known/apple-app-site-association file to include the following on the same root level as `applinks`
```json
   "webcredentials": {
      "apps": [ "XK7H4JAB3D.com.jb55.damus2" ]
   },
```