### PR TITLE
Lazy loading of thread child events

### DIFF
--- a/damus/Views/ThreadV2View.swift
+++ b/damus/Views/ThreadV2View.swift
@@ -289,15 +289,17 @@ struct ThreadV2View: View {
                     ).id("main")
                     
                     // MARK: - Responses of the actual event view
-                    ForEach(thread.childEvents, id: \.id) { event in
-                        MutedEventView(
-                            damus_state: damus,
-                            event: event,
-                            scroller: reader,
-                            nav_target: $nav_target,
-                            navigating: $navigating,
-                            selected: false
-                        )
+                    LazyVStack {
+                        ForEach(thread.childEvents, id: \.id) { event in
+                            MutedEventView(
+                                damus_state: damus,
+                                event: event,
+                                scroller: nil,
+                                nav_target: $nav_target,
+                                navigating: $navigating,
+                                selected: false
+                            )
+                        }
                     }
                 }.padding()
             }.navigationBarTitle(NSLocalizedString("Thread", comment: "Navigation bar title for note thread."))


### PR DESCRIPTION
This change should significantly improve performance on long threads. `note1e0ycd4q5njfxhnhz64q3t0xzrs3lmmxlnnzk9tf27faxdkc8z7nsx53x4r` may help with testing

### Before
![Screenshot 2023-02-22 at 6 46 47 PM](https://user-images.githubusercontent.com/19398259/220789643-3a7a65e4-faf2-41ae-8048-17196436cc8f.png)

### After
![Screenshot 2023-02-22 at 7 08 54 PM](https://user-images.githubusercontent.com/19398259/220792580-c6719e2a-e098-482e-8b93-d59db80f3ed5.png)
