### PR TITLE
code clean-up: @discardableResult, unused params, simplifications

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -328,7 +328,7 @@ struct ContentView: View {
                 PostView(replying_to: nil, references: [], damus_state: damus_state!)
             case .reply(let event):
                 ReplyView(replying_to: event, damus: damus_state!)
-            case .event(let event):
+            case .event:
                 EventDetailView()
             case .filter:
                 let timeline = selected_timeline ?? .home

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -471,12 +471,11 @@ class HomeModel: ObservableObject {
         }
     }
 
-    func insert_home_event(_ ev: NostrEvent) -> Bool {
+    func insert_home_event(_ ev: NostrEvent) {
         let ok = insert_uniq_sorted_event(events: &self.events, new_ev: ev, cmp: { $0.created_at > $1.created_at })
         if ok {
             handle_last_event(ev: ev, timeline: .home)
         }
-        return ok
     }
 
     func handle_text_event(sub_id: String, _ ev: NostrEvent) {
@@ -485,7 +484,7 @@ class HomeModel: ObservableObject {
         }
 
         if sub_id == home_subid {
-            let _ = insert_home_event(ev)
+            insert_home_event(ev)
         } else if sub_id == notifications_subid {
             handle_notification(ev: ev)
         }
@@ -657,14 +656,14 @@ func process_metadata_event(our_pubkey: String, profiles: Profiles, ev: NostrEve
     
     // load pfps asap
     let picture = tprof.profile.picture ?? robohash(ev.pubkey)
-    if let _ = URL(string: picture) {
+    if URL(string: picture) != nil {
         DispatchQueue.main.async {
             notify(.profile_updated, ProfileUpdate(pubkey: ev.pubkey, profile: profile))
         }
     }
     
     let banner = tprof.profile.banner ?? ""
-    if let _ = URL(string: banner) {
+    if URL(string: banner) != nil {
         DispatchQueue.main.async {
             notify(.profile_updated, ProfileUpdate(pubkey: ev.pubkey, profile: profile))
         }

--- a/damus/Models/ProfileModel.swift
+++ b/damus/Models/ProfileModel.swift
@@ -111,7 +111,7 @@ class ProfileModel: ObservableObject, Equatable {
             return
         }
         if ev.is_textlike || ev.known_kind == .boost {
-            let _ = insert_uniq_sorted_event(events: &self.events, new_ev: ev, cmp: { $0.created_at > $1.created_at})
+            insert_uniq_sorted_event(events: &self.events, new_ev: ev, cmp: { $0.created_at > $1.created_at})
         } else if ev.known_kind == .contacts {
             handle_profile_contact_event(ev)
         } else if ev.known_kind == .metadata {

--- a/damus/Models/SearchHomeModel.swift
+++ b/damus/Models/SearchHomeModel.swift
@@ -61,7 +61,7 @@ class SearchHomeModel: ObservableObject {
                 }
                 seen_pubkey.insert(ev.pubkey)
                 
-                let _ = insert_uniq_sorted_event(events: &events, new_ev: ev) {
+                insert_uniq_sorted_event(events: &events, new_ev: ev) {
                     $0.created_at > $1.created_at
                 }
             }

--- a/damus/Nostr/ProofOfWork.swift
+++ b/damus/Nostr/ProofOfWork.swift
@@ -72,7 +72,7 @@ func char_to_hex(_ c: UInt8) -> UInt8?
     return nil;
 }
 
-
+@discardableResult
 func hex_decode(_ str: String) -> [UInt8]?
 {
     if str.count == 0 {

--- a/damus/Nostr/RelayPool.swift
+++ b/damus/Nostr/RelayPool.swift
@@ -195,27 +195,13 @@ class RelayPool {
             relay.connection.send(req)
         }
     }
-
+    
     func get_relays(_ ids: [String]) -> [Relay] {
-        var relays: [Relay] = []
-
-        for id in ids {
-            if let relay = get_relay(id) {
-                relays.append(relay)
-            }
-        }
-
-        return relays
+        relays.filter { ids.contains($0.id) }
     }
-
+    
     func get_relay(_ id: String) -> Relay? {
-        for relay in relays {
-            if relay.id == id {
-                return relay
-            }
-        }
-
-        return nil
+        relays.first(where: { $0.id == id })
     }
     
     func record_last_pong(relay_id: String, event: NostrConnectionEvent) {

--- a/damus/Util/Bech32.swift
+++ b/damus/Util/Bech32.swift
@@ -143,6 +143,7 @@ func eightToFiveBits(_ input: [UInt8]) -> [UInt8] {
 }
     
     /// Decode Bech32 string
+@discardableResult
 public func bech32_decode(_ str: String) throws -> (hrp: String, data: Data)? {
     guard let strBytes = str.data(using: .utf8) else {
         throw Bech32Error.nonUTF8String

--- a/damus/Util/InsertSort.swift
+++ b/damus/Util/InsertSort.swift
@@ -38,6 +38,7 @@ func insert_uniq_by_pubkey(events: inout [NostrEvent], new_ev: NostrEvent, cmp: 
     return true
 }
 
+@discardableResult
 func insert_uniq_sorted_zap(zaps: inout [Zap], new_zap: Zap) -> Bool {
     var i: Int = 0
     
@@ -58,6 +59,7 @@ func insert_uniq_sorted_zap(zaps: inout [Zap], new_zap: Zap) -> Bool {
     return true
 }
 
+@discardableResult
 func insert_uniq_sorted_event(events: inout [NostrEvent], new_ev: NostrEvent, cmp: (NostrEvent, NostrEvent) -> Bool) -> Bool {
     var i: Int = 0
     

--- a/damus/Util/Zaps.swift
+++ b/damus/Util/Zaps.swift
@@ -36,7 +36,7 @@ class Zaps {
                 if our_zaps[note_target.note_id] == nil {
                     our_zaps[note_target.note_id] = [zap]
                 } else {
-                    let _ = insert_uniq_sorted_zap(zaps: &(our_zaps[note_target.note_id]!), new_zap: zap)
+                    insert_uniq_sorted_zap(zaps: &(our_zaps[note_target.note_id]!), new_zap: zap)
                 }
             case .profile(_):
                 break
@@ -61,7 +61,5 @@ class Zaps {
         event_totals[id] = event_totals[id]! + zap.invoice.amount
         
         notify(.update_stats, zap.target.id)
-        
-        return
     }
 }

--- a/damus/Views/Relays/RelayConfigView.swift
+++ b/damus/Views/Relays/RelayConfigView.swift
@@ -22,9 +22,8 @@ struct RelayConfigView: View {
     
     var recommended: [RelayDescriptor] {
         let rs: [RelayDescriptor] = []
-        return BOOTSTRAP_RELAYS.reduce(into: rs) { (xs, x) in
-            if let _ = state.pool.get_relay(x) {
-            } else {
+        return BOOTSTRAP_RELAYS.reduce(into: rs) { xs, x in
+            if state.pool.get_relay(x) == nil {
                 xs.append(RelayDescriptor(url: URL(string: x)!, info: .rw))
             }
         }

--- a/damus/Views/SearchResultsView.swift
+++ b/damus/Views/SearchResultsView.swift
@@ -95,20 +95,20 @@ struct SearchResultsView: View {
             return
         }
         
-        if let _ = hex_decode(new), new.count == 64 {
+        if hex_decode(new) != nil, new.count == 64 {
             self.result = .hex(new)
             return
         }
         
         if new.starts(with: "npub") {
-            if let _ = try? bech32_decode(new) {
+            if (try? bech32_decode(new)) != nil {
                 self.result = .profile(new)
                 return
             }
         }
         
         if new.starts(with: "note") {
-            if let _ = try? bech32_decode(new) {
+            if (try? bech32_decode(new)) != nil {
                 self.result = .note(new)
                 return
             }


### PR DESCRIPTION
Minor code clean-ups:

`let _ = ...`
Use `@discardableResult` to let the compiler know you might not need the result, or check `result != nil` for easier readability with the same meaning.

Use `Array.first(where:)` and `Array.filter(:)` to select items from an array, rather than looping through, for better readability and faster lookups.