### PR TITLE
Add options for event validation levels

### DIFF
--- a/damus/Models/EventValidation.swift
+++ b/damus/Models/EventValidation.swift
@@ -1,0 +1,38 @@
+//
+//  EventValidation.swift
+//  damus
+//
+//  Created by Jonathan on 2/22/23.
+//
+
+import Foundation
+
+enum EventValidation: String, CaseIterable, Identifiable {
+    var id: String { self.rawValue }
+    
+    struct Model: Identifiable, Hashable {
+        var id: String { self.tag }
+        var index: Int
+        var tag: String
+        var displayName : String
+    }
+    
+    case none
+    case subscribed
+    case all
+    
+    var model: Model {
+        switch self {
+        case .none:
+            return .init(index: -1, tag: "none", displayName: NSLocalizedString("None", comment: "None, not a single one"))
+        case .subscribed:
+            return .init(index: 1, tag: "subscribed", displayName: NSLocalizedString("People you follow", comment: "Only the notes from the people you follow"))
+        case .all:
+            return .init(index: 2, tag: "all", displayName: NSLocalizedString("All", comment: "Every single one"))
+        }
+    }
+    
+    static var allModels: [Model] {
+        return Self.allCases.map { $0.model }
+    }
+}

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -159,6 +159,12 @@ class UserSettingsStore: ObservableObject {
             }
         }
     }
+    
+    @Published var event_validation: EventValidation {
+        didSet {
+            UserDefaults.standard.set(event_validation.rawValue, forKey: "event_validation")
+        }
+    }
 
     init() {
         // TODO: pubkey-scoped settings
@@ -206,6 +212,8 @@ class UserSettingsStore: ObservableObject {
         } catch {
             deepl_api_key = ""
         }
+        
+        event_validation = UserDefaults.standard.object(forKey: "event_validation") as? EventValidation ?? .none
     }
 
     private func saveLibreTranslateApiKey(_ apiKey: String) throws {

--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -203,6 +203,15 @@ struct ConfigView: View {
                     Toggle(NSLocalizedString("Left Handed", comment: "Moves the post button to the left side of the screen"), isOn: $settings.left_handed)
                         .toggleStyle(.switch)
                 }
+                
+                Section(NSLocalizedString("Event Validation", comment: "Section title for validating events, where events are Nostr events and validation is proving the signature cryptographically correct")) {
+                    Picker(NSLocalizedString("Validation", comment: "Picker title for setting to validate Nostr events"), selection: $settings.event_validation) {
+                        ForEach(EventValidation.allCases, id: \.self) { validation in
+                            Text(validation.model.displayName)
+                                .tag(validation.model.tag)
+                        }
+                    }
+                }
 
                 Section(NSLocalizedString("Clear Cache", comment: "Section title for clearing cached data.")) {
                     Button(NSLocalizedString("Clear", comment: "Button for clearing cached data.")) {


### PR DESCRIPTION
The user now has the option for how many events they want to validate in a trade off between required CPU power and security.