### PR TITLE
Fix frequent Kingfisher hang and other scrolling improvements

### DIFF
--- a/damus/Components/ImageCarousel.swift
+++ b/damus/Components/ImageCarousel.swift
@@ -231,10 +231,10 @@ struct ImageCarousel: View {
                         KFAnimatedImage(url)
                             .callbackQueue(.dispatch(.global(qos: .background)))
                             .processingQueue(.dispatch(.global(qos: .background)))
+                            .cancelOnDisappear(true)
+                            .backgroundDecode()
                             .cacheOriginalImage()
-                            .loadDiskFileSynchronously()
                             .scaleFactor(UIScreen.main.scale)
-                            .fade(duration: 0.1)
                             .configure { view in
                                 view.framePreloadCount = 3
                             }

--- a/damus/Views/BannerImageView.swift
+++ b/damus/Views/BannerImageView.swift
@@ -33,15 +33,15 @@ struct InnerBannerImageView: View {
                     .processingQueue(.dispatch(.global(qos: .background)))
                     .serialize(by: imageModel.serializer)
                     .setProcessor(imageModel.processor)
+                    .cacheOriginalImage()
                     .configure { view in
-                        view.framePreloadCount = 1
+                        view.framePreloadCount = 3
                     }
                     .placeholder { _ in
                         Color(uiColor: .secondarySystemBackground)
                     }
                     .scaleFactor(UIScreen.main.scale)
                     .loadDiskFileSynchronously()
-                    .fade(duration: 0.1)
                     .onFailureImage(defaultImage)
                     .id(imageModel.refreshID)
             } else {

--- a/damus/Views/ProfilePicView.swift
+++ b/damus/Views/ProfilePicView.swift
@@ -70,19 +70,20 @@ struct InnerProfilePicView: View {
             KFAnimatedImage(imageModel.url)
                 .callbackQueue(.dispatch(.global(qos: .background)))
                 .processingQueue(.dispatch(.global(qos: .background)))
+                .cancelOnDisappear(true)
+                .backgroundDecode()
                 .serialize(by: imageModel.serializer)
                 .setProcessor(imageModel.processor)
                 .cacheOriginalImage()
+                .scaleFactor(UIScreen.main.scale)
                 .configure { view in
-                    view.framePreloadCount = 1
+                    view.framePreloadCount = 3
                 }
                 .placeholder { _ in
                     Placeholder
                 }
-                .scaleFactor(UIScreen.main.scale)
-                .loadDiskFileSynchronously()
-                .fade(duration: 0.1)
-                .onFailure { _ in
+                .onFailure { error in
+                    if error.isTaskCancelled { return }
                     imageModel.downloadFailed()
                 }
                 .id(imageModel.refreshID)


### PR DESCRIPTION
This PR should, hopefully, fix the hang that many users have been experiencing related to Kingfisher
Ref: [`note13j4kv0qc6eju03yc58kqhd00tuekc68z6pz8tk8y8y55l92c5rdslf9mw8`](https://damus.io/note13j4kv0qc6eju03yc58kqhd00tuekc68z6pz8tk8y8y55l92c5rdslf9mw8)

I believe the hang is caused when many images are queued for download from scrolling  quickly; too many callbacks on the main thread at once, or network blocking? `cancelOnDisappear` will help for this. 

According to KF docs [line 98-101](https://github.com/onevcat/Kingfisher/blob/master/Sources/General/KingfisherOptionsInfo.swift), `backgroundDecode` will also help eliminate scrolling hitches. **IMPORTANT**: If used, this option will have a significant impact on memory when downloading images. Older devices will crash while loading large files, even with a downsampler. If we decide to use this option, I recommend we implement #335 first.
- The accounts [`npub1ea6y6er4n7vt9t5cxdf2p2jhp2ppga5texfmrma0xqj6t6frudaszaw8g5`](https://damus.io/npub1ea6y6er4n7vt9t5cxdf2p2jhp2ppga5texfmrma0xqj6t6frudaszaw8g5) is following will help with testing older devices. Includes PFP and Banner for popular file types in small/medium/large/xlarge sizes.

Removed `fade` and `loadDiskFileSynchronously` as it impacts performance and doesn't make a noticeable UX difference.

# Instruments Tests
Ran the following flow before and after changes
![](https://user-images.githubusercontent.com/19398259/218930735-92750279-8a18-4c90-a273-30b2bec78353.mov)

## Results Before (Contains KFImage.ImageBinder hang)
![before](https://user-images.githubusercontent.com/19398259/218930952-10c64899-c1e6-40ec-a7ee-81ee4b8aef10.png)

## Results After (Less frequent and shorter delays in hangs/hitches)
![after](https://user-images.githubusercontent.com/19398259/218931035-dd863ff4-044b-4a51-a039-6494de9838e1.png)






