### PR TITLE
Readme.MD: add privacy section, and link to issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,16 @@ damus implements the following [Nostr Implementation Possibilities][nips]
 
 ## Contributing
 
-Contributors welcome!
+Contributors welcome! Start by examining known issues: https://github.com/damus-io/damus/issues.
 
 ### Code
 
 [Email patches][git-send-email] to jb55@jb55.com are preferred, but I accept PRs on GitHub as well.
 
 [git-send-email]: http://git-send-email.io
+
+### Privacy
+Your internet protocol (IP) address is exposed to the relays you connect to, and third party media hosters (e.g. nostr.build, imgur.com, giphy.com, youtube.com etc.) that render on Damus. If you want to improve your privacy, consider utilizing a service that masks your IP address (e.g. a VPN) from trackers online.
 
 ### Translations
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Contributors welcome! Start by examining known issues: https://github.com/damus-
 ### Privacy
 Your internet protocol (IP) address is exposed to the relays you connect to, and third party media hosters (e.g. nostr.build, imgur.com, giphy.com, youtube.com etc.) that render on Damus. If you want to improve your privacy, consider utilizing a service that masks your IP address (e.g. a VPN) from trackers online.
 
+The relay also learns which public keys you are requesting, meaning your public key will be tied to your IP address.
+
 ### Translations
 
 Translators welcome! Join the [Transifex][transifex] project.


### PR DESCRIPTION
Added:
1. Damus implications on user privacy (IP address)
2. Added direct link to Damus github issues for interested contributors