### PR TITLE
Updated Share Sheet

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 		50A50A8D29A09E1C00C01BE7 /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A50A8C29A09E1C00C01BE7 /* RequestTests.swift */; };
 		5C513FBA297F72980072348F /* CustomPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C513FB9297F72980072348F /* CustomPicker.swift */; };
 		5C513FCC2984ACA60072348F /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C513FCB2984ACA60072348F /* QRCodeView.swift */; };
+		5CF72FC229B9142F00124A13 /* ShareAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CF72FC129B9142F00124A13 /* ShareAction.swift */; };
 		6439E014296790CF0020672B /* ProfileZoomView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6439E013296790CF0020672B /* ProfileZoomView.swift */; };
 		643EA5C8296B764E005081BB /* RelayFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643EA5C7296B764E005081BB /* RelayFilterView.swift */; };
 		647D9A8D2968520300A295DE /* SideMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647D9A8C2968520300A295DE /* SideMenuView.swift */; };
@@ -569,6 +570,7 @@
 		50A50A8C29A09E1C00C01BE7 /* RequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
 		5C513FB9297F72980072348F /* CustomPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPicker.swift; sourceTree = "<group>"; };
 		5C513FCB2984ACA60072348F /* QRCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeView.swift; sourceTree = "<group>"; };
+		5CF72FC129B9142F00124A13 /* ShareAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAction.swift; sourceTree = "<group>"; };
 		6439E013296790CF0020672B /* ProfileZoomView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileZoomView.swift; sourceTree = "<group>"; };
 		643EA5C7296B764E005081BB /* RelayFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayFilterView.swift; sourceTree = "<group>"; };
 		647D9A8C2968520300A295DE /* SideMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuView.swift; sourceTree = "<group>"; };
@@ -907,6 +909,7 @@
 			children = (
 				4CEE2B01280B39E800AB5EEF /* EventActionBar.swift */,
 				4CB88388296AF99A00DC99E7 /* EventDetailBar.swift */,
+				5CF72FC129B9142F00124A13 /* ShareAction.swift */,
 			);
 			path = ActionBar;
 			sourceTree = "<group>";
@@ -1312,6 +1315,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C3AC79D2833036D00E1F516 /* FollowingView.swift in Sources */,
+				5CF72FC229B9142F00124A13 /* ShareAction.swift in Sources */,
 				4C363A8A28236B57006E126D /* MentionView.swift in Sources */,
 				4CE4F8CD281352B30009DFBB /* Notifications.swift in Sources */,
 				4C30AC7829A577AB00E2BD5A /* EventCache.swift in Sources */,

--- a/damus/Components/HalfSheet.swift
+++ b/damus/Components/HalfSheet.swift
@@ -1,0 +1,8 @@
+//
+//  HalfSheet.swift
+//  damus
+//
+//  Created by eric on 3/8/23.
+//
+
+import Foundation

--- a/damus/Components/HalfSheet.swift
+++ b/damus/Components/HalfSheet.swift
@@ -1,8 +1,0 @@
-//
-//  HalfSheet.swift
-//  damus
-//
-//  Created by eric on 3/8/23.
-//
-
-import Foundation

--- a/damus/Views/ActionBar/EventActionBar.swift
+++ b/damus/Views/ActionBar/EventActionBar.swift
@@ -28,8 +28,11 @@ struct EventActionBar: View {
     @State var sheet: ActionBarSheet? = nil
     @State var confirm_boost: Bool = false
     @State var show_share_sheet: Bool = false
+    @State var show_share_action: Bool = false
     
     @ObservedObject var bar: ActionBarModel
+    
+    @Environment(\.colorScheme) var colorScheme
     
     init(damus_state: DamusState, event: NostrEvent, bar: ActionBarModel? = nil, test_lnurl: String? = nil) {
         self.damus_state = damus_state
@@ -88,9 +91,22 @@ struct EventActionBar: View {
 
             Spacer()
             EventActionButton(img: "square.and.arrow.up", col: Color.gray) {
-                show_share_sheet = true
+                show_share_action = true
             }
             .accessibilityLabel(NSLocalizedString("Share", comment: "Button to share a post"))
+        }
+        .sheet(isPresented: $show_share_action) {
+            if #available(iOS 16.0, *) {
+                ShareAction(event: event, bookmarks: damus_state.bookmarks, show_share_sheet: $show_share_sheet, show_share_action: $show_share_action)
+                    .presentationDetents([.height(300)])
+                    .presentationDragIndicator(.visible)
+            } else {
+                if let note_id = bech32_note_id(event.id) {
+                    if let url = URL(string: "https://damus.io/" + note_id) {
+                        ShareSheet(activityItems: [url])
+                    }
+                }
+            }
         }
         .sheet(isPresented: $show_share_sheet) {
             if let note_id = bech32_note_id(event.id) {

--- a/damus/Views/ActionBar/ShareAction.swift
+++ b/damus/Views/ActionBar/ShareAction.swift
@@ -1,0 +1,110 @@
+//
+//  ShareAction.swift
+//  damus
+//
+//  Created by eric on 3/8/23.
+//
+
+import SwiftUI
+
+struct ShareAction: View {
+    let event: NostrEvent
+    let bookmarks: BookmarksManager
+    @State private var isBookmarked: Bool = false
+
+    @Binding var show_share_sheet: Bool
+    @Binding var show_share_action: Bool
+    
+    @Environment(\.colorScheme) var colorScheme
+    
+    init(event: NostrEvent, bookmarks: BookmarksManager, show_share_sheet: Binding<Bool>, show_share_action: Binding<Bool>) {
+        let bookmarked = bookmarks.isBookmarked(event)
+        self._isBookmarked = State(initialValue: bookmarked)
+        
+        self.bookmarks = bookmarks
+        self.event = event
+        self._show_share_sheet = show_share_sheet
+        self._show_share_action = show_share_action
+    }
+    
+    var body: some View {
+        
+        let col = colorScheme == .light ? Color("DamusMediumGrey") : Color("DamusWhite")
+        
+        VStack {
+            Text("Share Note")
+                .padding()
+                .font(.system(size: 17, weight: .bold))
+            
+            Spacer()
+
+            HStack(alignment: .top, spacing: 25) {
+                
+                ShareActionButton(img: "link", txt: "Copy Link", comment: "Button to copy link to note", col: col) {
+                    show_share_action = false
+                    UIPasteboard.general.string = "https://damus.io/" + (bech32_note_id(event.id) ?? event.id)
+                }
+                
+                let bookmarkImg = isBookmarked ? "bookmark.slash" : "bookmark"
+                let bookmarkTxt = isBookmarked ? "Remove\nBookmark" : "Bookmark"
+                let boomarkCol = isBookmarked ? Color(.red) : col
+                ShareActionButton(img: bookmarkImg, txt: bookmarkTxt, comment: "Button to bookmark to note", col: boomarkCol) {
+                    show_share_action = false
+                    self.bookmarks.updateBookmark(event)
+                    isBookmarked = self.bookmarks.isBookmarked(event)
+                }
+                
+                ShareActionButton(img: "globe", txt: "Broadcast", comment: "Button to broadcast note to all your relays", col: col) {
+                    show_share_action = false
+                    NotificationCenter.default.post(name: .broadcast_event, object: event)
+                }
+                
+                ShareActionButton(img: "square.and.arrow.up", txt: "Share Via...", comment: "Button to present iOS share sheet", col: col) {
+                    show_share_action = false
+                    show_share_sheet = true
+                }
+                
+            }
+            
+            Spacer()
+            
+            HStack {
+                
+                Button(action: {
+                    show_share_action = false
+                }) {
+                    Text(NSLocalizedString("Cancel", comment: "Button to cancel a repost."))
+                    .frame(minWidth: 300, maxWidth: .infinity, minHeight: 50, maxHeight: 50, alignment: .center)
+                    .foregroundColor(colorScheme == .light ? Color("DamusBlack") : Color("DamusWhite"))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 24)
+                            .stroke(colorScheme == .light ? Color("DamusMediumGrey") : Color("DamusWhite"), lineWidth: 1)
+                    }
+                    .padding(EdgeInsets(top: 10, leading: 50, bottom: 25, trailing: 50))
+                }
+            }
+        }
+    }
+}
+
+func ShareActionButton(img: String, txt: String, comment: String, col: Color, action: @escaping () -> ()) -> some View {
+    Button(action: action) {
+        VStack() {
+            Image(systemName: img)
+                .foregroundColor(col)
+                .font(.system(size: 23, weight: .bold))
+                .overlay {
+                    Circle()
+                        .stroke(col, lineWidth: 1)
+                        .frame(width: 55.0, height: 55.0)
+                }
+                .frame(height: 25)
+            Text(NSLocalizedString(txt, comment: comment))
+                .foregroundColor(col)
+                .font(.footnote)
+                .multilineTextAlignment(.center)
+                .padding(.top)
+        }
+    }
+
+}


### PR DESCRIPTION
This PR modifies the previous share sheet being shown to be a half sheet modal with additional options. Allows the user to:
- Copy Link of a note
- Bookmark note
- Broadcast note
- Or Share note via the iOS share sheet options

 ![copylink](https://user-images.githubusercontent.com/14004132/223912913-1a3256d5-a5b2-4d97-81c9-dda217a52306.gif) ![bookmark](https://user-images.githubusercontent.com/14004132/223912901-d9e8ebe4-7345-478a-a9de-3587f83f0ea5.gif) ![broadcast_and_share](https://user-images.githubusercontent.com/14004132/223912905-0172ba51-c50f-4e14-8931-bb733b7f489b.gif)
