### PR TITLE
Private Zaps

### DIFF
--- a/damus/Components/ZapButton.swift
+++ b/damus/Components/ZapButton.swift
@@ -138,7 +138,7 @@ struct ZapButton_Previews: PreviewProvider {
 
 
 func send_zap(damus_state: DamusState, event: NostrEvent, lnurl: String, is_custom: Bool, comment: String?, amount_sats: Int?, zap_type: ZapType) {
-    guard let privkey = damus_state.keypair.privkey else {
+    guard let keypair = damus_state.keypair.to_full() else {
         return
     }
     
@@ -146,7 +146,8 @@ func send_zap(damus_state: DamusState, event: NostrEvent, lnurl: String, is_cust
     let relays = Array(damus_state.pool.descriptors.prefix(10))
     let target = ZapTarget.note(id: event.id, author: event.pubkey)
     let content = comment ?? ""
-    let zapreq = make_zap_request_event(pubkey: damus_state.pubkey, privkey: privkey, content: content, relays: relays, target: target, is_anon: zap_type == .anon)
+    
+    let zapreq = make_zap_request_event(keypair: keypair, content: content, relays: relays, target: target, zap_type: zap_type)
     
     Task {
         var mpayreq = damus_state.lnurls.lookup(target.pubkey)

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -130,14 +130,14 @@ class HomeModel: ObservableObject {
         }
     }
     
-    func handle_zap_event_with_zapper(_ ev: NostrEvent, our_pubkey: String, zapper: String) {
-        guard let zap = Zap.from_zap_event(zap_ev: ev, zapper: zapper) else {
+    func handle_zap_event_with_zapper(_ ev: NostrEvent, our_keypair: Keypair, zapper: String) {
+        guard let zap = Zap.from_zap_event(zap_ev: ev, zapper: zapper, our_privkey: our_keypair.privkey) else {
             return
         }
         
         damus_state.zaps.add_zap(zap: zap)
         
-        guard zap.target.pubkey == our_pubkey else {
+        guard zap.target.pubkey == our_keypair.pubkey else {
             return
         }
         
@@ -155,8 +155,9 @@ class HomeModel: ObservableObject {
             return
         }
         
+        let our_keypair = damus_state.keypair
         if let local_zapper = damus_state.profiles.lookup_zapper(pubkey: ptag) {
-            handle_zap_event_with_zapper(ev, our_pubkey: damus_state.pubkey, zapper: local_zapper)
+            handle_zap_event_with_zapper(ev, our_keypair: our_keypair, zapper: local_zapper)
             return
         }
         
@@ -175,7 +176,7 @@ class HomeModel: ObservableObject {
             
             DispatchQueue.main.async {
                 self.damus_state.profiles.zappers[ptag] = zapper
-                self.handle_zap_event_with_zapper(ev, our_pubkey: self.damus_state.pubkey, zapper: zapper)
+                self.handle_zap_event_with_zapper(ev, our_keypair: our_keypair, zapper: zapper)
             }
         }
         

--- a/damus/Models/Notifications/ZapGroup.swift
+++ b/damus/Models/Notifications/ZapGroup.swift
@@ -21,7 +21,13 @@ class ZapGroup {
     }
     
     func zap_requests() -> [NostrEvent] {
-        zaps.map { z in z.request.ev }
+        zaps.map { z in
+            if let priv = z.private_request {
+                return priv
+            } else {
+                return z.request.ev
+            }
+        }
     }
     
     init(zaps: [Zap]) {

--- a/damus/Models/ZapsModel.swift
+++ b/damus/Models/ZapsModel.swift
@@ -65,7 +65,7 @@ class ZapsModel: ObservableObject {
                     return
                 }
                 
-                guard let zap = Zap.from_zap_event(zap_ev: ev, zapper: zapper) else {
+                guard let zap = Zap.from_zap_event(zap_ev: ev, zapper: zapper, our_privkey: state.keypair.privkey) else {
                     return
                 }
                 

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -29,29 +29,29 @@ func eventviewsize_to_font(_ size: EventViewKind) -> Font {
 
 struct EventView: View {
     let event: NostrEvent
-    let has_action_bar: Bool
+    let options: EventViewOptions
     let damus: DamusState
     let pubkey: String
 
     @EnvironmentObject var action_bar: ActionBarModel
 
-    init(damus: DamusState, event: NostrEvent, has_action_bar: Bool) {
+    init(damus: DamusState, event: NostrEvent, options: EventViewOptions) {
         self.event = event
-        self.has_action_bar = has_action_bar
+        self.options = options
         self.damus = damus
         self.pubkey = event.pubkey
     }
 
     init(damus: DamusState, event: NostrEvent) {
         self.event = event
-        self.has_action_bar = false
+        self.options = []
         self.damus = damus
         self.pubkey = event.pubkey
     }
 
     init(damus: DamusState, event: NostrEvent, pubkey: String) {
         self.event = event
-        self.has_action_bar = false
+        self.options = [.no_action_bar]
         self.damus = damus
         self.pubkey = pubkey
     }
@@ -68,7 +68,7 @@ struct EventView: View {
                             Reposted(damus: damus, pubkey: event.pubkey, profile: prof)
                         }
                         .buttonStyle(PlainButtonStyle())
-                        TextEvent(damus: damus, event: inner_ev, pubkey: inner_ev.pubkey, has_action_bar: has_action_bar, booster_pubkey: event.pubkey)
+                        TextEvent(damus: damus, event: inner_ev, pubkey: inner_ev.pubkey, options: options)
                             .padding([.top], 1)
                     }
                 } else {
@@ -81,7 +81,7 @@ struct EventView: View {
                     EmptyView()
                 }
             } else {
-                TextEvent(damus: damus, event: event, pubkey: pubkey, has_action_bar: has_action_bar, booster_pubkey: nil)
+                TextEvent(damus: damus, event: event, pubkey: pubkey, options: options)
                     .padding([.top], 6)
             }
         }
@@ -176,11 +176,7 @@ struct EventView_Previews: PreviewProvider {
             EventView(damus: test_damus_state(), event: NostrEvent(content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jb55 cool", pubkey: "pk"), show_friend_icon: true, size: .big)
             
              */
-            EventView(
-                damus: test_damus_state(),
-                event: test_event,
-                has_action_bar: true
-            )
+            EventView( damus: test_damus_state(), event: test_event )
         }
         .padding()
     }

--- a/damus/Views/Events/MutedEventView.swift
+++ b/damus/Views/Events/MutedEventView.swift
@@ -57,7 +57,7 @@ struct MutedEventView: View {
             if selected {
                 SelectedEventView(damus: damus_state, event: event)
             } else {
-                EventView(damus: damus_state, event: event, has_action_bar: true)
+                EventView(damus: damus_state, event: event)
                     .onTapGesture {
                         nav_target = event.id
                         navigating = true

--- a/damus/Views/Events/TextEvent.swift
+++ b/damus/Views/Events/TextEvent.swift
@@ -7,12 +7,22 @@
 
 import SwiftUI
 
+struct EventViewOptions: OptionSet {
+    let rawValue: UInt8
+    static let no_action_bar = EventViewOptions(rawValue: 1 << 0)
+    static let no_replying_to = EventViewOptions(rawValue: 1 << 1)
+    static let no_images = EventViewOptions(rawValue: 1 << 2)
+}
+
 struct TextEvent: View {
     let damus: DamusState
     let event: NostrEvent
     let pubkey: String
-    let has_action_bar: Bool
-    let booster_pubkey: String?
+    let options: EventViewOptions
+    
+    var has_action_bar: Bool {
+        !options.contains(.no_action_bar)
+    }
     
     var body: some View {
         HStack(alignment: .top) {
@@ -62,7 +72,7 @@ struct TextEvent: View {
 
 struct TextEvent_Previews: PreviewProvider {
     static var previews: some View {
-        TextEvent(damus: test_damus_state(), event: test_event, pubkey: "pk", has_action_bar: true, booster_pubkey: nil)
+        TextEvent(damus: test_damus_state(), event: test_event, pubkey: "pk", options: [])
     }
 }
 

--- a/damus/Views/Events/ZapEvent.swift
+++ b/damus/Views/Events/ZapEvent.swift
@@ -13,21 +13,44 @@ struct ZapEvent: View {
     
     var body: some View {
         VStack(alignment: .leading) {
-            Text("⚡️ \(format_msats(zap.invoice.amount))", comment: "Text indicating the zap amount. i.e. number of satoshis that were tipped to a user")
-                .font(.headline)
-                .padding([.top], 2)
+            HStack(alignment: .center) {
+                Text("⚡️ \(format_msats(zap.invoice.amount))", comment: "Text indicating the zap amount. i.e. number of satoshis that were tipped to a user")
+                    .font(.headline)
+                    .padding([.top], 2)
+                
+                if zap.private_request != nil {
+                    Image(systemName: "lock.fill")
+                        .foregroundColor(Color("DamusGreen"))
+                        .help("Only you can see this message and who sent it.")
+                }
+            }
 
-            TextEvent(damus: damus, event: zap.request.ev, pubkey: zap.request.ev.pubkey, has_action_bar: false, booster_pubkey: nil)
-                .padding([.top], 1)
+            if let priv = zap.private_request {
+                
+                TextEvent(damus: damus, event: priv, pubkey: priv.pubkey, options: [.no_action_bar, .no_replying_to])
+                    .padding([.top], 1)
+            } else {
+                TextEvent(damus: damus, event: zap.request.ev, pubkey: zap.request.ev.pubkey, options: [.no_action_bar, .no_replying_to])
+                    .padding([.top], 1)
+            }
         }
     }
 }
 
-/*
+
+let test_zap_invoice = ZapInvoice(description: .description("description"), amount: 10000, string: "lnbc1", expiry: 1000000, payment_hash: Data(), created_at: 1000000)
+let test_zap_request_ev = NostrEvent(content: "hi", pubkey: "pk", kind: 9734)
+let test_zap_request = ZapRequest(ev: test_zap_request_ev)
+let test_zap = Zap(event: test_event, invoice: test_zap_invoice, zapper: "zapper", target: .profile("pk"), request: test_zap_request, is_anon: false, private_request: nil)
+
+let test_private_zap = Zap(event: test_event, invoice: test_zap_invoice, zapper: "zapper", target: .profile("pk"), request: test_zap_request, is_anon: false, private_request: test_event)
+
 struct ZapEvent_Previews: PreviewProvider {
     static var previews: some View {
-        ZapEvent()
+        VStack {
+            ZapEvent(damus: test_damus_state(), zap: test_zap)
+            
+            ZapEvent(damus: test_damus_state(), zap: test_private_zap)
+        }
     }
 }
-
-*/

--- a/damus/Views/Notifications/NotificationItemView.swift
+++ b/damus/Views/Notifications/NotificationItemView.swift
@@ -52,7 +52,7 @@ struct NotificationItemView: View {
             
             case .reply(let ev):
                 NavigationLink(destination: BuildThreadV2View(damus: state, event_id: ev.id)) {
-                    EventView(damus: state, event: ev, has_action_bar: true)
+                    EventView(damus: state, event: ev)
                 }
                 .buttonStyle(.plain)
             }

--- a/damus/Views/ReplyView.swift
+++ b/damus/Views/ReplyView.swift
@@ -45,7 +45,7 @@ struct ReplyView: View {
                 ParticipantsView(damus_state: damus, references: $references, originalReferences: $originalReferences)
             }
             ScrollView {
-                EventView(damus: damus, event: replying_to, has_action_bar: false)
+                EventView(damus: damus, event: replying_to, options: [.no_action_bar])
             }
             PostView(replying_to: replying_to, references: references, damus_state: damus)
         }

--- a/damus/Views/Timeline/InnerTimelineView.swift
+++ b/damus/Views/Timeline/InnerTimelineView.swift
@@ -36,7 +36,7 @@ struct InnerTimelineView: View {
                 EmptyTimelineView()
             } else {
                 ForEach(events.filter(filter), id: \.id) { (ev: NostrEvent) in
-                    EventView(damus: damus, event: ev, has_action_bar: true)
+                    EventView(damus: damus, event: ev)
                         .onTapGesture {
                             nav_target = ev
                             navigating = true

--- a/damus/Views/Zaps/ZapsView.swift
+++ b/damus/Views/Zaps/ZapsView.swift
@@ -21,7 +21,7 @@ struct ZapsView: View {
             LazyVStack {
                 ForEach(model.zaps, id: \.event.id) { zap in
                     ZapEvent(damus: state, zap: zap)
-                        .padding()
+                        .padding([.horizontal])
                 }
             }
         }

--- a/damusTests/ZapTests.swift
+++ b/damusTests/ZapTests.swift
@@ -17,7 +17,32 @@ final class ZapTests: XCTestCase {
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
+    
+    func test_private_zap() throws {
+        let alice = generate_new_keypair().to_full()!
+        let bob = generate_new_keypair().to_full()!
+        let target = ZapTarget.profile(bob.pubkey)
+        
+        let message = "hey bob!"
+        let zapreq = make_zap_request_event(keypair: alice, content: message, relays: [], target: target, zap_type: .priv)
+        
+        XCTAssertNotNil(zapreq)
+        guard let zapreq else {
+            return
+        }
+        
+        let decrypted = decrypt_private_zap(our_privkey: bob.privkey, zapreq: zapreq, target: target)
+        
+        XCTAssertNotNil(decrypted)
+        guard let decrypted else {
+            return
+        }
+        
+        XCTAssertEqual(zapreq.content, "")
+        XCTAssertEqual(decrypted.pubkey, alice.pubkey)
+        XCTAssertEqual(message, decrypted.content)
+    }
+    
     func testZap() throws {
         let zapjson = "eyJpZCI6IjUzNmJlZTllODNjODE4ZTNiODJjMTAxOTM1MTI4YWUyN2EwZDQyOTAwMzlhYWYyNTNlZmU1ZjA5MjMyYzE5NjIiLCJwdWJrZXkiOiI5NjMwZjQ2NGNjYTZhNTE0N2FhOGEzNWYwYmNkZDNjZTQ4NTMyNGU3MzJmZDM5ZTA5MjMzYjFkODQ4MjM4ZjMxIiwiY3JlYXRlZF9hdCI6MTY3NDIwNDUzNSwia2luZCI6OTczNSwidGFncyI6W1sicCIsIjMyZTE4Mjc2MzU0NTBlYmIzYzVhN2QxMmMxZjhlN2IyYjUxNDQzOWFjMTBhNjdlZWYzZDlmZDljNWM2OGUyNDUiXSxbImJvbHQxMSIsImxuYmMxMHUxcDN1NTR0bnNwNTcyOXF2eG5renRqamtkNTg1eW4wbDg2MzBzMm01eDZsNTZ3eXk0ZWMybnU4eHV6NjI5eHFwcDV2MnE3aHVjNGpwamgwM2Z4OHVqZXQ1Nms3OWd4cXg3bWUycGV2ejZqMms4dDhtNGxnNXZxaHA1eWc1MDU3OGNtdWoyNG1mdDNxcnNybWd3ZjMwa2U3YXY3ZDc3Z2FtZmxkazlrNHNmMzltcXhxeWp3NXFjcXBqcnpqcTJoeWVoNXEzNmx3eDZ6dHd5cmw2dm1tcnZ6NnJ1ZndqZnI4N3lremZuYXR1a200dWRzNHl6YWszc3FxOW1jcXFxcXFxcWxncXFxcTg2cXF5ZzlxeHBxeXNncWFkeWVjdmR6ZjI3MHBkMzZyc2FmbDA3azQ1ZmNqMnN5OGU1djJ0ZW5kNTB2OTU3NnV4cDNkdmp6amV1aHJlODl5cGdjbTkwZDZsbTAwNGszMHlqNGF2NW1jc3M1bnl4NHU5bmVyOWdwcHY2eXF3Il0sWyJkZXNjcmlwdGlvbiIsIntcImlkXCI6XCJiMDkyMTYzNGIxYmI4ZWUzNTg0YmJiZjJlOGQ3OTBhZDk4NTk5ZDhlMDhmODFjNzAwZGRiZTQ4MjAxNTY4Yjk3XCIsXCJwdWJrZXlcIjpcIjdmYTU2ZjVkNjk2MmFiMWUzY2Q0MjRlNzU4YzMwMDJiODY2NWY3YjBkOGRjZWU5ZmU5ZTI4OGQ3NzUxYWMxOTRcIixcImNyZWF0ZWRfYXRcIjoxNjc0MjA0NTMxLFwia2luZFwiOjk3MzQsXCJ0YWdzXCI6W1tcInBcIixcIjMyZTE4Mjc2MzU0NTBlYmIzYzVhN2QxMmMxZjhlN2IyYjUxNDQzOWFjMTBhNjdlZWYzZDlmZDljNWM2OGUyNDVcIl0sW1wicmVsYXlzXCIsXCJ3c3M6Ly9yZWxheS5zbm9ydC5zb2NpYWxcIixcIndzczovL3JlbGF5LmRhbXVzLmlvXCIsXCJ3c3M6Ly9ub3N0ci1wdWIud2VsbG9yZGVyLm5ldFwiLFwid3NzOi8vbm9zdHIudjBsLmlvXCIsXCJ3c3M6Ly9wcml2YXRlLW5vc3RyLnYwbC5pb1wiLFwid3NzOi8vbm9zdHIuemViZWRlZS5jbG91ZFwiLFwid3NzOi8vcmVsYXkubm9zdHIuaW5mby9cIl1dLFwiY29udGVudFwiOlwiXCIsXCJzaWdcIjpcImQwODQwNGU2MjVmOWM1NjMzYWZhZGQxMWMxMTBiYTg4ZmNkYjRiOWUwOTJiOTg0MGU3NDgyYThkNTM3YjFmYzExODY5MmNmZDEzMWRkODMzNTM2NDc2OWE2NzE3NTRhZDdhYTk3MzEzNjgzYTRhZDdlZmI3NjQ3NmMwNGU1ZjE3XCJ9Il0sWyJwcmVpbWFnZSIsIjNlMDJhM2FmOGM4YmNmMmEzNzUzYzg3ZjMxMTJjNjU2YTIwMTE0ZWUwZTk4ZDgyMTliYzU2ZjVlOGE3MjM1YjMiXV0sImNvbnRlbnQiOiIiLCJzaWciOiIzYWI0NGQwZTIyMjhiYmQ0ZDIzNDFjM2ZhNzQwOTZjZmY2ZjU1Y2ZkYTk5YTVkYWRjY2Y0NWM2NjQ2MzdlMjExNTFiMmY5ZGQwMDQwZjFhMjRlOWY4Njg2NzM4YjE2YmY4MTM0YmRiZTQxYTIxOGM5MTFmN2JiMzFlNTk1NzhkMSJ9Cg=="
         
@@ -33,7 +58,7 @@ final class ZapTests: XCTestCase {
             return
         }
         
-        guard let zap = Zap.from_zap_event(zap_ev: ev, zapper: "9630f464cca6a5147aa8a35f0bcdd3ce485324e732fd39e09233b1d848238f31") else {
+        guard let zap = Zap.from_zap_event(zap_ev: ev, zapper: "9630f464cca6a5147aa8a35f0bcdd3ce485324e732fd39e09233b1d848238f31", our_privkey: nil) else {
             XCTAssert(false)
             return
         }


### PR DESCRIPTION
This adds private zaps, which have messages and authors encrypted to the target. Keys are deterministically generated so that both the receiver and sender can decrypt.

Changelog-Added: Private Zaps