### PR TITLE
configurable-custom-zap-sheet

### DIFF
--- a/damus/Components/ZapButton.swift
+++ b/damus/Components/ZapButton.swift
@@ -75,19 +75,22 @@ struct ZapButton: View {
                     .font(.footnote.weight(.medium))
             })
             .simultaneousGesture(LongPressGesture().onEnded {_  in
-                guard !zapping else {
+                guard !zapping, get_zap_sheet_display(pubkey: damus_state.pubkey) == false else {
                     return
                 }
-                
-                self.showing_zap_customizer = true
+                showing_zap_customizer = true
             })
             .simultaneousGesture(TapGesture().onEnded {_  in
                 guard !zapping else {
                     return
                 }
-                
-                send_zap(damus_state: damus_state, event: event, lnurl: lnurl, is_custom: false, comment: nil, amount_sats: nil, zap_type: ZapType.pub)
-                self.zapping = true
+
+                if get_zap_sheet_display(pubkey: damus_state.pubkey) {
+                    showing_zap_customizer = true
+                } else {
+                    send_zap(damus_state: damus_state, event: event, lnurl: lnurl, is_custom: false, comment: nil, amount_sats: nil, zap_type: ZapType.pub)
+                    zapping = true
+                }
             })
             .accessibilityLabel(NSLocalizedString("Zap", comment: "Accessibility label for zap button"))
 

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -26,6 +26,16 @@ func set_default_zap_amount(pubkey: String, amount: Int) {
     UserDefaults.standard.setValue(amount, forKey: key)
 }
 
+func set_zap_sheet_display(pubkey: String, display: Bool) {
+    let key = pk_setting_key(pubkey, key: "zap_sheet_display_key")
+    UserDefaults.standard.setValue(display, forKey: key)
+}
+
+func get_zap_sheet_display(pubkey: String) -> Bool {
+    let key = pk_setting_key(pubkey, key: "zap_sheet_display_key")
+    return UserDefaults.standard.bool(forKey: key)
+}
+
 func get_default_zap_amount(pubkey: String) -> Int? {
     let key = default_zap_setting_key(pubkey: pubkey)
     let amt = UserDefaults.standard.integer(forKey: key)

--- a/damusTests/ReplyDescriptionTests.swift
+++ b/damusTests/ReplyDescriptionTests.swift
@@ -8,6 +8,8 @@
 import XCTest
 @testable import damus
 
+/* The Github test suite is failing below.
+
 final class ReplyDescriptionTests: XCTestCase {
 
     let enUsLocale = Locale(identifier: "en-US")
@@ -84,3 +86,4 @@ final class ReplyDescriptionTests: XCTestCase {
         }
     }
 }
+*/

--- a/damusTests/ReplyDescriptionTests.swift
+++ b/damusTests/ReplyDescriptionTests.swift
@@ -83,5 +83,4 @@ final class ReplyDescriptionTests: XCTestCase {
             }
         }
     }
-
 }

--- a/damusTests/ReplyDescriptionTests.swift
+++ b/damusTests/ReplyDescriptionTests.swift
@@ -8,8 +8,6 @@
 import XCTest
 @testable import damus
 
-/* The Github test suite is failing below.
-
 final class ReplyDescriptionTests: XCTestCase {
 
     let enUsLocale = Locale(identifier: "en-US")
@@ -86,4 +84,3 @@ final class ReplyDescriptionTests: XCTestCase {
         }
     }
 }
-*/


### PR DESCRIPTION
**Story:**
The new users might not know anything about Zap. Considering the new users, it is always good to show the users the custom zap sheet by default. Once the users are habituated, they can turn off the sheet by switching off the toggle (located by the end of the sheet) and immediately defining their default zap amount on the same zap sheet (next to the toggle). That being said, the long pressing of zap icon will always trigger the custom zap sheet at given point of time. 

**Relevant screenshots (two):**
![Simulator Screen Shot - iPhone 14 - 2023-03-14 at 20 04 07](https://user-images.githubusercontent.com/120697811/225170902-0de64b80-ac53-4de8-9195-1d3aba065c94.png)
![Simulator Screen Shot - iPhone 14 - 2023-03-14 at 20 04 18](https://user-images.githubusercontent.com/120697811/225170905-0de41eb1-cf82-44a2-83b2-62ea3ca14185.png)
