### PR TITLE
Remove trailing slash when adding a relay

### DIFF
--- a/damus/Views/Relays/RelayConfigView.swift
+++ b/damus/Views/Relays/RelayConfigView.swift
@@ -43,6 +43,10 @@ struct RelayConfigView: View {
                     relay = "wss://" + relay
                 }
                 
+                if relay.hasSuffix("/") {
+                    relay.removeLast();
+                }
+                
                 guard let url = URL(string: relay) else {
                     return
                 }


### PR DESCRIPTION
Remove trailing slash from relay URI to be added to
- prevent relays with duplicate URIs from being registered
- unify the appearance of URIs in the relay list