### PR TITLE
Unblur image on long press in threads / blur again when long press ends

### DIFF
--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -32,6 +32,7 @@ struct NoteContentView: View {
 
     @State var artifacts: NoteArtifacts
     @State var preview: LinkViewRepresentable?
+    @State private var blur_images: Bool = true
     
     init(damus_state: DamusState, event: NostrEvent, show_images: Bool, size: EventViewKind, artifacts: NoteArtifacts, truncate: Bool) {
         self.damus_state = damus_state
@@ -46,6 +47,18 @@ struct NoteContentView: View {
     }
     
     func MainContent() -> some View {
+        
+        let unblur_gesture = LongPressGesture()
+            .onEnded { _ in
+                blur_images = false
+            }
+            .sequenced(
+                before: DragGesture(minimumDistance: 0)
+                    .onEnded { _ in
+                        blur_images = true
+                    }
+            )
+        
         return VStack(alignment: .leading) {
             
             if size == .selected {
@@ -60,9 +73,10 @@ struct NoteContentView: View {
                 ImageCarousel(urls: artifacts.images)
             } else if !show_images && artifacts.images.count > 0 {
                 ZStack {
-                    ImageCarousel(urls: artifacts.images)
-                    Blur()
-                        .disabled(true)
+                    ImageCarousel(urls: artifacts.images).gesture(unblur_gesture)
+                    if blur_images {
+                        Blur().disabled(true)
+                    }
                 }
                 .cornerRadius(10)
             }


### PR DESCRIPTION
This change removes the blur overlay on an image in a thread on long press, and blurs again once the user stops pressing.
