### PR TITLE
move misplaced error log statement

### DIFF
--- a/damus/Nostr/RelayConnection.swift
+++ b/damus/Nostr/RelayConnection.swift
@@ -96,18 +96,20 @@ final class RelayConnection: WebSocketDelegate {
                             self.handleEvent(.nostr_event(ev))
                         }
                         return
+                    } else {
+                        print("decode failed for \(txt)")
+                        // TODO: trigger event error
                     }
                 }
             } else {
                 if let ev = decode_nostr_event(txt: txt) {
                     handleEvent(.nostr_event(ev))
-                    return
+                } else {
+                    print("decode failed for \(txt)")
+                    // TODO: trigger event error
                 }
             }
-
-            print("decode failed for \(txt)")
-            // TODO: trigger event error
-
+            
         default:
             break
         }


### PR DESCRIPTION
Before this change:
A log statement of "decode failed for ..." was repeatedly logged to the console, causing me to think there was a parsing problem for events. I started trying to debug that issue.

It turned out that it was just that the log statement was misplaced. It was being shown for every event over 2000 characters, because they were being sent to a background thread for decoding.

After this change:
The log statement is in the correct place, and it only shows in the console when there is actually a failure to decode an event.