### PR TITLE
Add atlas.nostr.land as a bootstrap relay

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -16,6 +16,7 @@ var BOOTSTRAP_RELAYS = [
     "wss://nos.lol",
     "wss://relay.current.fyi",
     "wss://brb.io",
+    "wss://atlas.nostr.land",
 ]
 
 struct TimestampedProfile {


### PR DESCRIPTION
Paid relay (15k sat), hosted with Hetzner in Germany, 16GB RAM + 8 threads