### PR TITLE
top-level tab state restoration

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -62,7 +62,7 @@ struct ContentView: View {
     @State var status: String = "Not connected"
     @State var active_sheet: Sheets? = nil
     @State var damus_state: DamusState? = nil
-    @State var selected_timeline: Timeline? = .home
+    @SceneStorage("ContentView.selected_timeline") var selected_timeline: Timeline = .home
     @State var is_deleted_account: Bool = false
     @State var is_profile_open: Bool = false
     @State var event: NostrEvent? = nil
@@ -76,7 +76,7 @@ struct ContentView: View {
     @State var confirm_mute: Bool = false
     @State var user_muted_confirm: Bool = false
     @State var confirm_overwrite_mutelist: Bool = false
-    @State var filter_state : FilterState = .posts_and_replies
+    @SceneStorage("ContentView.filter_state") var filter_state : FilterState = .posts_and_replies
     @State private var isSideBarOpened = false
     @StateObject var home: HomeModel = HomeModel()
     
@@ -180,9 +180,6 @@ struct ContentView: View {
                 
             case .dms:
                 DirectMessagesView(damus_state: damus_state!, model: damus_state!.dms, settings: damus_state!.settings)
-            
-            case .none:
-                EmptyView()
             }
         }
         .navigationBarTitle(timeline_name(selected_timeline), displayMode: .inline)

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -152,9 +152,6 @@ class UserSettingsStore: ObservableObject {
     
     @StringSetting(key: "friend_filter", default_value: .all)
     var friend_filter: FriendFilter
-    
-    @StringSetting(key: "notification_state", default_value: .all)
-    var notification_state: NotificationFilterState
 
     @StringSetting(key: "translation_service", default_value: .none)
     var translation_service: TranslationService

--- a/damus/Views/MainTabView.swift
+++ b/damus/Views/MainTabView.swift
@@ -37,7 +37,7 @@ func show_indicator(timeline: Timeline, current: NewEventsBits, indicator_settin
 struct TabButton: View {
     let timeline: Timeline
     let img: String
-    @Binding var selected: Timeline?
+    @Binding var selected: Timeline
     @Binding var new_events: NewEventsBits
     
     let settings: UserSettingsStore
@@ -75,7 +75,7 @@ struct TabButton: View {
 
 struct TabBar: View {
     @Binding var new_events: NewEventsBits
-    @Binding var selected: Timeline?
+    @Binding var selected: Timeline
     
     let settings: UserSettingsStore
     let action: (Timeline) -> ()


### PR DESCRIPTION
Before this change:
Every time the app launches, you are shown the Home tab and you're on Posts & Replies. What if I like to primarily use the app for DMs? Or what if I like to obsessively check my Notifications tab?

After this change:
The app will restore you to whichever of the four main tabs you were on last, and for the Home tab, it will also remember if you were on Posts or Posts & Replies.

Here it is opening directly to Notifications from a cold launch:

![restore](https://user-images.githubusercontent.com/445882/219655261-d7ab1250-fd8d-4f10-a9c7-2273c692f106.gif)
