### PR TITLE
Format Large Numbers of Action Bar Actions

### DIFF
--- a/damus/Models/Mentions.swift
+++ b/damus/Models/Mentions.swift
@@ -211,6 +211,32 @@ enum Amount: Equatable {
     }
 }
 
+func format_actions_abbrev(_ actions: Int) -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.positiveSuffix = "m"
+    formatter.positivePrefix = ""
+    formatter.minimumFractionDigits = 0
+    formatter.maximumFractionDigits = 3
+    formatter.roundingMode = .down
+    formatter.roundingIncrement = 0.1
+    formatter.multiplier = 1
+        
+    if actions >= 1_000_000 {
+        formatter.positiveSuffix = "m"
+        formatter.multiplier = 0.000001
+    } else if actions >= 1000 {
+        formatter.positiveSuffix = "k"
+        formatter.multiplier = 0.001
+    } else {
+        return "\(actions)"
+    }
+    
+    let actions = NSNumber(value: actions)
+    
+    return formatter.string(from: actions) ?? "\(actions)"
+}
+
 func format_msats_abbrev(_ msats: Int64) -> String {
     let formatter = NumberFormatter()
     formatter.numberStyle = .decimal

--- a/damus/Views/ActionBar/EventActionBar.swift
+++ b/damus/Views/ActionBar/EventActionBar.swift
@@ -61,7 +61,7 @@ struct EventActionBar: View {
                     }
                 }
                 .accessibilityLabel(NSLocalizedString("Boosts", comment: "Accessibility label for boosts button"))
-                Text(String("\(bar.boosts > 0 ? "\(bar.boosts)" : "")"))
+                Text(String("\(bar.boosts > 0 ? "\(format_actions_abbrev(bar.boosts))" : "")"))
                     .offset(x: 18)
                     .font(.footnote.weight(.medium))
                     .foregroundColor(bar.boosted ? Color.green : Color.gray)
@@ -76,7 +76,7 @@ struct EventActionBar: View {
                         send_like()
                     }
                 }
-                Text(String("\(bar.likes > 0 ? "\(bar.likes)" : "")"))
+                Text(String("\(bar.likes > 0 ? "\(format_actions_abbrev(bar.likes))" : "")"))
                     .offset(x: 22)
                     .font(.footnote.weight(.medium))
                     .foregroundColor(bar.liked ? Color.accentColor : Color.gray)
@@ -190,6 +190,8 @@ struct EventActionBar_Previews: PreviewProvider {
         let likedbar = ActionBarModel(likes: 10, boosts: 0, zaps: 0, zap_total: 0, our_like: nil, our_boost: nil, our_zap: nil)
         let likedbar_ours = ActionBarModel(likes: 10, boosts: 0, zaps: 0, zap_total: 0, our_like: NostrEvent(id: "", content: "", pubkey: ""), our_boost: nil, our_zap: nil)
         let maxed_bar = ActionBarModel(likes: 999, boosts: 999, zaps: 999, zap_total: 99999999,  our_like: NostrEvent(id: "", content: "", pubkey: ""), our_boost: NostrEvent(id: "", content: "", pubkey: ""), our_zap: nil)
+        let extra_max_bar = ActionBarModel(likes: 9999, boosts: 9999, zaps: 9999, zap_total: 99999999,  our_like: NostrEvent(id: "", content: "", pubkey: ""), our_boost: NostrEvent(id: "", content: "", pubkey: ""), our_zap: nil)
+        let mega_max_bar = ActionBarModel(likes: 9999999, boosts: 99999, zaps: 9999, zap_total: 99999999,  our_like: NostrEvent(id: "", content: "", pubkey: ""), our_boost: NostrEvent(id: "", content: "", pubkey: ""), our_zap: nil)
         let zapbar = ActionBarModel(likes: 0, boosts: 0, zaps: 5, zap_total: 10000000, our_like: nil, our_boost: nil, our_zap: nil)
         
         VStack(spacing: 50) {
@@ -200,7 +202,11 @@ struct EventActionBar_Previews: PreviewProvider {
             EventActionBar(damus_state: ds, event: ev, bar: likedbar_ours)
             
             EventActionBar(damus_state: ds, event: ev, bar: maxed_bar)
+            
+            EventActionBar(damus_state: ds, event: ev, bar: extra_max_bar)
 
+            EventActionBar(damus_state: ds, event: ev, bar: mega_max_bar)
+            
             EventActionBar(damus_state: ds, event: ev, bar: zapbar, test_lnurl: "lnurl")
         }
         .padding(20)


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="72" alt="Screenshot 2023-02-15 at 10 10 42 PM" src="https://user-images.githubusercontent.com/264977/219286431-ba349a64-ec0b-41de-8f2b-0e0c03eb93aa.png"> | <img width="351" alt="Screenshot 2023-02-15 at 10 29 29 PM" src="https://user-images.githubusercontent.com/264977/219286462-16530d7b-8d5f-45e8-8b7e-6342fe8bd5ed.png"> |

