### PR TITLE
Search by QR code

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		7C902AE32981D55B002AB16E /* ZoomableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C902AE22981D55B002AB16E /* ZoomableScrollView.swift */; };
 		7C95CAEE299DCEF1009DCB67 /* KFOptionSetter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */; };
 		7CFF6317299FEFE5005D382A /* SelectableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFF6316299FEFE5005D382A /* SelectableText.swift */; };
+		83952EF829A5842900A695C3 /* QRCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83952EF729A5842900A695C3 /* QRCaptureView.swift */; };
 		9609F058296E220800069BF3 /* BannerImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609F057296E220800069BF3 /* BannerImageView.swift */; };
 		BA693074295D649800ADDB87 /* UserSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA693073295D649800ADDB87 /* UserSettingsStore.swift */; };
 		BAB68BED29543FA3007BA466 /* SelectWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */; };
@@ -533,6 +534,7 @@
 		7C902AE22981D55B002AB16E /* ZoomableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableScrollView.swift; sourceTree = "<group>"; };
 		7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KFOptionSetter+.swift"; sourceTree = "<group>"; };
 		7CFF6316299FEFE5005D382A /* SelectableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableText.swift; sourceTree = "<group>"; };
+		83952EF729A5842900A695C3 /* QRCaptureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCaptureView.swift; sourceTree = "<group>"; };
 		9609F057296E220800069BF3 /* BannerImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerImageView.swift; sourceTree = "<group>"; };
 		BA693073295D649800ADDB87 /* UserSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsStore.swift; sourceTree = "<group>"; };
 		BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectWalletView.swift; sourceTree = "<group>"; };
@@ -754,6 +756,7 @@
 				3AA247FE297E3D900090C62D /* RepostsView.swift */,
 				5C513FCB2984ACA60072348F /* QRCodeView.swift */,
 				643EA5C7296B764E005081BB /* RelayFilterView.swift */,
+				83952EF729A5842900A695C3 /* QRCaptureView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1346,6 +1349,7 @@
 				4C8682872814DE470026224F /* ProfileView.swift in Sources */,
 				4C5F9114283D694D0052CD1C /* FollowTarget.swift in Sources */,
 				4CF0ABD629817F5B00D66079 /* ReportView.swift in Sources */,
+				83952EF829A5842900A695C3 /* QRCaptureView.swift in Sources */,
 				4CB8838629656C8B00DC99E7 /* NIP05.swift in Sources */,
 				4CF0ABD82981980C00D66079 /* Lists.swift in Sources */,
 				4C5C7E6A284EDE2E00A22DF5 /* SearchResultsView.swift in Sources */,

--- a/damus/Info.plist
+++ b/damus/Info.plist
@@ -31,6 +31,8 @@
 		<string>walletofsatoshi</string>
 		<string>blixtwallet</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Camera access required to scan QR codes</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/damus/Views/QRCaptureView.swift
+++ b/damus/Views/QRCaptureView.swift
@@ -1,0 +1,171 @@
+//
+//  QRCaptureView.swift
+//  damus
+//
+//  Created by hazeycode on 21/02/2023.
+//
+
+import SwiftUI
+import UIKit
+import AVFoundation
+
+private var delegate = QrCaptureDelegate()
+
+struct QRCaptureView: View {
+    let onCapture: (String) -> Void
+    
+    @Environment(\.dismiss) var dismiss
+    @Environment(\.presentationMode) var presentationMode
+    @State var torchOn = false
+    
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            QrCaptureViewRepresentable()
+                .capture(onCapture)
+                .torchLight(isOn: torchOn)
+            
+            HStack{
+                Button {
+                    presentationMode.wrappedValue.dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .foregroundColor(.white)
+                        .font(.subheadline)
+                        .padding(.top, 20)
+                        .padding(.leading, 20)
+                }
+                Spacer()
+                Button(action: {
+                    torchOn.toggle()
+                }, label: {
+                    Image(systemName: torchOn ? "lightbulb.fill" : "lightbulb.slash")
+                        .foregroundColor(Color.white)
+                        .font(.subheadline)
+                        .padding(.top, 20)
+                        .padding(.trailing, 20)
+                        .background(Color.clear)
+                })
+            }
+        }
+        .modifier(SwipeToDismissModifier(minDistance: nil, onDismiss: {
+            presentationMode.wrappedValue.dismiss()
+        }))
+    }
+}
+
+struct QrCaptureViewRepresentable: UIViewRepresentable {
+    
+    typealias UIViewType = CameraPreview
+    
+    private let session = AVCaptureSession()
+    private let metadataOutput = AVCaptureMetadataOutput()
+    
+    func capture(_ onCapture: @escaping (String) -> Void) -> QrCaptureViewRepresentable {
+        delegate.onCapture = onCapture
+        return self
+    }
+    
+    func torchLight(isOn: Bool) -> QrCaptureViewRepresentable {
+        if let backCamera = AVCaptureDevice.default(for: AVMediaType.video) {
+            if backCamera.hasTorch {
+                try? backCamera.lockForConfiguration()
+                if isOn {
+                    backCamera.torchMode = .on
+                } else {
+                    backCamera.torchMode = .off
+                }
+                backCamera.unlockForConfiguration()
+            }
+        }
+        return self
+    }
+    
+    func makeUIView(context: UIViewRepresentableContext<QrCaptureViewRepresentable>) -> QrCaptureViewRepresentable.UIViewType {
+        let cameraView = CameraPreview(session: session)
+        
+        #if targetEnvironment(simulator)
+        cameraView.createSimulatorView()
+        #else
+        let previewLayer = AVCaptureVideoPreviewLayer(session: session)
+        previewLayer.videoGravity = .resizeAspectFill
+        cameraView.layer.addSublayer(previewLayer)
+        cameraView.previewLayer = previewLayer
+        if AVCaptureDevice.authorizationStatus(for: .video) != .authorized {
+            AVCaptureDevice.requestAccess(for: .video) { _ in }
+        }
+        if let backCamera = AVCaptureDevice.default(for: AVMediaType.video) {
+            if let input = try? AVCaptureDeviceInput(device: backCamera) {
+                session.addInput(input)
+                session.addOutput(metadataOutput)
+                metadataOutput.metadataObjectTypes = [
+                    AVMetadataObject.ObjectType.qr
+                ]
+                metadataOutput.setMetadataObjectsDelegate(delegate, queue: DispatchQueue.main)
+                DispatchQueue.global(qos: .background).async {
+                    session.startRunning()
+                }
+            }
+        }
+        #endif
+        
+        return cameraView
+    }
+    
+    func dismantleUIView(_ uiView: CameraPreview, coordinator: ()) {
+        uiView.session.stopRunning()
+    }
+    
+    func updateUIView(_ uiView: CameraPreview, context: UIViewRepresentableContext<QrCaptureViewRepresentable>) {
+    }
+}
+
+class CameraPreview: UIView {
+        
+    var previewLayer: AVCaptureVideoPreviewLayer?
+    var session = AVCaptureSession()
+    
+    init(session: AVCaptureSession) {
+        super.init(frame: .zero)
+        self.session = session
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func createSimulatorView(){
+        self.backgroundColor = UIColor.black
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(onTap))
+        self.addGestureRecognizer(gesture)
+    }
+    
+    @objc func onTap() {
+        delegate.onCapture("npub1h77jdhr42sx9a697prc0ltepjx5scclr0nsxvsfdyhx055gyuucq8gytje")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        #if !targetEnvironment(simulator)
+            previewLayer?.frame = self.bounds
+        #endif
+    }
+}
+
+class QrCaptureDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate {
+    
+    var onCapture: (String) -> Void = { _  in }
+    
+    func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
+        if let metadataObject = metadataObjects.first {
+            guard let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject else { return }
+            guard let stringValue = readableObject.stringValue else { return }
+            self.onCapture(stringValue)
+        }
+    }
+}
+
+struct QRCaptureView_Previews: PreviewProvider {
+    static var previews: some View {
+        QRCaptureView(onCapture: { code in })
+    }
+}

--- a/damus/Views/SearchHomeView.swift
+++ b/damus/Views/SearchHomeView.swift
@@ -12,6 +12,7 @@ struct SearchHomeView: View {
     let damus_state: DamusState
     @StateObject var model: SearchHomeModel
     @State var search: String = ""
+    @State private var showQRCapture = false
     
     var SearchInput: some View {
         ZStack(alignment: .leading) {
@@ -26,12 +27,28 @@ struct SearchHomeView: View {
                     .padding(EdgeInsets(top: 0.0, leading: 0.0, bottom: 0.0, trailing: 10.0))
                     .opacity((search == "") ? 0.0 : 1.0)
                     .onTapGesture {
-                        self.search = ""
+                        search = ""
                     }
             }
                 
             Label("", systemImage: "magnifyingglass")
                 .padding(.leading, 10)
+            
+            if (search.isEmpty) {
+                Button(action: {
+                    showQRCapture.toggle()
+                }, label: {
+                    Label("", systemImage: "qrcode")
+                        .font(.title)
+                })
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .fullScreenCover(isPresented: $showQRCapture) {
+                    QRCaptureView(onCapture: { code in
+                        search = code
+                        showQRCapture = false
+                    });
+                }
+            }
         }
         .background {
             RoundedRectangle(cornerRadius: 8)


### PR DESCRIPTION
Added QR capture functionality, accessible from the SearchHomeView.

- Tap the purple QR button to bring up the capture view (requests camera access)
- When a QR code is captured the view will be dismissed and the search field will simply be populated with the string
- Toggle the device flashlight by tapping the button in the top right of the capture view
- The capture view may be dismissed by swiping it or by tapping the X in the top left of the capture view

![IMG_59D6EE0ADF52-1](https://user-images.githubusercontent.com/22148308/220623519-27542b74-7c04-4d7f-a58b-3913ac1aa376.jpeg)
