### PR TITLE
Fix Issue #748 - Profile search using npub exposes JSON string

### DIFF
--- a/damus/Views/Search/SearchingEventView.swift
+++ b/damus/Views/Search/SearchingEventView.swift
@@ -75,22 +75,23 @@ struct SearchingEventView: View {
                     self.search_state = .found(ev)
                     return
                 }
+                find_event(state: state, evid: evid, search_type: search_type, find_from: nil) { ev in
+                    if let ev {
+                        self.search_state = .found(ev)
+                    } else {
+                        self.search_state = .not_found
+                    }
+                }
             case .profile:
-                if state.profiles.lookup(id: evid) != nil {
-                    self.search_state = .found_profile(evid)
-                    return
+                find_event(state: state, evid: evid, search_type: search_type, find_from: nil) { _ in
+                    if state.profiles.lookup(id: evid) != nil {
+                        self.search_state = .found_profile(evid)
+                        return
+                    } else {
+                        self.search_state = .not_found
+                    }
                 }
             }
-            
-            find_event(state: state, evid: evid, search_type: search_type, find_from: nil) { ev in
-                
-                if let ev {
-                    self.search_state = .found(ev)
-                } else {
-                    self.search_state = .not_found
-                }
-            }
-        
         }
     }
 }


### PR DESCRIPTION
Fix Issue #748 [https://github.com/damus-io/damus/issues/748]

Fix:
-profile search now immediately shows profile being searched (given a valid npub or npub's hex)
-tested other searches -- found to still work normally (eg. searching note or npub's hex or note's hex)

Video:
-4 search tests - 2 npub searches; 2 note searches

https://user-images.githubusercontent.com/47217795/223861120-b9d57258-7067-4391-aee2-7fc2d1e8e897.mov


