### PR TITLE
Fix keyboard related bugs

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -214,7 +214,6 @@ struct ContentView: View {
                 }
             }
         }
-        .ignoresSafeArea(.keyboard)
     }
     
     var MaybeSearchView: some View {
@@ -257,49 +256,47 @@ struct ContentView: View {
         VStack(alignment: .leading, spacing: 0) {
             if let damus = self.damus_state {
                 NavigationView {
-                    ZStack {
-                        TabView { // Prevents navbar appearance change on scroll
-                            MainContent(damus: damus)
-                                .toolbar() {
-                                    ToolbarItem(placement: .navigationBarLeading) {
-                                        Button {
-                                            isSideBarOpened.toggle()
-                                        } label: {
-                                            ProfilePicView(pubkey: damus_state!.pubkey, size: 32, highlight: .none, profiles: damus_state!.profiles)
-                                                .opacity(isSideBarOpened ? 0 : 1)
-                                                .animation(isSideBarOpened ? .none : .default, value: isSideBarOpened)
-                                        }
-                                        .disabled(isSideBarOpened)
+                    TabView { // Prevents navbar appearance change on scroll
+                        MainContent(damus: damus)
+                            .toolbar() {
+                                ToolbarItem(placement: .navigationBarLeading) {
+                                    Button {
+                                        isSideBarOpened.toggle()
+                                    } label: {
+                                        ProfilePicView(pubkey: damus_state!.pubkey, size: 32, highlight: .none, profiles: damus_state!.profiles)
+                                            .opacity(isSideBarOpened ? 0 : 1)
+                                            .animation(isSideBarOpened ? .none : .default, value: isSideBarOpened)
                                     }
-                                    
-                                    ToolbarItem(placement: .navigationBarTrailing) {
-                                        HStack(alignment: .center) {
-                                            if home.signal.signal != home.signal.max_signal {
-                                                NavigationLink(destination: RelayConfigView(state: damus_state!)) {
-                                                    Text("\(home.signal.signal)/\(home.signal.max_signal)", comment: "Fraction of how many of the user's relay servers that are operational.")
-                                                        .font(.callout)
-                                                        .foregroundColor(.gray)
-                                                }
+                                    .disabled(isSideBarOpened)
+                                }
+                                
+                                ToolbarItem(placement: .navigationBarTrailing) {
+                                    HStack(alignment: .center) {
+                                        if home.signal.signal != home.signal.max_signal {
+                                            NavigationLink(destination: RelayConfigView(state: damus_state!)) {
+                                                Text("\(home.signal.signal)/\(home.signal.max_signal)", comment: "Fraction of how many of the user's relay servers that are operational.")
+                                                    .font(.callout)
+                                                    .foregroundColor(.gray)
                                             }
-                                            
-                                            // maybe expand this to other timelines in the future
-                                            if selected_timeline == .search {
-                                                Button(action: {
-                                                    //isFilterVisible.toggle()
-                                                    self.active_sheet = .filter
-                                                }) {
-                                                    // checklist, checklist.checked, lisdt.bullet, list.bullet.circle, line.3.horizontal.decrease...,  line.3.horizontail.decrease
-                                                    Label(NSLocalizedString("Filter", comment: "Button label text for filtering relay servers."), systemImage: "line.3.horizontal.decrease")
-                                                        .foregroundColor(.gray)
-                                                        //.contentShape(Rectangle())
-                                                }
+                                        }
+                                        
+                                        // maybe expand this to other timelines in the future
+                                        if selected_timeline == .search {
+                                            Button(action: {
+                                                //isFilterVisible.toggle()
+                                                self.active_sheet = .filter
+                                            }) {
+                                                // checklist, checklist.checked, lisdt.bullet, list.bullet.circle, line.3.horizontal.decrease...,  line.3.horizontail.decrease
+                                                Label(NSLocalizedString("Filter", comment: "Button label text for filtering relay servers."), systemImage: "line.3.horizontal.decrease")
+                                                    .foregroundColor(.gray)
+                                                    //.contentShape(Rectangle())
                                             }
                                         }
                                     }
                                 }
-                        }
-                        .tabViewStyle(.page(indexDisplayMode: .never))
+                            }
                     }
+                    .tabViewStyle(.page(indexDisplayMode: .never))
                     .overlay(
                         SideMenuView(damus_state: damus, isSidebarVisible: $isSideBarOpened.animation())
                     )
@@ -308,8 +305,10 @@ struct ContentView: View {
             
                 TabBar(new_events: $home.new_events, selected: $selected_timeline, isSidebarVisible: $isSideBarOpened, action: switch_timeline)
                     .padding([.bottom], 8)
+                    .background(Color(uiColor: .systemBackground).ignoresSafeArea())
             }
         }
+        .ignoresSafeArea(.keyboard)
         .onAppear() {
             self.connect()
             setup_notifications()

--- a/damus/Views/EditMetadataView.swift
+++ b/damus/Views/EditMetadataView.swift
@@ -206,7 +206,7 @@ struct EditMetadataView: View {
                 }
             }
         }
-        .ignoresSafeArea()
+        .ignoresSafeArea(edges: .top)
     }
 }
 

--- a/damus/Views/Zaps/CustomizeZapView.swift
+++ b/damus/Views/Zaps/CustomizeZapView.swift
@@ -148,6 +148,7 @@ struct CustomizeZapView: View {
                 self.invoice = inv
                 self.showing_wallet_selector = true
             } else {
+                end_editing()
                 open_with_wallet(wallet: get_default_wallet(state.pubkey).model, invoice: inv)
                 self.showing_wallet_selector = false
                 dismiss()


### PR DESCRIPTION
Sending a wallet link from the custom zap view while the keyboard is up breaks keyboard avoidance. The solution is to dismiss the keyboard before sending the app link.

Before             |  After
:-------------------------:|:-------------------------:
![keyboard-1](https://user-images.githubusercontent.com/19398259/223906965-57138e5e-a76e-4d3a-9a8a-15294f09dcf2.gif) | ![keyboard-2](https://user-images.githubusercontent.com/19398259/223907005-1e760334-e446-49c3-9bbe-9937bd6f6381.gif)

</br>

Also removed keyboard avoidance for the tabbar

Before             |  After
:-------------------------:|:-------------------------:
![tabbar-1](https://user-images.githubusercontent.com/19398259/223907636-ba8d3add-0890-4e4f-85b2-67603ea2ddc5.gif) | ![tabbar-2](https://user-images.githubusercontent.com/19398259/223907677-f93fa3c1-aaa0-44d5-9554-c9a440f82cbd.gif)

