### PR TITLE
Fix Issue #766 - Unable to render a non-image URL ending in 'gif'

### DIFF
--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -240,7 +240,8 @@ func render_blocks(blocks: [Block], profiles: Profiles, privkey: String?) -> Not
 
 func is_image_url(_ url: URL) -> Bool {
     let str = url.lastPathComponent.lowercased()
-    return str.hasSuffix("png") || str.hasSuffix("jpg") || str.hasSuffix("jpeg") || str.hasSuffix("gif")
+    let isUrl = str.hasSuffix(".png") || str.hasSuffix(".jpg") || str.hasSuffix(".jpeg") || str.hasSuffix(".gif")
+    return isUrl
 }
 
 func lookup_cached_preview_size(previews: PreviewCache, evid: String) -> CGFloat? {


### PR DESCRIPTION
Fix Issue: #766

Fix:
Include `.` in image extensions checked for in `url.lastPathComponent`, 
to avoid catching url(s) ending w/ those strings as words (eg. https://ezgif.com/webp-to-gif)

Screenshot [Searching reference note ID: note1gud8lr2ljxlg2n2gvr670x85u2wp0lr5ler6ygxc537vp70qmrvqzrn2v3]:
![Screenshot 2023-03-13 at 12 18 17 AM](https://user-images.githubusercontent.com/47217795/224607270-27ce7975-2aba-430e-8550-3c35289f4578.png)
