### PR TITLE
refactor similar RepostsModel and ReactionsModel into one parent class

### DIFF
--- a/damus/Models/EventsModel.swift
+++ b/damus/Models/EventsModel.swift
@@ -9,9 +9,63 @@ import Foundation
 
 
 class EventsModel: ObservableObject {
-    var has_event: Set<String> = Set()
+    let state: DamusState
+    let target: String
+    let kind: NostrKind
+    let sub_id = UUID().uuidString
+    let profiles_id = UUID().uuidString
+    
     @Published var events: [NostrEvent] = []
     
-    init() {
+    init(state: DamusState, target: String, kind: NostrKind) {
+        self.state = state
+        self.target = target
+        self.kind = kind
+    }
+    
+    private func get_filter() -> NostrFilter {
+        var filter = NostrFilter.filter_kinds([kind.rawValue])
+        filter.referenced_ids = [target]
+        filter.limit = 500
+        return filter
+    }
+    
+    func subscribe() {
+        state.pool.subscribe(sub_id: sub_id,
+                             filters: [get_filter()],
+                             handler: handle_nostr_event)
+    }
+    
+    func unsubscribe() {
+        state.pool.unsubscribe(sub_id: sub_id)
+    }
+    
+    private func handle_event(relay_id: String, ev: NostrEvent) {
+        guard ev.kind == kind.rawValue else {
+            return
+        }
+        
+        guard last_etag(tags: ev.tags) == target else {
+            return
+        }
+        
+        if insert_uniq_sorted_event(events: &self.events, new_ev: ev, cmp: { a, b in a.created_at < b.created_at } ) {
+            objectWillChange.send()
+        }
+    }
+    
+    func handle_nostr_event(relay_id: String, ev: NostrConnectionEvent) {
+        guard case .nostr_event(let nev) = ev else {
+            return
+        }
+        
+        switch nev {
+        case .event(_, let ev):
+            handle_event(relay_id: relay_id, ev: ev)
+        case .notice(_):
+            break
+        case .eose(_):
+            load_profiles(profiles_subid: profiles_id, relay_id: relay_id, events: events, damus_state: state)
+        }
     }
 }

--- a/damus/Models/ReactionsModel.swift
+++ b/damus/Models/ReactionsModel.swift
@@ -8,71 +8,9 @@
 import Foundation
 
 
-class ReactionsModel: ObservableObject {
-    let state: DamusState
-    let target: String
-    let sub_id: String
-    let profiles_id: String
+final class ReactionsModel: EventsModel {
     
-    @Published var reactions: [NostrEvent]
-    
-    init (state: DamusState, target: String) {
-        self.state = state
-        self.target = target
-        self.sub_id = UUID().description
-        self.profiles_id = UUID().description
-        self.reactions = []
-    }
-    
-    func get_filter() -> NostrFilter {
-        var filter = NostrFilter.filter_kinds([7])
-        filter.referenced_ids = [target]
-        filter.limit = 500
-        return filter
-    }
-    
-    func subscribe() {
-        let filter = get_filter()
-        let filters = [filter]
-        self.state.pool.subscribe(sub_id: sub_id, filters: filters, handler: handle_nostr_event)
-    }
-    
-    func unsubscribe() {
-        self.state.pool.unsubscribe(sub_id: sub_id)
-    }
-    
-    func handle_event(relay_id: String, ev: NostrEvent) {
-        guard ev.kind == 7 else {
-            return
-        }
-        
-        guard let reacted_to = last_etag(tags: ev.tags) else {
-            return
-        }
-        
-        guard reacted_to == self.target else {
-            return
-        }
-        
-        if insert_uniq_sorted_event(events: &self.reactions, new_ev: ev, cmp: { a, b in a.created_at < b.created_at } ) {
-            objectWillChange.send()
-        }
-    }
-    
-    func handle_nostr_event(relay_id: String, ev: NostrConnectionEvent) {
-        guard case .nostr_event(let nev) = ev else {
-            return
-        }
-        
-        switch nev {
-        case .event(_, let ev):
-            handle_event(relay_id: relay_id, ev: ev)
-            
-        case .notice(_):
-            break
-        case .eose(_):
-            load_profiles(profiles_subid: profiles_id, relay_id: relay_id, events: reactions, damus_state: state)
-            break
-        }
+    init(state: DamusState, target: String) {
+        super.init(state: state, target: target, kind: .like)
     }
 }

--- a/damus/Models/RepostsModel.swift
+++ b/damus/Models/RepostsModel.swift
@@ -7,71 +7,9 @@
 
 import Foundation
 
-class RepostsModel: ObservableObject {
-    let state: DamusState
-    let target: String
-    let sub_id: String
-    let profiles_id: String
-
-    @Published var reposts: [NostrEvent]
-
-    init (state: DamusState, target: String) {
-        self.state = state
-        self.target = target
-        self.sub_id = UUID().description
-        self.profiles_id = UUID().description
-        self.reposts = []
-    }
-
-    func get_filter() -> NostrFilter {
-        var filter = NostrFilter.filter_kinds([NostrKind.boost.rawValue])
-        filter.referenced_ids = [target]
-        filter.limit = 500
-        return filter
-    }
-
-    func subscribe() {
-        let filter = get_filter()
-        let filters = [filter]
-        self.state.pool.subscribe(sub_id: sub_id, filters: filters, handler: handle_nostr_event)
-    }
-
-    func unsubscribe() {
-        self.state.pool.unsubscribe(sub_id: sub_id)
-    }
-
-    func handle_event(relay_id: String, ev: NostrEvent) {
-        guard ev.kind == NostrKind.boost.rawValue else {
-            return
-        }
-
-        guard let reposted_event = last_etag(tags: ev.tags) else {
-            return
-        }
-
-        guard reposted_event == self.target else {
-            return
-        }
-
-        if insert_uniq_sorted_event(events: &self.reposts, new_ev: ev, cmp: { a, b in a.created_at < b.created_at } ) {
-            objectWillChange.send()
-        }
-    }
-
-    func handle_nostr_event(relay_id: String, ev: NostrConnectionEvent) {
-        guard case .nostr_event(let nev) = ev else {
-            return
-        }
-
-        switch nev {
-        case .event(_, let ev):
-            handle_event(relay_id: relay_id, ev: ev)
-
-        case .notice(_):
-            break
-        case .eose(_):
-            load_profiles(profiles_subid: profiles_id, relay_id: relay_id, events: reposts, damus_state: state)
-            break
-        }
+final class RepostsModel: EventsModel {
+    
+    init(state: DamusState, target: String) {
+        super.init(state: state, target: target, kind: .boost)
     }
 }

--- a/damus/Views/ReactionsView.swift
+++ b/damus/Views/ReactionsView.swift
@@ -14,7 +14,7 @@ struct ReactionsView: View {
     var body: some View {
         ScrollView {
             LazyVStack {
-                ForEach(model.reactions, id: \.id) { ev in
+                ForEach(model.events, id: \.id) { ev in
                     ReactionView(damus_state: damus_state, reaction: ev)
                 }
             }

--- a/damus/Views/RepostsView.swift
+++ b/damus/Views/RepostsView.swift
@@ -14,7 +14,7 @@ struct RepostsView: View {
     var body: some View {
         ScrollView {
             LazyVStack {
-                ForEach(model.reposts, id: \.id) { ev in
+                ForEach(model.events, id: \.id) { ev in
                     RepostView(damus_state: damus_state, repost: ev)
                 }
             }


### PR DESCRIPTION
`ReactionsModel` and `RepostsModel` had 99% the same code, so I refactored it into a common parent class where you can specify the `NostrKind`. I found an unused class called `EventsModel` which seemed like an apt name, so I used that for the parent class. Can rename it if that isn't clear or accurate enough or you don't like it.

Verified that the `RepostsView` and `ReactionsView` still function as expected.