### PR TITLE
Truncate long notes

### DIFF
--- a/damus/Views/ChatView.swift
+++ b/damus/Views/ChatView.swift
@@ -113,7 +113,8 @@ struct ChatView: View {
                                     event: event,
                                     show_images: show_images,
                                     size: .normal,
-                                    artifacts: .just_content(event.content))
+                                    artifacts: .just_content(event.content),
+                                    truncate: false)
 
                     if is_active || next_ev == nil || next_ev!.pubkey != event.pubkey {
                         let bar = make_actionbar_model(ev: event.id, damus: damus_state)

--- a/damus/Views/DMView.swift
+++ b/damus/Views/DMView.swift
@@ -23,7 +23,7 @@ struct DMView: View {
 
             let should_show_img = should_show_images(contacts: damus_state.contacts, ev: event, our_pubkey: damus_state.pubkey)
 
-            NoteContentView(damus_state: damus_state, event: event, show_images: should_show_img, size: .normal, artifacts: .just_content(event.get_content(damus_state.keypair.privkey)))
+            NoteContentView(damus_state: damus_state, event: event, show_images: should_show_img, size: .normal, artifacts: .just_content(event.get_content(damus_state.keypair.privkey)), truncate: false)
                 .foregroundColor(is_ours ? Color.white : Color.primary)
                 .padding(10)
                 .background(is_ours ? Color.accentColor : Color.secondary.opacity(0.15))

--- a/damus/Views/Events/EventBody.swift
+++ b/damus/Views/Events/EventBody.swift
@@ -29,7 +29,7 @@ struct EventBody: View {
             ReplyDescription(event: event, profiles: damus_state.profiles)
         }
 
-        NoteContentView(damus_state: damus_state, event: event, show_images: should_show_img, size: size, artifacts: .just_content(content))
+        NoteContentView(damus_state: damus_state, event: event, show_images: should_show_img, size: size, artifacts: .just_content(content), truncate: true)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 }


### PR DESCRIPTION
Ref: #410 

In addition to the visual improvement, this fixes scrolling hitches caused by loading long notes. 

Before             |  After
:-------------------------:|:-------------------------:
![IMG_4971](https://user-images.githubusercontent.com/19398259/222048863-7c3e4cd4-02c5-4cc8-aa88-07d997d64551.jpg) | ![IMG_4973](https://user-images.githubusercontent.com/19398259/222048893-2f3dc6b6-8aeb-4b2b-a18c-6c97993fae32.jpg)

Before             |  After
:-------------------------:|:-------------------------:
![IMG_4972](https://user-images.githubusercontent.com/19398259/222049005-fac8d2f3-0083-4c0c-8e13-ae12b5e3bcc8.jpg) | ![IMG_4974](https://user-images.githubusercontent.com/19398259/222049028-4ba2fd28-e171-4a78-9b62-ab0e0c9339ac.jpg)
