### PR TITLE
Fix notifications to show previews and allow tapping reaction text to navigate to threaded event

### DIFF
--- a/damus/Views/Notifications/EventGroupView.swift
+++ b/damus/Views/Notifications/EventGroupView.swift
@@ -206,17 +206,20 @@ struct EventGroupView: View {
             VStack(alignment: .leading) {
                 ProfilePicturesView(state: state, events: group.events)
                 
-                GroupDescription
-                
                 if let event {
                     let thread = ThreadModel(event: event, damus_state: state)
                     let dest = ThreadView(state: state, thread: thread)
                     NavigationLink(destination: dest) {
-                        Text(render_note_content(ev: event, profiles: state.profiles, privkey: state.keypair.privkey).content)
-                            .padding([.top], 1)
-                            .foregroundColor(.gray)
+                        VStack(alignment: .leading) {
+                            GroupDescription
+                            EventBody(damus_state: state, event: event, size: .normal, options: [])
+                                .padding([.top], 1)
+                                .foregroundColor(.gray)
+                        }
                     }
                     .buttonStyle(.plain)
+                } else {
+                    GroupDescription
                 }
             }
         }


### PR DESCRIPTION
![Simulator Screen Recording - iPhone 14 Pro - 2023-03-24 at 22 08 49](https://user-images.githubusercontent.com/963907/227694939-0ca612d3-5141-4f7f-87ed-599eedf03569.gif)
