### PR TITLE
Strip punctuation from URLs

### DIFF
--- a/damus-c/damus.c
+++ b/damus-c/damus.c
@@ -55,8 +55,8 @@ static int consume_until_whitespace(struct cursor *cur, int or_end) {
     while (cur->p < cur->end) {
         c = *cur->p;
         
-        if (is_whitespace(c) && consumedAtLeastOne)
-            return 1;
+        if (is_whitespace(c))
+            return consumedAtLeastOne;
         
         cur->p++;
         consumedAtLeastOne = true;

--- a/damus-c/damus.c
+++ b/damus-c/damus.c
@@ -26,6 +26,10 @@ static inline int is_boundary(char c) {
     return !isalnum(c);
 }
 
+static inline int is_invalid_url_ending(char c) {
+    return c == '!' || c == '?' || c == ')' || c == '.' || c == ',' || c == ';';
+}
+
 static void make_cursor(struct cursor *c, const u8 *content, size_t len)
 {
     c->start = content;
@@ -220,6 +224,9 @@ static int parse_url(struct cursor *cur, struct block *block) {
         cur->p = start;
         return 0;
     }
+    
+    // strip any unwanted characters
+    while(is_invalid_url_ending(peek_char(cur, -1))) cur->p--;
     
     block->type = BLOCK_URL;
     block->block.str.start = (const char *)start;

--- a/damusTests/damusTests.swift
+++ b/damusTests/damusTests.swift
@@ -133,7 +133,7 @@ class damusTests: XCTestCase {
     }
     
     func testNoParseUrlWithOnlyWhitespace() {
-        let testString = "https:// "
+        let testString = "https://  "
         let parsed = parse_mentions(content: testString, tags: [])
         
         XCTAssertNotNil(parsed)

--- a/damusTests/damusTests.swift
+++ b/damusTests/damusTests.swift
@@ -140,6 +140,14 @@ class damusTests: XCTestCase {
         XCTAssertEqual(parsed[0].is_text, testString)
     }
     
+    func testNoParseUrlTrailingCharacters() {
+        let testString = "https://foo.bar, "
+        let parsed = parse_mentions(content: testString, tags: [])
+        
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed[0].is_url?.absoluteString, "https://foo.bar")
+    }
+    
     func testParseMentionBlank() {
         let parsed = parse_mentions(content: "", tags: [["e", "event_id"]])
         


### PR DESCRIPTION
2 fixes:
- slight adjustment to `consume_until_whitespace`
- fix #574

<img width="374" alt="Screenshot 2023-02-12 at 14 14 31" src="https://user-images.githubusercontent.com/290596/218313271-fcc9e58c-cc62-43f8-9cde-ed9865a2bae3.png">
