### PR TITLE
Fix Issue #741 - Space after #hashtag in search displays no results

### DIFF
--- a/damus/Views/SearchResultsView.swift
+++ b/damus/Views/SearchResultsView.swift
@@ -96,7 +96,7 @@ func search_changed(profiles: Profiles, _ new: String) -> Search? {
     }
     
     if new.first! == "#" {
-        let ht = String(new.dropFirst())
+        let ht = String(new.dropFirst().filter{$0 != " "})
         return .hashtag(ht)
     }
     


### PR DESCRIPTION
Fix Issue #741 

Fix:
-Filter out whitespaces from the `Search.hashtag` value obtained from the search query (ie `search`, the source-of-truth)
-As expected, the proper hashtag shows below in the NavigationLink - with no spaces

Screenshots:
[Search entry]
![Screenshot 2023-03-12 at 6 00 56 PM](https://user-images.githubusercontent.com/47217795/224577498-41b8c56e-ec9e-4a98-9c8b-c56a4e56df04.png)

[On tap of link]
![Screenshot 2023-03-12 at 6 27 11 PM](https://user-images.githubusercontent.com/47217795/224577579-ba957af9-d1db-4de3-94e7-89b26e604a0d.png)
