### PR TITLE
Delete user settings store on logout

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -473,6 +473,18 @@ struct ContentView: View {
         .onReceive(handle_notify(.new_mutes)) { notif in
             home.filter_muted()
         }
+        .onReceive(handle_notify(.logout)) { _ in
+            guard damus_state != nil else {
+                return
+            }
+
+            do {
+                try damus_state!.settings.delete_settings(damus_state!.pubkey)
+            } catch {
+                // Could not delete all settings for some reason. Continue with logout.
+                print("Unable to delete all user settings for \(damus_state!.pubkey). Continuing with logout.")
+            }
+        }
         .alert(NSLocalizedString("Deleted Account", comment: "Alert message to indicate this is a deleted account"), isPresented: $is_deleted_account) {
             Button(NSLocalizedString("Logout", comment: "Button to close the alert that informs that the current account has been deleted.")) {
                 is_deleted_account = false

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -227,6 +227,19 @@ class UserSettingsStore: ObservableObject {
             return deepl_api_key != ""
         }
     }
+
+    func delete_settings(_ pubkey: String) throws {
+        UserDefaults.standard.removeObject(forKey: pk_setting_key(pubkey, key: tip_amount_key))
+        UserDefaults.standard.removeObject(forKey: "show_wallet_selector")
+        UserDefaults.standard.removeObject(forKey: "default_wallet")
+        UserDefaults.standard.removeObject(forKey: "left_handed")
+        UserDefaults.standard.removeObject(forKey: "translation_service")
+        UserDefaults.standard.removeObject(forKey: "deepl_plan")
+        UserDefaults.standard.removeObject(forKey: "libretranslate_server")
+        UserDefaults.standard.removeObject(forKey: "libretranslate_url")
+        try clearLibreTranslateApiKey()
+        try clearDeepLApiKey()
+    }
 }
 
 struct DamusLibreTranslateKeychainConfiguration: KeychainConfiguration {


### PR DESCRIPTION
Logout should probably get rid of all local settings tied to the pubkey. Some settings are currently global. If we want to have multi-account support in the future, we'd need to update user settings store to support that and then update the settings deletion to be scoped only to that.