### PR TITLE
Wrap event profile display name

### DIFF
--- a/damus/Views/ProfileName.swift
+++ b/damus/Views/ProfileName.swift
@@ -134,11 +134,13 @@ struct EventProfileName: View {
             if let real_name = profile?.display_name {
                 Text(real_name)
                     .font(.body.weight(.bold))
-                    .padding([.trailing], 2)
                 
-                Text(verbatim: "@\(display_name ?? Profile.displayName(profile: profile, pubkey: pubkey))")
+                + Text(real_name.isEmpty ? "" : " ")
+
+                + Text(verbatim: "@\(display_name ?? Profile.displayName(profile: profile, pubkey: pubkey))")
                     .foregroundColor(Color("DamusMediumGrey"))
                     .font(eventviewsize_to_font(size))
+                
             } else {
                 Text(verbatim: "\(display_name ?? Profile.displayName(profile: profile, pubkey: pubkey))")
                     .font(eventviewsize_to_font(size))


### PR DESCRIPTION
Long display name and username separated by new line

Before             |  After
:-------------------------:|:-------------------------:
![IMG_4950](https://user-images.githubusercontent.com/19398259/221699658-614465b3-4712-49b5-a6f7-046d6a774970.jpg) | ![IMG_4948](https://user-images.githubusercontent.com/19398259/221699696-a28ba0c4-ac44-4f7b-af86-00fa78035821.jpg)

Short display name and username stay on the same line

Before             |  After
:-------------------------:|:-------------------------:
![IMG_4951](https://user-images.githubusercontent.com/19398259/221700142-3b5cd15e-140d-48b0-b269-1c82ad4eeb7a.jpg) | ![IMG_4952](https://user-images.githubusercontent.com/19398259/221700223-4f513e5d-a427-4bd9-9525-8d8028a8c504.jpg)


