### PR TITLE
fix: unexpected font size on PostView

### DIFF
--- a/damus/Views/TextViewWrapper.swift
+++ b/damus/Views/TextViewWrapper.swift
@@ -13,7 +13,7 @@ struct TextViewWrapper: UIViewRepresentable {
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
         textView.delegate = context.coordinator
-        textView.font = UIFont.systemFont(ofSize: 18)
+        textView.font = UIFont.preferredFont(forTextStyle: .body)
         textView.textColor = UIColor.label
         let linkAttributes: [NSAttributedString.Key : Any] = [
             NSAttributedString.Key.foregroundColor: UIColor(Color.accentColor)]


### PR DESCRIPTION
Fixes an issue where the text field the user types in for posts and replies does not respect the user's Dynamic Type setting (selected font size).

|Before|After|
|---|---|
|![bad-1](https://user-images.githubusercontent.com/445882/223884025-2f7ce887-d259-4561-acf5-6c6de11454b1.png)|![good-1](https://user-images.githubusercontent.com/445882/223884067-713a2cdd-9f3c-4db1-8e11-2e79856327d8.png)|
|![bad-2](https://user-images.githubusercontent.com/445882/223884114-6a5ba335-6858-4b09-bc82-3a38f1544ce5.png)|![good-2](https://user-images.githubusercontent.com/445882/223884125-737b0c80-3b51-4761-b6c0-0d5295748288.png)|


Fixes issue: https://github.com/damus-io/damus/issues/725