### PR TITLE
Beautify eula

### DIFF
--- a/damus/Views/EULAView.swift
+++ b/damus/Views/EULAView.swift
@@ -17,105 +17,103 @@ struct EULAView: View {
             DamusGradient()
             
             ScrollView {
-                //Text("End User License Agreement", comment: "Label indicating that the below text is the EULA, an acronym for End User License Agreement.")
-                //    .font(.title.bold())
-                //    .foregroundColor(.white)
-                
-                Divider()
+                Text(NSLocalizedString("End User License Agreement", comment: "Title of the EULA page"))
+                    .font(.title.bold())
+                    .foregroundColor(.white)
                 
                 // Introduction
                 Group {
-                    Text("Introduction")
+                    Text(NSLocalizedString("Introduction", comment:"Introduction heading in the EULA"))
                         .font(.title2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding()
-                    Text("This End User License Agreement (EULA) is a legal agreement between you and Damus Nostr Inc. for the use of our mobile application Damus. By installing, accessing, or using our application, you agree to be bound by the terms and conditions of this EULA.")
+                         Text(NSLocalizedString("This End User License Agreement (EULA) is a legal agreement between you and Damus Nostr Inc. for the use of our mobile application Damus. By installing, accessing, or using our application, you agree to be bound by the terms and conditions of this EULA.", comment: "Introduction paragraph in the EULA"))
                         .padding()
                 }
 
                 // Prohibited Content and Conduct
                 Group {
-                    Text("Prohibited Content and Conduct")
+                    Text(NSLocalizedString("Prohibited Content and Conduct", comment: "Prohibited Content and Conduct heading in the EULA"))
                         .font(.title2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding()
                     
-                    Text("You agree not to use our application to create, upload, post, send, or store any content that:")
-                    
+                    Text(NSLocalizedString("You agree not to use our application to create, upload, post, send, or store any content that:", comment: "First paragraph of the Prohibited Content and Conduct heading in the EULA"))
+
                     VStack(alignment:.leading) {
-                        Label("Is illegal, infringing, or fraudulent",systemImage: "exclamationmark.square")
-                        Label("Is defamatory, libelous, or threatening",systemImage: "exclamationmark.square")
-                        Label("Is pornographic, obscene, or offensive",systemImage: "exclamationmark.square")
-                        Label("Is discriminatory or promotes hate speech",systemImage: "exclamationmark.square")
-                        Label("Is harmful to minors",systemImage: "exclamationmark.square")
-                        Label("Is intended to harass or bully others",systemImage: "exclamationmark.square")
-                        Label("Is intended to impersonate others",systemImage: "exclamationmark.square")
+                        Label(NSLocalizedString("Is illegal, infringing, or fraudulent", comment: "Bullet point in EULA"),systemImage: "exclamationmark.square")
+                        Label(NSLocalizedString("Is defamatory, libelous, or threatening", comment: "Bullet point in EULA"),systemImage: "exclamationmark.square")
+                        Label(NSLocalizedString("Is pornographic, obscene, or offensive", comment: "Bullet point in EULA"),systemImage: "exclamationmark.square")
+                        Label(NSLocalizedString("Is discriminatory or promotes hate speech", comment: "Bullet point in EULA"),systemImage: "exclamationmark.square")
+                        Label(NSLocalizedString("Is harmful to minors", comment: "Bullet point in EULA"),systemImage: "exclamationmark.square")
+                        Label(NSLocalizedString("Is intended to harass or bully others", comment: "Bullet point in EULA"),systemImage: "exclamationmark.square")
+                        Label(NSLocalizedString("Is intended to impersonate others", comment: "Bullet point in EULA"),systemImage: "exclamationmark.square")
                     }
                     .padding()
                     
-                    Text("You also agree not to engage in any conduct that:")
+                    Text(NSLocalizedString("You also agree not to engage in any conduct that:",comment: "Second paragraph of the Prohibited Content and Conduct heading in the EULA"))
                     
                     VStack(alignment:.leading) {
-                        Label("Harasses or bullies others",systemImage: "exclamationmark.square")
-                        Label("Impersonates others",systemImage: "exclamationmark.square")
-                        Label("Is intended to intimidate or threaten others",systemImage: "exclamationmark.square")
-                        Label("Is intended to promote or incite violence",systemImage: "exclamationmark.square")
+                        Label(NSLocalizedString("Harasses or bullies others", comment: "Bullet point in EULA"),systemImage: "exclamationmark.square")
+                        Label(NSLocalizedString("Impersonates others", comment: "Bullet point in EULA"),systemImage: "exclamationmark.square")
+                        Label(NSLocalizedString("Is intended to intimidate or threaten others", comment: "Bullet point in EULA"),systemImage: "exclamationmark.square")
+                        Label(NSLocalizedString("Is intended to promote or incite violence", comment: "Bullet point in EULA"),systemImage: "exclamationmark.square")
                     }
                     .padding()
                 }
                 
                 // Consequences of Violation
                 Group {
-                    Text("Consequences of Violation")
+                    Text(NSLocalizedString("Consequences of Violation",comment: "Consequences of Violation heading in the EULA"))
                         .font(.title2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding()
                     
-                    Text("Any violation of this EULA, including the prohibited content and conduct outlined above, may result in the termination of your access to our application.")
+                    Text(NSLocalizedString("Any violation of this EULA, including the prohibited content and conduct outlined above, may result in the termination of your access to our application.", comment: "Consequences of Violation paragraph in the EULA"))
                     .padding()
                 }
 
                 // Disclaimer of Warranties and Limitation of Liability
                 Group {
-                    Text("Disclaimer of Warranties and Limitation of Liability")
+                    Text(NSLocalizedString("Disclaimer of Warranties and Limitation of Liability", comment: "Disclaimer of Warranties and Limitation of Liability heading in the EULA"))
                         .font(.title2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding()
                     
-                    Text("Our application is provided \"as is\" and \"as available\" without warranty of any kind, either express or implied, including but not limited to the implied warranties of merchantability and fitness for a particular purpose. We do not guarantee that our application will be uninterrupted or error-free. In no event shall Damus Nostr Inc. be liable for any damages whatsoever, including but not limited to direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the use or inability to use our application.")
+                    Text(NSLocalizedString("Our application is provided \"as is\" and \"as available\" without warranty of any kind, either express or implied, including but not limited to the implied warranties of merchantability and fitness for a particular purpose. We do not guarantee that our application will be uninterrupted or error-free. In no event shall Damus Nostr Inc. be liable for any damages whatsoever, including but not limited to direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the use or inability to use our application.", comment: "Disclaimer of Warranties and Limitation of Liability paragraph in the EULA"))
                     .padding()
                 }
 
                 // Changes to EULA
                 Group {
-                    Text("Changes to EULA")
+                    Text(NSLocalizedString("Changes to EULA",comment:"Changes to EULA heading in the EULA"))
                         .font(.title2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding()
                     
-                    Text("We reserve the right to update or modify this EULA at any time and without prior notice. Your continued use of our application following any changes to this EULA will be deemed to be your acceptance of such changes.")
+                         Text(NSLocalizedString("We reserve the right to update or modify this EULA at any time and without prior notice. Your continued use of our application following any changes to this EULA will be deemed to be your acceptance of such changes.", comment:"Changes to EULA paragraph in the EULA"))
                     .padding()
                 }
 
                 // Contact information
                 Group {
-                    Text("Contact Information")
+                        Text(NSLocalizedString("Contact Information",comment:"Contact Information heading in the EULA"))
                         .font(.title2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding()
                     
-                    Text("If you have any questions about this EULA, please contact us at damus@jb55.com")
+                    Text(NSLocalizedString("If you have any questions about this EULA, please contact us at damus@jb55.com",comment:"Contact Information paragraph in the EULA"))
                         .padding()
                 }
 
                 // Acceptance of Terms
                 Group {
-                    Text("Acceptance of Terms")
+                        Text(NSLocalizedString("Acceptance of Terms",comment:"Acceptance of Terms heading in the EULA"))
                         .font(.title2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding()
                     
-                    Text("By using our Application, you signify your acceptance of this EULA. If you do not agree to this EULA, you may not use our Application.")
+                        Text(NSLocalizedString("By using our Application, you signify your acceptance of this EULA. If you do not agree to this EULA, you may not use our Application.",comment: "Acceptance of Terms paragraph in the EULA"))
                     .padding()
                 }
 

--- a/damus/Views/EULAView.swift
+++ b/damus/Views/EULAView.swift
@@ -17,59 +17,108 @@ struct EULAView: View {
             DamusGradient()
             
             ScrollView {
-                Text("EULA", comment: "Label indicating that the below text is the EULA, an acronym for End User License Agreement.")
-                    .font(.title.bold())
-                    .foregroundColor(.white)
+                //Text("End User License Agreement", comment: "Label indicating that the below text is the EULA, an acronym for End User License Agreement.")
+                //    .font(.title.bold())
+                //    .foregroundColor(.white)
                 
-                Text(Markdown.parse(content: """
-End User License Agreement
-
-## Introduction
-
-This End User License Agreement ("EULA") is a legal agreement between you and Damus Nostr Inc. for the use of our mobile application Damus. By installing, accessing, or using our application, you agree to be bound by the terms and conditions of this EULA.
-
-## Prohibited Content and Conduct
-
-You agree not to use our application to create, upload, post, send, or store any content that:
-
-* Is illegal, infringing, or fraudulent
-* Is defamatory, libelous, or threatening
-* Is pornographic, obscene, or offensive
-* Is discriminatory or promotes hate speech
-* Is harmful to minors
-* Is intended to harass or bully others
-* Is intended to impersonate others
-
-## You also agree not to engage in any conduct that:
-
-* Harasses or bullies others
-* Impersonates others
-* Is intended to intimidate or threaten others
-* Is intended to promote or incite violence
-
-## Consequences of Violation
-
-Any violation of this EULA, including the prohibited content and conduct outlined above, may result in the termination of your access to our application.
-
-## Disclaimer of Warranties and Limitation of Liability
-
-Our application is provided "as is" and "as available" without warranty of any kind, either express or implied, including but not limited to the implied warranties of merchantability and fitness for a particular purpose. We do not guarantee that our application will be uninterrupted or error-free. In no event shall Damus Nostr Inc. be liable for any damages whatsoever, including but not limited to direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the use or inability to use our application.
-
-## Changes to EULA
-
-We reserve the right to update or modify this EULA at any time and without prior notice. Your continued use of our application following any changes to this EULA will be deemed to be your acceptance of such changes.
-
-## Contact Information
-
-If you have any questions about this EULA, please contact us at damus@jb55.com
-
-## Acceptance of Terms
-
-By using our Application, you signify your acceptance of this EULA. If you do not agree to this EULA, you may not use our Application.
-
-"""))
-                .padding()
+                Divider()
                 
+                // Introduction
+                Group {
+                    Text("Introduction")
+                        .font(.title2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                    Text("This End User License Agreement (EULA) is a legal agreement between you and Damus Nostr Inc. for the use of our mobile application Damus. By installing, accessing, or using our application, you agree to be bound by the terms and conditions of this EULA.")
+                        .padding()
+                }
+
+                // Prohibited Content and Conduct
+                Group {
+                    Text("Prohibited Content and Conduct")
+                        .font(.title2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                    
+                    Text("You agree not to use our application to create, upload, post, send, or store any content that:")
+                    
+                    VStack(alignment:.leading) {
+                        Label("Is illegal, infringing, or fraudulent",systemImage: "exclamationmark.square")
+                        Label("Is defamatory, libelous, or threatening",systemImage: "exclamationmark.square")
+                        Label("Is pornographic, obscene, or offensive",systemImage: "exclamationmark.square")
+                        Label("Is discriminatory or promotes hate speech",systemImage: "exclamationmark.square")
+                        Label("Is harmful to minors",systemImage: "exclamationmark.square")
+                        Label("Is intended to harass or bully others",systemImage: "exclamationmark.square")
+                        Label("Is intended to impersonate others",systemImage: "exclamationmark.square")
+                    }
+                    .padding()
+                    
+                    Text("You also agree not to engage in any conduct that:")
+                    
+                    VStack(alignment:.leading) {
+                        Label("Harasses or bullies others",systemImage: "exclamationmark.square")
+                        Label("Impersonates others",systemImage: "exclamationmark.square")
+                        Label("Is intended to intimidate or threaten others",systemImage: "exclamationmark.square")
+                        Label("Is intended to promote or incite violence",systemImage: "exclamationmark.square")
+                    }
+                    .padding()
+                }
+                
+                // Consequences of Violation
+                Group {
+                    Text("Consequences of Violation")
+                        .font(.title2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                    
+                    Text("Any violation of this EULA, including the prohibited content and conduct outlined above, may result in the termination of your access to our application.")
+                    .padding()
+                }
+
+                // Disclaimer of Warranties and Limitation of Liability
+                Group {
+                    Text("Disclaimer of Warranties and Limitation of Liability")
+                        .font(.title2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                    
+                    Text("Our application is provided \"as is\" and \"as available\" without warranty of any kind, either express or implied, including but not limited to the implied warranties of merchantability and fitness for a particular purpose. We do not guarantee that our application will be uninterrupted or error-free. In no event shall Damus Nostr Inc. be liable for any damages whatsoever, including but not limited to direct, indirect, special, incidental, or consequential damages, arising out of or in connection with the use or inability to use our application.")
+                    .padding()
+                }
+
+                // Changes to EULA
+                Group {
+                    Text("Changes to EULA")
+                        .font(.title2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                    
+                    Text("We reserve the right to update or modify this EULA at any time and without prior notice. Your continued use of our application following any changes to this EULA will be deemed to be your acceptance of such changes.")
+                    .padding()
+                }
+
+                // Contact information
+                Group {
+                    Text("Contact Information")
+                        .font(.title2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                    
+                    Text("If you have any questions about this EULA, please contact us at damus@jb55.com")
+                        .padding()
+                }
+
+                // Acceptance of Terms
+                Group {
+                    Text("Acceptance of Terms")
+                        .font(.title2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                    
+                    Text("By using our Application, you signify your acceptance of this EULA. If you do not agree to this EULA, you may not use our Application.")
+                    .padding()
+                }
+
                 if state == .create_account {
                     NavigationLink(destination: CreateAccountView(), isActive: $accepted) {
                         EmptyView()
@@ -79,12 +128,18 @@ By using our Application, you signify your acceptance of this EULA. If you do no
                         EmptyView()
                     }
                 }
-                DamusWhiteButton(NSLocalizedString("Accept", comment: "Button to accept the end user license agreement before being allowed into the app.")) {
-                    accepted = true
-                }
-
-                DamusWhiteButton(NSLocalizedString("Reject", comment: "Button to reject the end user license agreement, which disallows the user from being let into the app.")) {
-                    dismiss()
+                
+                // Buttons
+                Group {
+                    DamusWhiteButton(NSLocalizedString("Accept", comment: "Button to accept the end user license agreement before being allowed into the app.")) {
+                        accepted = true
+                    }
+                    .padding()
+                    
+                    DamusWhiteButton(NSLocalizedString("Reject", comment: "Button to reject the end user license agreement, which disallows the user from being let into the app.")) {
+                        dismiss()
+                    }
+                    .padding()
                 }
             }
             .padding()


### PR DESCRIPTION
Hi, I have now formatted the EULA so it is styled correctly and can be localised by section.

Could you please review @tyiu, as I am thinking instead of say:

```
Text(NSLocalizedString("By using our Application, you signify your acceptance of this EULA. If you do not agree to this EULA, you may not use our Application.",comment: "Acceptance of Terms paragraph in the EULA"))
```

We should use a shorter key, so if the text is to be updated in the future, you don't need to update the Key in all the localizations, e.g.

```
Text(NSLocalizedString("EULA-Acceptance-of-Terms-Paragraph",comment: "Acceptance of Terms paragraph in the EULA"))
```

