### PR TITLE
prune EventCache when iOS fires memory warning

### DIFF
--- a/damus/Util/EventCache.swift
+++ b/damus/Util/EventCache.swift
@@ -5,17 +5,23 @@
 //  Created by William Casarin on 2023-02-21.
 //
 
+import Combine
 import Foundation
+import UIKit
 
 class EventCache {
-    private var events: [String: NostrEvent]
-    private var replies: ReplyMap = ReplyMap()
+    private var events: [String: NostrEvent] = [:]
+    private var replies = ReplyMap()
+    private var cancellable: AnyCancellable?
     
     //private var thread_latest: [String: Int64]
     
     init() {
-        self.events = [:]
-        self.replies = ReplyMap()
+        cancellable = NotificationCenter.default.publisher(
+            for: UIApplication.didReceiveMemoryWarningNotification
+        ).sink { [weak self] _ in
+            self?.prune()
+        }
     }
     
     func parent_events(event: NostrEvent) -> [NostrEvent] {
@@ -79,4 +85,8 @@ class EventCache {
         events[ev.id] = ev
     }
     
+    private func prune() {
+        events = [:]
+        replies.replies = [:]
+    }
 }


### PR DESCRIPTION
The new `EventCache` is fantastic for speed in Damus. However it can very quickly cache hundreds or thousands of events in memory. When Damus is backgrounded by the user, iOS may fire memory warning notifications to reclaim memory. If Damus does not return enough memory to the OS, it will kill the app. However if Damus does return enough memory to the OS, it will get to keep running. This will make Damus a better OS citizen, and it will be more reliable for the user and resume rather than launching from scratch more often.

You can simulate a memory to see it work:
<img width="666" alt="Debug_and_Menubar_and_iPhone_14_Pro" src="https://user-images.githubusercontent.com/445882/222963809-b3395900-2a91-40e7-902d-81525e0895bd.png">
