### PR TITLE
Restrict dynamic font type - max font size

### DIFF
--- a/damus/damusApp.swift
+++ b/damus/damusApp.swift
@@ -32,6 +32,7 @@ struct MainView: View {
                     }
             }
         }
+        .dynamicTypeSize(.xSmall ... .xxxLarge)
         .onReceive(handle_notify(.logout)) { _ in
             try? clear_keypair()
             keypair = nil


### PR DESCRIPTION
Issue ref: #511 

The UI completely breaks on some views when large accessibility font is used. This change will limit font size in the entire app to be no bigger than xxxLarge. Eventually, the layout should be redesigned to support the accessibility sizes.

Using Accessibility 5 size:
Before             |  After
:-------------------------:|:-------------------------:
![IMG_4839](https://user-images.githubusercontent.com/19398259/218241692-28ff1cfc-3a4b-459b-8843-38aa5757af10.PNG) | ![IMG_4840](https://user-images.githubusercontent.com/19398259/218241699-068c8c00-8d3f-49d7-929f-1acda3ac2299.PNG)



