### PR TITLE
Use systemBackground for CustomPicker (only shows on macOS)

### DIFF
--- a/damus/Components/CustomPicker.swift
+++ b/damus/Components/CustomPicker.swift
@@ -52,6 +52,7 @@ struct CustomPicker<SelectionValue: Hashable, Content: View>: View {
                 .accentColor(tag == selection ? textColor() : .gray)
             }
         }
+        .background(Color(UIColor.systemBackground))
     }
     
     func textColor() -> Color {


### PR DESCRIPTION
The custom picker on macOS has an odd background, this makes it match the rest of the app.

**macOS**
| Before (Dark) |
| - |
| <img width="1025" alt="Screenshot 2023-03-08 at 11 24 40 PM" src="https://user-images.githubusercontent.com/264977/223952389-be186be3-ffef-45d3-80ff-8620356bff85.png"> |
| After (Dark) |
| <img width="1206" alt="Screenshot 2023-03-08 at 11 32 19 PM" src="https://user-images.githubusercontent.com/264977/223952519-85280a64-8cdf-4bc8-bce9-a0b9e947cc98.png"> |




**iOS** (should be unchanged)
| Light | Dark |
| - | - |
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-08 at 23 32 52](https://user-images.githubusercontent.com/264977/223952694-33f844f1-4b6d-478f-8d84-3022db0027fd.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-08 at 23 32 54](https://user-images.githubusercontent.com/264977/223952766-c823ec79-d6b8-4078-a4c7-5b0310c68b2a.png) |

