### PR TITLE
Add replies count to selected event action bar

### DIFF
--- a/damus/Views/Events/MutedEventView.swift
+++ b/damus/Views/Events/MutedEventView.swift
@@ -11,6 +11,7 @@ struct MutedEventView: View {
     let damus_state: DamusState
     let event: NostrEvent
     let scroller: ScrollViewProxy?
+    let thread: ThreadV2?
     
     let selected: Bool
     @Binding var nav_target: String?
@@ -18,7 +19,7 @@ struct MutedEventView: View {
     @State var shown: Bool
     @Environment(\.colorScheme) var colorScheme
     
-    init(damus_state: DamusState, event: NostrEvent, scroller: ScrollViewProxy?, nav_target: Binding<String?>, navigating: Binding<Bool>, selected: Bool) {
+    init(damus_state: DamusState, event: NostrEvent, scroller: ScrollViewProxy?, nav_target: Binding<String?>, navigating: Binding<Bool>, selected: Bool, thread: ThreadV2?) {
         self.damus_state = damus_state
         self.event = event
         self.scroller = scroller
@@ -26,6 +27,7 @@ struct MutedEventView: View {
         self._nav_target = nav_target
         self._navigating = navigating
         self._shown = State(initialValue: should_show_event(contacts: damus_state.contacts, ev: event))
+        self.thread = thread
     }
     
     var should_mute: Bool {
@@ -55,7 +57,7 @@ struct MutedEventView: View {
     var Event: some View {
         Group {
             if selected {
-                SelectedEventView(damus: damus_state, event: event)
+                SelectedEventView(damus: damus_state, event: event, thread: thread)
             } else {
                 EventView(damus: damus_state, event: event, has_action_bar: true)
                     .onTapGesture {
@@ -106,7 +108,7 @@ struct MutedEventView_Previews: PreviewProvider {
     
     static var previews: some View {
         
-        MutedEventView(damus_state: test_damus_state(), event: test_event, scroller: nil, nav_target: $nav_target, navigating: $navigating, selected: false)
+        MutedEventView(damus_state: test_damus_state(), event: test_event, scroller: nil, nav_target: $nav_target, navigating: $navigating, selected: false, thread: nil)
             .frame(width: .infinity, height: 50)
     }
 }

--- a/damus/Views/Events/SelectedEventView.swift
+++ b/damus/Views/Events/SelectedEventView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SelectedEventView: View {
     let damus: DamusState
     let event: NostrEvent
+    let thread: ThreadV2?
     
     var pubkey: String {
         event.pubkey
@@ -17,10 +18,11 @@ struct SelectedEventView: View {
     
     @StateObject var bar: ActionBarModel
     
-    init(damus: DamusState, event: NostrEvent) {
+    init(damus: DamusState, event: NostrEvent, thread: ThreadV2?) {
         self.damus = damus
         self.event = event
         self._bar = StateObject(wrappedValue: make_actionbar_model(ev: event.id, damus: damus))
+        self.thread = thread
     }
     
     var body: some View {
@@ -47,8 +49,8 @@ struct SelectedEventView: View {
                     EventDetailBar(state: damus, target: event.id, target_pk: event.pubkey)
                     Divider()
                 }
-                
-                EventActionBar(damus_state: damus, event: event)
+
+                EventActionBar(damus_state: damus, event: event, thread: thread)
                     .padding([.top], 4)
 
                 Divider()
@@ -67,7 +69,7 @@ struct SelectedEventView: View {
 
 struct SelectedEventView_Previews: PreviewProvider {
     static var previews: some View {
-        SelectedEventView(damus: test_damus_state(), event: test_event)
+        SelectedEventView(damus: test_damus_state(), event: test_event, thread: nil)
             .padding()
     }
 }

--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -263,7 +263,8 @@ struct ThreadV2View: View {
                                            scroller: reader,
                                            nav_target: $nav_target,
                                            navigating: $navigating,
-                                           selected: false
+                                           selected: false,
+                                           thread: nil
                             )
                         }
                     }.background(GeometryReader { geometry in
@@ -285,7 +286,8 @@ struct ThreadV2View: View {
                         scroller: reader,
                         nav_target: $nav_target,
                         navigating: $navigating,
-                        selected: true
+                        selected: true,
+                        thread: thread
                     ).id("main")
                     
                     // MARK: - Responses of the actual event view
@@ -296,7 +298,8 @@ struct ThreadV2View: View {
                             scroller: reader,
                             nav_target: $nav_target,
                             navigating: $navigating,
-                            selected: false
+                            selected: false,
+                            thread: nil
                         )
                     }
                 }.padding()


### PR DESCRIPTION
Replies count shows up only when you tap into an event as the threaded information is only fetched when you select the event. The count and icon will turn blue if you have replied.

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-12 at 02 52 57 Medium](https://user-images.githubusercontent.com/963907/218299516-7ab87a85-62ab-405f-a0c9-8c844d56b41a.png)![Simulator Screen Shot - iPhone 14 Pro - 2023-02-12 at 02 53 08 Medium](https://user-images.githubusercontent.com/963907/218299518-90c232bf-4e11-4126-a12a-5d2680b3242b.png)![Simulator Screen Shot - iPhone 14 Pro - 2023-02-12 at 02 53 21 Medium](https://user-images.githubusercontent.com/963907/218299519-b80eaa12-b5ca-4f11-b482-96a51a7f524c.png)
