### PR TITLE
Add option to disable image animation

### DIFF
--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Vault
+import UIKit
 
 func should_show_wallet_selector(_ pubkey: String) -> Bool {
     return UserDefaults.standard.object(forKey: "show_wallet_selector") as? Bool ?? true
@@ -34,6 +35,10 @@ func get_default_zap_amount(pubkey: String) -> Int? {
     return amt
 }
 
+func should_disable_image_animation() -> Bool {
+    return (UserDefaults.standard.object(forKey: "disable_animation") as? Bool)
+            ?? UIAccessibility.isReduceMotionEnabled
+ }
 
 func get_default_wallet(_ pubkey: String) -> Wallet {
     if let defaultWalletName = UserDefaults.standard.string(forKey: "default_wallet"),
@@ -159,6 +164,12 @@ class UserSettingsStore: ObservableObject {
             }
         }
     }
+    
+    @Published var disable_animation: Bool {
+        didSet {
+            UserDefaults.standard.set(disable_animation, forKey: "disable_animation")
+        }
+     }
 
     init() {
         // TODO: pubkey-scoped settings
@@ -167,6 +178,7 @@ class UserSettingsStore: ObservableObject {
         show_wallet_selector = should_show_wallet_selector(pubkey)
 
         left_handed = UserDefaults.standard.object(forKey: "left_handed") as? Bool ?? false
+        disable_animation = should_disable_image_animation()
 
         // Note from @tyiu:
         // Default translation service is disabled by default for now until we gain some confidence that it is working well in production.

--- a/damus/Util/KFOptionSetter+.swift
+++ b/damus/Util/KFOptionSetter+.swift
@@ -17,6 +17,7 @@ extension KFOptionSetter {
         options.backgroundDecode = true
         options.cacheOriginalImage = true
         options.scaleFactor = UIScreen.main.scale
+        options.onlyLoadFirstFrame = should_disable_image_animation()
         
         options.processor = CustomImageProcessor(
             maxSize: imageContext.maxMebibyteSize(),

--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -192,11 +192,15 @@ struct ConfigView: View {
                         .toggleStyle(.switch)
                 }
 
-                Section(NSLocalizedString("Clear Cache", comment: "Section title for clearing cached data.")) {
-                    Button(NSLocalizedString("Clear", comment: "Button for clearing cached data.")) {
-                        KingfisherManager.shared.cache.clearMemoryCache()
-                        KingfisherManager.shared.cache.clearDiskCache()
-                        KingfisherManager.shared.cache.cleanExpiredDiskCache()
+                Section(NSLocalizedString("Images", comment: "Section title for images configuration.")) {
+                    Toggle(NSLocalizedString("Disable animations", comment: "Button to disable image animation"), isOn: $settings.disable_animation)
+                        .toggleStyle(.switch)
+                        .onChange(of: settings.disable_animation) { _ in
+                            clear_kingfisher_cache()
+                        }
+
+                    Button(NSLocalizedString("Clear Cache", comment: "Button to clear image cache.")) {
+                        clear_kingfisher_cache()
                     }
                 }
 
@@ -348,4 +352,10 @@ func handle_string_amount(new_value: String) -> Int? {
     }
     
     return amt
+}
+
+func clear_kingfisher_cache() -> Void {
+    KingfisherManager.shared.cache.clearMemoryCache()
+    KingfisherManager.shared.cache.clearDiskCache()
+    KingfisherManager.shared.cache.cleanExpiredDiskCache()
 }


### PR DESCRIPTION
Ref: #666 

The option to disable animated images defaults to `UIAccessibility.isReduceMotionEnabled`. 

![IMG_4962](https://user-images.githubusercontent.com/19398259/221965547-b6e4c622-5c32-42fd-8b57-e52694616049.jpg)

