### PR TITLE
ContentView.swift: fix nav title text presentation

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -210,6 +210,7 @@ struct ContentView: View {
                             .shadow(color: Color("DamusPurple"), radius: 2)
                     } else {
                         timelineNavItem
+                            .frame(width:300,height:30)
                             .opacity(isSideBarOpened ? 0 : 1)
                             .animation(isSideBarOpened ? .none : .default, value: isSideBarOpened)
                     }


### PR DESCRIPTION
When the damus-home image is presented - the .frame is set to 30x30
We set the .frame to 300x30 to handle other cases.