### PR TITLE
Minor text changes

### DIFF
--- a/damus/Components/Reposted.swift
+++ b/damus/Components/Reposted.swift
@@ -15,12 +15,12 @@ struct Reposted: View {
     var body: some View {
         HStack(alignment: .center) {
             Image(systemName: "arrow.2.squarepath")
-                .font(.footnote)
+                .font(.system(size: 13, weight: .heavy))
                 .foregroundColor(Color.gray)
             ProfileName(pubkey: pubkey, profile: profile, damus: damus, show_friend_confirmed: true, show_nip5_domain: false)
                     .foregroundColor(Color.gray)
             Text("Reposted", comment: "Text indicating that the post was reposted (i.e. re-shared).")
-                .font(.footnote)
+                .font(.system(size: 14, weight: .heavy))
                 .foregroundColor(Color.gray)
         }
     }

--- a/damus/Views/Events/EventMenu.swift
+++ b/damus/Views/Events/EventMenu.swift
@@ -13,6 +13,8 @@ struct EventMenuContext: View {
     let target_pubkey: String
     let bookmarks: BookmarksManager
     
+    @Environment(\.colorScheme) var colorScheme
+    
     var body: some View {
         HStack {
             Menu {
@@ -21,12 +23,11 @@ struct EventMenuContext: View {
                 
             } label: {
                 Label(NSLocalizedString("", comment: "Context menu"), systemImage: "ellipsis")
-                    .foregroundColor(Color.gray)
+                    .foregroundColor(colorScheme == .light ? Color(.lightGray) : Color("DamusMediumGrey"))
             }
         }
         .contentShape(Rectangle())
         .onTapGesture {}
-        
     }
 }
 

--- a/damus/Views/Events/TextEvent.swift
+++ b/damus/Views/Events/TextEvent.swift
@@ -36,11 +36,15 @@ struct TextEvent: View {
             }
 
             VStack(alignment: .leading) {
-                HStack(alignment: .center) {
+                HStack(alignment: .center, spacing: 0) {
                     let pk = is_anon ? "anon" : pubkey
                     EventProfileName(pubkey: pk, profile: profile, damus: damus, show_friend_confirmed: true, size: .normal)
                     
+                    Text("⋅")
+                        .font(.footnote)
+                        .foregroundColor(.gray)
                     Text(verbatim: "\(format_relative_time(event.created_at))")
+                        .font(.system(size: 16))
                         .foregroundColor(.gray)
                     
                     Spacer()

--- a/damus/Views/ProfileName.swift
+++ b/damus/Views/ProfileName.swift
@@ -138,7 +138,7 @@ struct EventProfileName: View {
                 + Text(real_name.isEmpty ? "" : " ")
 
                 + Text(verbatim: "@\(display_name ?? Profile.displayName(profile: profile, pubkey: pubkey))")
-                    .foregroundColor(Color("DamusMediumGrey"))
+                    .foregroundColor(.gray)
                     .font(eventviewsize_to_font(size))
                 
             } else {


### PR DESCRIPTION
This PR adds some minor text changes to events:

- Adjusted repost font size and weight to use a heavier font and size that matches profile name
- Adjusted ellipsis color to use light gray in light mode and medium gray in dark mode
- Added dot operator to separate event time from profile name
- Use the same color form profile name as event time

**|--------------------Before-----------------------------|--------------------------After-------------------------|**

<img src="https://user-images.githubusercontent.com/14004132/223621095-29f31a92-5728-4880-b5f2-f8bb96875204.png" width="370"> <img src="https://user-images.githubusercontent.com/14004132/223621084-42f55595-1cf4-481e-83ff-4756957ed80a.png" width="370">

**|--------------------Before-----------------------------|--------------------------After-------------------------|**

<img src="https://user-images.githubusercontent.com/14004132/223621097-4cb4e1a0-cdfb-425c-9736-f5c0d8f02649.png" width="370"> <img src="https://user-images.githubusercontent.com/14004132/223621088-d5c1f02d-d8f2-4d7c-8be5-3bc3e592e917.png" width="370">
