### PR TITLE
simplified usage of NostrFilter

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -716,7 +716,7 @@ func update_filters_with_since(last_of_kind: [Int: NostrEvent], filters: [NostrF
         let kinds = filter.kinds ?? []
         let initial: Int64? = nil
         let earliest = kinds.reduce(initial) { earliest, kind in
-            let last = last_of_kind[kind]
+            let last = last_of_kind[kind.rawValue]
             let since: Int64? = get_since_time(last_event: last)
             
             if earliest == nil {
@@ -771,7 +771,7 @@ func find_event(state: DamusState, evid: String, find_from: [String]?, callback:
     let subid = UUID().description
     
     var has_event = false
-    var filter = NostrFilter.filter_ids([ evid ])
+    var filter = NostrFilter(ids: [evid])
     filter.limit = 1
     var attempts = 0
     

--- a/damus/Models/EventsModel.swift
+++ b/damus/Models/EventsModel.swift
@@ -24,7 +24,7 @@ class EventsModel: ObservableObject {
     }
     
     private func get_filter() -> NostrFilter {
-        var filter = NostrFilter.filter_kinds([kind.rawValue])
+        var filter = NostrFilter(kinds: [kind])
         filter.referenced_ids = [target]
         filter.limit = 500
         return filter

--- a/damus/Models/FollowingModel.swift
+++ b/damus/Models/FollowingModel.swift
@@ -22,7 +22,7 @@ class FollowingModel {
     }
     
     func get_filter() -> NostrFilter {
-        var f = NostrFilter.filter_kinds([0])
+        var f = NostrFilter(kinds: [.metadata])
         f.authors = self.contacts.reduce(into: Array<String>()) { acc, pk in
             // don't fetch profiles we already have
             if damus_state.profiles.lookup(id: pk) != nil {

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -346,23 +346,19 @@ class HomeModel: ObservableObject {
         var friends = damus_state.contacts.get_friend_list()
         friends.append(damus_state.pubkey)
 
-        var contacts_filter = NostrFilter.filter_kinds([0])
+        var contacts_filter = NostrFilter(kinds: [.metadata])
         contacts_filter.authors = friends
         
-        var our_contacts_filter = NostrFilter.filter_kinds([3, 0])
+        var our_contacts_filter = NostrFilter(kinds: [.contacts, .metadata])
         our_contacts_filter.authors = [damus_state.pubkey]
         
-        var our_blocklist_filter = NostrFilter.filter_kinds([30000])
+        var our_blocklist_filter = NostrFilter(kinds: [.list])
         our_blocklist_filter.parameter = ["mute"]
         our_blocklist_filter.authors = [damus_state.pubkey]
         
-        var dms_filter = NostrFilter.filter_kinds([
-            NostrKind.dm.rawValue,
-        ])
+        var dms_filter = NostrFilter(kinds: [.dm])
 
-        var our_dms_filter = NostrFilter.filter_kinds([
-            NostrKind.dm.rawValue,
-        ])
+        var our_dms_filter = NostrFilter(kinds: [.dm])
 
         // friends only?...
         //dms_filter.authors = friends
@@ -371,21 +367,12 @@ class HomeModel: ObservableObject {
         our_dms_filter.authors = [ damus_state.pubkey ]
 
         // TODO: separate likes?
-        var home_filter = NostrFilter.filter_kinds([
-            NostrKind.text.rawValue,
-            NostrKind.like.rawValue,
-            NostrKind.boost.rawValue,
-        ])
+        var home_filter = NostrFilter(kinds: [.text, .like, .boost])
         // include our pubkey as well even if we're not technically a friend
         home_filter.authors = friends
         home_filter.limit = 500
 
-        var notifications_filter = NostrFilter.filter_kinds([
-            NostrKind.text.rawValue,
-            NostrKind.like.rawValue,
-            NostrKind.boost.rawValue,
-            NostrKind.zap.rawValue,
-        ])
+        var notifications_filter = NostrFilter(kinds: [.text, .like, .boost, .zap])
         notifications_filter.pubkeys = [damus_state.pubkey]
         notifications_filter.limit = 100
 

--- a/damus/Models/ProfileModel.swift
+++ b/damus/Models/ProfileModel.swift
@@ -65,16 +65,9 @@ class ProfileModel: ObservableObject, Equatable {
     }
     
     func subscribe() {
-        var text_filter = NostrFilter.filter_kinds([
-            NostrKind.text.rawValue,
-            NostrKind.chat.rawValue,
-        ])
+        var text_filter = NostrFilter(kinds: [.text, .chat])
         
-        var profile_filter = NostrFilter.filter_kinds([
-            NostrKind.contacts.rawValue,
-            NostrKind.metadata.rawValue,
-            NostrKind.boost.rawValue,
-        ])
+        var profile_filter = NostrFilter(kinds: [.contacts, .metadata, .boost])
         
         profile_filter.authors = [pubkey]
         

--- a/damus/Models/SearchHomeModel.swift
+++ b/damus/Models/SearchHomeModel.swift
@@ -24,7 +24,7 @@ class SearchHomeModel: ObservableObject {
     }
     
     func get_base_filter() -> NostrFilter {
-        var filter = NostrFilter.filter_kinds([1, 42])
+        var filter = NostrFilter(kinds: [.text, .chat])
         filter.limit = self.limit
         filter.until = Int64(Date.now.timeIntervalSince1970)
         return filter

--- a/damus/Models/SearchModel.swift
+++ b/damus/Models/SearchModel.swift
@@ -33,7 +33,7 @@ class SearchModel: ObservableObject {
     func subscribe() {
         // since 1 month
         search.limit = self.limit
-        search.kinds = [1,5,7]
+        search.kinds = [.text, .delete, .like]
 
         //likes_filter.ids = ref_events.referenced_ids!
 

--- a/damus/Models/ThreadModel.swift
+++ b/damus/Models/ThreadModel.swift
@@ -77,18 +77,18 @@ class ThreadModel: ObservableObject {
         var meta_events = NostrFilter()
         var event_filter = NostrFilter()
         var ref_events = NostrFilter()
-        //var likes_filter = NostrFilter.filter_kinds(7])
+        //var likes_filter = NostrFilter(kinds: [.like])
 
         let thread_id = event.thread_id(privkey: nil)
         
         ref_events.referenced_ids = [thread_id, event.id]
-        ref_events.kinds = [1]
+        ref_events.kinds = [.text]
         ref_events.limit = 1000
         
         event_filter.ids = [thread_id, event.id]
         
         meta_events.referenced_ids = [event.id]
-        meta_events.kinds = [9735, 1, 6, 7]
+        meta_events.kinds = [.zap, .text, .boost, .like]
         meta_events.limit = 1000
         
         /*

--- a/damus/Models/ZapsModel.swift
+++ b/damus/Models/ZapsModel.swift
@@ -22,7 +22,7 @@ class ZapsModel: ObservableObject {
     }
     
     func subscribe() {
-        var filter = NostrFilter.filter_kinds([9735])
+        var filter = NostrFilter(kinds: [.zap])
         switch target {
         case .profile(let profile_id):
             filter.pubkeys = [profile_id]

--- a/damus/Nostr/NostrFilter.swift
+++ b/damus/Nostr/NostrFilter.swift
@@ -9,15 +9,15 @@ import Foundation
 
 struct NostrFilter: Codable, Equatable {
     var ids: [String]?
-    var kinds: [Int]?
+    var kinds: [NostrKind]?
     var referenced_ids: [String]?
     var pubkeys: [String]?
     var since: Int64?
     var until: Int64?
     var limit: UInt32?
     var authors: [String]?
-    var hashtag: [String]? = nil
-    var parameter: [String]? = nil
+    var hashtag: [String]?
+    var parameter: [String]?
 
     private enum CodingKeys : String, CodingKey {
         case ids
@@ -32,39 +32,27 @@ struct NostrFilter: Codable, Equatable {
         case limit
     }
     
+    init(ids: [String]? = nil, kinds: [NostrKind]? = nil, referenced_ids: [String]? = nil, pubkeys: [String]? = nil, since: Int64? = nil, until: Int64? = nil, limit: UInt32? = nil, authors: [String]? = nil, hashtag: [String]? = nil) {
+        self.ids = ids
+        self.kinds = kinds
+        self.referenced_ids = referenced_ids
+        self.pubkeys = pubkeys
+        self.since = since
+        self.until = until
+        self.limit = limit
+        self.authors = authors
+        self.hashtag = hashtag
+    }
+    
     public static func copy(from: NostrFilter) -> NostrFilter {
-        return NostrFilter(ids: from.ids, kinds: from.kinds, referenced_ids: from.referenced_ids, pubkeys: from.pubkeys, since: from.since, until: from.until, authors: from.authors, hashtag: from.hashtag)
-    }
-    
-    public static func filter_hashtag(_ htags: [String]) -> NostrFilter {
-        return NostrFilter(ids: nil, kinds: nil, referenced_ids: nil, pubkeys: nil, since: nil, until: nil, authors: nil, hashtag: htags)
-    }
-
-    public static var filter_text: NostrFilter {
-        return filter_kinds([1])
-    }
-    
-    public static func filter_ids(_ ids: [String]) -> NostrFilter {
-        return NostrFilter(ids: ids, kinds: nil, referenced_ids: nil, pubkeys: nil, since: nil, until: nil, authors: nil, hashtag: nil)
+        NostrFilter(ids: from.ids, kinds: from.kinds, referenced_ids: from.referenced_ids, pubkeys: from.pubkeys, since: from.since, until: from.until, authors: from.authors, hashtag: from.hashtag)
     }
     
     public static var filter_profiles: NostrFilter {
-        return filter_kinds([0])
+        NostrFilter(kinds: [.metadata])
     }
 
     public static var filter_contacts: NostrFilter {
-        return filter_kinds([3])
-    }
-    
-    public static func filter_authors(_ authors: [String]) -> NostrFilter {
-        return NostrFilter(ids: nil, kinds: nil, referenced_ids: nil, pubkeys: nil, since: nil, until: nil, authors: authors)
-    }
-
-    public static func filter_kinds(_ kinds: [Int]) -> NostrFilter {
-        return NostrFilter(ids: nil, kinds: kinds, referenced_ids: nil, pubkeys: nil, since: nil, until: nil, authors: nil)
-    }
-
-    public static func filter_since(_ val: Int64) -> NostrFilter {
-        return NostrFilter(ids: nil, kinds: nil, referenced_ids: nil, pubkeys: nil, since: val, until: nil, authors: nil)
+        NostrFilter(kinds: [.contacts])
     }
 }

--- a/damus/Nostr/NostrKind.swift
+++ b/damus/Nostr/NostrKind.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 
-enum NostrKind: Int {
+enum NostrKind: Int, Codable {
     case metadata = 0
     case text = 1
     case contacts = 3

--- a/damus/Nostr/NostrLink.swift
+++ b/damus/Nostr/NostrLink.swift
@@ -137,7 +137,7 @@ func decode_nostr_uri(_ s: String) -> NostrLink? {
         }
     
     if tag_is_hashtag(parts) {
-        return .filter(NostrFilter.filter_hashtag([parts[1].lowercased()]))
+        return .filter(NostrFilter(hashtag: [parts[1].lowercased()]))
     }
     
     if let rid = tag_to_refid(parts) {

--- a/damus/Views/Events/BuilderEventView.swift
+++ b/damus/Views/Events/BuilderEventView.swift
@@ -52,7 +52,7 @@ struct BuilderEventView: View {
         subscribe(filters: [
             NostrFilter(ids: [self.event_id], limit: 1),
             NostrFilter(
-                kinds: [NostrKind.zap.rawValue],
+                kinds: [.zap],
                 referenced_ids: [self.event_id]
             )
         ])

--- a/damus/Views/SearchResultsView.swift
+++ b/damus/Views/SearchResultsView.swift
@@ -35,7 +35,7 @@ struct SearchResultsView: View {
                         }
                     }
                 case .hashtag(let ht):
-                    let search_model = SearchModel(contacts: damus_state.contacts, pool: damus_state.pool, search: .filter_hashtag([ht]))
+                    let search_model = SearchModel(contacts: damus_state.contacts, pool: damus_state.pool, search: NostrFilter(hashtag: [ht]))
                     let dst = SearchView(appstate: damus_state, search: search_model)
                     NavigationLink(destination: dst) {
                         Text("Search hashtag: #\(ht)", comment: "Navigation link to search hashtag.")

--- a/damus/Views/SearchView.swift
+++ b/damus/Views/SearchView.swift
@@ -42,7 +42,7 @@ func describe_search(_ filter: NostrFilter) -> String {
 struct SearchView_Previews: PreviewProvider {
     static var previews: some View {
         let test_state = test_damus_state()
-        let filter = NostrFilter.filter_hashtag(["bitcoin"])
+        let filter = NostrFilter(hashtag: ["bitcoin"])
         let pool = test_state.pool
         
         let model = SearchModel(contacts: test_state.contacts, pool: pool, search: filter)

--- a/damusTests/RequestTests.swift
+++ b/damusTests/RequestTests.swift
@@ -30,7 +30,7 @@ final class RequestTests: XCTestCase {
     }
     
     func testMakeSubscriptionRequest() {
-        let filter = NostrFilter(kinds: [3], limit: 1, authors: ["d9fa34214aa9d151c4f4db843e9c2af4f246bab4205137731f91bcfa44d66a62"])
+        let filter = NostrFilter(kinds: [.contacts], limit: 1, authors: ["d9fa34214aa9d151c4f4db843e9c2af4f246bab4205137731f91bcfa44d66a62"])
         let subscribe = NostrSubscribe(filters: [filter], sub_id: "31C737B7-C8F9-41DD-8707-325974F279A4")
         let result = make_nostr_req(.subscribe(subscribe))
         let expectedResult = "[\"REQ\",\"31C737B7-C8F9-41DD-8707-325974F279A4\",{\"kinds\":[3],\"authors\":[\"d9fa34214aa9d151c4f4db843e9c2af4f246bab4205137731f91bcfa44d66a62\"],\"limit\":1}]"


### PR DESCRIPTION
This PR simplifies the usage of NostrFilter. Rather than passing `Int`s into the filter, you can now pass `NostrKind`s, making the code more readable and maintainable. We can also specify only the parameters we want to specify and leave all the others nil as desired, without static functions. Note: No functional changes are intended.

Examples:

Before:
```swift
var our_contacts_filter = NostrFilter.filter_kinds([3, 0])
```
After:
```swift
var our_contacts_filter = NostrFilter(kinds: [.contacts, .metadata])
```
---------
Before:
```swift
var home_filter = NostrFilter.filter_kinds([
    NostrKind.text.rawValue,
    NostrKind.like.rawValue,
    NostrKind.boost.rawValue,
])
```
After:
```swift
var home_filter = NostrFilter(kinds: [.text, .like, .boost])
```
---------
Before:
```swift
let filter = NostrFilter.filter_hashtag(["bitcoin"])
```
After:
```swift
let filter = NostrFilter(hashtag: ["bitcoin"])
```