### PR TITLE
Fix profile banner blocking touch in horizontal orientation

### DIFF
--- a/damus/Views/ProfileView.swift
+++ b/damus/Views/ProfileView.swift
@@ -156,6 +156,7 @@ struct ProfileView: View {
 
         }
         .frame(height: bannerHeight)
+        .allowsHitTesting(false)
     }
     
     var navbarHeight: CGFloat {


### PR DESCRIPTION
The frame of the clipped banner view is incorrect in the horizontal orientation and is blocking touches to views under it. I haven't figured out how to solve the frame size yet but this should be a sufficient fix for now.

Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/19398259/219968294-2d3e9452-0c83-4712-8df9-b498c0da1634.mov) | ![](https://user-images.githubusercontent.com/19398259/219968315-3ee2bb80-fbb2-4b15-86d3-d9337ccd5139.mov)




