### PR TITLE
fixes issue where pasteboard.co image links don't render

### DIFF
--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -239,9 +239,20 @@ func render_blocks(blocks: [Block], profiles: Profiles, privkey: String?) -> Not
 }
 
 func is_image_url(_ url: URL) -> Bool {
-    let str = url.lastPathComponent.lowercased()
-    let isUrl = str.hasSuffix(".png") || str.hasSuffix(".jpg") || str.hasSuffix(".jpeg") || str.hasSuffix(".gif")
-    return isUrl
+    // Some media hosts provide links to an "image preview" with
+    // ads and other content instead of directly to an image file,
+    // which causes problems with rendering in an image view.
+    let hostsThatWrapImages = [
+        "pasteboard.co"
+    ]
+    guard let comps = URLComponents(url: url, resolvingAgainstBaseURL: false),
+          let host = comps.host,
+          !hostsThatWrapImages.contains(host) else {
+        return false
+    }
+    
+    let path = comps.path.lowercased()
+    return path.hasSuffix(".png") || path.hasSuffix(".jpg") || path.hasSuffix(".jpeg") || path.hasSuffix(".gif")
 }
 
 func lookup_cached_preview_size(previews: PreviewCache, evid: String) -> CGFloat? {


### PR DESCRIPTION
This PR fixes an issue where images from pasteboard.co do not render in `EventView`. It appears to be because although the URLs from pasteboard end with common image format file extensions, the content is actually html rather than image data. If we instead treat it as a non-image link, the meta information from pasteboard.co will be rendered in the view.

|Before|After|
|---|---|
|![bad](https://user-images.githubusercontent.com/445882/225639030-2694786f-268d-43ec-a5bd-826aacfaf86b.png)|![good](https://user-images.githubusercontent.com/445882/225639086-8c49a0b6-bc29-4927-8196-0e7f9e842228.png)|
