### PR TITLE
Add menu ellipsis button to notes

### DIFF
--- a/damus/Views/ChatroomView.swift
+++ b/damus/Views/ChatroomView.swift
@@ -24,7 +24,7 @@ struct ChatroomView: View {
                                  next_ev: ind == count-1 ? nil : thread.events[ind+1],
                                  damus_state: damus
                         )
-                        .event_context_menu(ev, keypair: damus.keypair, target_pubkey: ev.pubkey)
+                        .contextMenu{MenuItems(event: ev, keypair: damus.keypair, target_pubkey: ev.pubkey)}
                         .onTapGesture {
                             if thread.initial_event.id == ev.id {
                                 //dismiss()

--- a/damus/Views/DMChatView.swift
+++ b/damus/Views/DMChatView.swift
@@ -20,7 +20,7 @@ struct DMChatView: View {
                 VStack(alignment: .leading) {
                     ForEach(Array(zip(dms.events, dms.events.indices)), id: \.0.id) { (ev, ind) in
                         DMView(event: dms.events[ind], damus_state: damus_state)
-                            .event_context_menu(ev, keypair: damus_state.keypair, target_pubkey: ev.pubkey)
+                            .contextMenu{MenuItems(event: ev, keypair: damus_state.keypair, target_pubkey: ev.pubkey)}
                     }
                     EndBlock(height: 80)
                 }

--- a/damus/Views/Events/EmbeddedEventView.swift
+++ b/damus/Views/Events/EmbeddedEventView.swift
@@ -18,12 +18,20 @@ struct EmbeddedEventView: View {
     var body: some View {
         VStack(alignment: .leading) {
             let profile = damus_state.profiles.lookup(id: pubkey)
-            
-            EventProfile(damus_state: damus_state, pubkey: pubkey, profile: profile, size: .small)
+            HStack {
+                EventProfile(damus_state: damus_state, pubkey: pubkey, profile: profile, size: .small)
+                
+                Spacer()
+                
+                EventMenuContext(event: event, keypair: damus_state.keypair, target_pubkey: event.pubkey)
+                    .padding([.bottom], 4)
+
+            }
+            .minimumScaleFactor(0.75)
+            .lineLimit(1)
             
             EventBody(damus_state: damus_state, event: event, size: .small)
         }
-        .event_context_menu(event, keypair: damus_state.keypair, target_pubkey: pubkey)
     }
 }
 

--- a/damus/Views/Events/EventMenu.swift
+++ b/damus/Views/Events/EventMenu.swift
@@ -13,50 +13,73 @@ struct EventMenuContext: View {
     let target_pubkey: String
     
     var body: some View {
-    
-        Button {
-            UIPasteboard.general.string = event.get_content(keypair.privkey)
-        } label: {
-            Label(NSLocalizedString("Copy Text", comment: "Context menu option for copying the text from an note."), systemImage: "doc.on.doc")
-        }
-
-        Button {
-            UIPasteboard.general.string = bech32_pubkey(target_pubkey)
-        } label: {
-            Label(NSLocalizedString("Copy User Pubkey", comment: "Context menu option for copying the ID of the user who created the note."), systemImage: "person")
-        }
-
-        Button {
-            UIPasteboard.general.string = bech32_note_id(event.id) ?? event.id
-        } label: {
-            Label(NSLocalizedString("Copy Note ID", comment: "Context menu option for copying the ID of the note."), systemImage: "note.text")
-        }
-
-        Button {
-            UIPasteboard.general.string = event_to_json(ev: event)
-        } label: {
-            Label(NSLocalizedString("Copy Note JSON", comment: "Context menu option for copying the JSON text from the note."), systemImage: "square.on.square")
-        }
-
-        Button {
-            NotificationCenter.default.post(name: .broadcast_event, object: event)
-        } label: {
-            Label(NSLocalizedString("Broadcast", comment: "Context menu option for broadcasting the user's note to all of the user's connected relay servers."), systemImage: "globe")
-        }
-
-        // Only allow reporting if logged in with private key and the currently viewed profile is not the logged in profile.
-        if keypair.pubkey != target_pubkey && keypair.privkey != nil {
-            Button(role: .destructive) {
-                let target: ReportTarget = .note(ReportNoteTarget(pubkey: target_pubkey, note_id: event.id))
-                notify(.report, target)
+        HStack {
+            Menu {
+                
+                MenuItems(event: event, keypair: keypair, target_pubkey: target_pubkey)
+                
             } label: {
-                Label(NSLocalizedString("Report", comment: "Context menu option for reporting content."), systemImage: "exclamationmark.bubble")
+                Label(NSLocalizedString("", comment: "Context menu"), systemImage: "ellipsis")
+                    .foregroundColor(Color.gray)
             }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {}
+        
+    }
+}
 
-            Button(role: .destructive) {
-                notify(.block, target_pubkey)
+struct MenuItems: View {
+    let event: NostrEvent
+    let keypair: Keypair
+    let target_pubkey: String
+    
+    var body: some View {
+        Group {
+            Button {
+                UIPasteboard.general.string = event.get_content(keypair.privkey)
             } label: {
-                Label(NSLocalizedString("Block", comment: "Context menu option for blocking users."), systemImage: "exclamationmark.octagon")
+                Label(NSLocalizedString("Copy Text", comment: "Context menu option for copying the text from an note."), systemImage: "doc.on.doc")
+            }
+            
+            Button {
+                UIPasteboard.general.string = bech32_pubkey(target_pubkey)
+            } label: {
+                Label(NSLocalizedString("Copy User Pubkey", comment: "Context menu option for copying the ID of the user who created the note."), systemImage: "person")
+            }
+            
+            Button {
+                UIPasteboard.general.string = bech32_note_id(event.id) ?? event.id
+            } label: {
+                Label(NSLocalizedString("Copy Note ID", comment: "Context menu option for copying the ID of the note."), systemImage: "note.text")
+            }
+            
+            Button {
+                UIPasteboard.general.string = event_to_json(ev: event)
+            } label: {
+                Label(NSLocalizedString("Copy Note JSON", comment: "Context menu option for copying the JSON text from the note."), systemImage: "square.on.square")
+            }
+            
+            Button {
+                NotificationCenter.default.post(name: .broadcast_event, object: event)
+            } label: {
+                Label(NSLocalizedString("Broadcast", comment: "Context menu option for broadcasting the user's note to all of the user's connected relay servers."), systemImage: "globe")
+            }
+            
+            // Only allow reporting if logged in with private key and the currently viewed profile is not the logged in profile.
+            if keypair.pubkey != target_pubkey && keypair.privkey != nil {
+                Button(role: .destructive) {
+                    let target: ReportTarget = .note(ReportNoteTarget(pubkey: target_pubkey, note_id: event.id))
+                    notify(.report, target)
+                } label: {
+                    Label(NSLocalizedString("Report", comment: "Context menu option for reporting content."), systemImage: "exclamationmark.bubble")
+                }
+                
+                Button(role: .destructive) {
+                    notify(.block, target_pubkey)
+                } label: {
+                    Label(NSLocalizedString("Block", comment: "Context menu option for blocking users."), systemImage: "exclamationmark.octagon")
+                }
             }
         }
     }

--- a/damus/Views/Events/SelectedEventView.swift
+++ b/damus/Views/Events/SelectedEventView.swift
@@ -20,7 +20,18 @@ struct SelectedEventView: View {
             let profile = damus.profiles.lookup(id: pubkey)
 
             VStack(alignment: .leading) {
-                EventProfile(damus_state: damus, pubkey: pubkey, profile: profile, size: .normal)
+                HStack {
+                    EventProfile(damus_state: damus, pubkey: pubkey, profile: profile, size: .normal)
+                    
+                    Spacer()
+                    
+                    EventMenuContext(event: event, keypair: damus.keypair, target_pubkey: event.pubkey)
+                        .padding([.bottom], 4)
+
+                }
+                .minimumScaleFactor(0.75)
+                .lineLimit(1)
+                
                 EventBody(damus_state: damus, event: event, size: .selected)
                 
                 if let mention = first_eref_mention(ev: event, privkey: damus.keypair.privkey) {
@@ -49,7 +60,6 @@ struct SelectedEventView: View {
                     .padding([.top], 4)
             }
             .padding([.leading], 2)
-            .event_context_menu(event, keypair: damus.keypair, target_pubkey: event.pubkey)
         }
     }
 }

--- a/damus/Views/Events/TextEvent.swift
+++ b/damus/Views/Events/TextEvent.swift
@@ -37,7 +37,13 @@ struct TextEvent: View {
                         .foregroundColor(.gray)
                     
                     Spacer()
+                    
+                    EventMenuContext(event: event, keypair: damus.keypair, target_pubkey: event.pubkey)
+                        .padding([.bottom], 4)
+
                 }
+                .minimumScaleFactor(0.75)
+                .lineLimit(1)
                 
                 EventBody(damus_state: damus, event: event, size: .normal)
                 
@@ -61,7 +67,6 @@ struct TextEvent: View {
         .id(event.id)
         .frame(maxWidth: .infinity, minHeight: PFP_SIZE)
         .padding([.bottom], 2)
-        .event_context_menu(event, keypair: damus.keypair, target_pubkey: pubkey)
     }
 }
 


### PR DESCRIPTION
This PR replaces the context menu (long press on notes) with a menu button, shown as ellipsis, on each note. This will allow for other long press gestures on notes while still allowing users to access the context menu. 
![menu-ellipsis](https://user-images.githubusercontent.com/14004132/218245354-1d8a8705-2153-4efd-9d95-4210e79be2ae.gif)
