### PR TITLE
simplify grey colors with an adaptable color in xcassets

### DIFF
--- a/damus/Assets.xcassets/Colors/DamusAdaptableGrey.colorset/Contents.json
+++ b/damus/Assets.xcassets/Colors/DamusAdaptableGrey.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF4",
+          "green" : "0xEE",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x1E",
+          "green" : "0x1C",
+          "red" : "0x1C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/damus/Views/Events/MutedEventView.swift
+++ b/damus/Views/Events/MutedEventView.swift
@@ -14,7 +14,6 @@ struct MutedEventView: View {
     
     let selected: Bool
     @State var shown: Bool
-    @Environment(\.colorScheme) var colorScheme
     
     init(damus_state: DamusState, event: NostrEvent, scroller: ScrollViewProxy?, selected: Bool) {
         self.damus_state = damus_state
@@ -28,14 +27,10 @@ struct MutedEventView: View {
         return !should_show_event(contacts: damus_state.contacts, ev: event)
     }
     
-    var FillColor: Color {
-        colorScheme == .light ? Color("DamusLightGrey") : Color("DamusDarkGrey")
-    }
-    
     var MutedBox: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 20)
-                .foregroundColor(FillColor)
+                .foregroundColor(Color("DamusAdaptableGrey"))
             
             HStack {
                 Text("Post from a user you've blocked", comment: "Text to indicate that what is being shown is a post from a user who has been blocked.")

--- a/damus/Views/Profile/FollowsYou.swift
+++ b/damus/Views/Profile/FollowsYou.swift
@@ -8,11 +8,6 @@
 import SwiftUI
 
 struct FollowsYou: View {
-    @Environment(\.colorScheme) var colorScheme
-
-    var fill_color: Color {
-        colorScheme == .light ? Color("DamusLightGrey") : Color("DamusDarkGrey")
-    }
     
     var body: some View {
         Text("Follows you", comment: "Text to indicate that a user is following your profile.")
@@ -21,7 +16,7 @@ struct FollowsYou: View {
             .foregroundColor(.gray)
             .background {
                 RoundedRectangle(cornerRadius: 5.0)
-                    .foregroundColor(fill_color)
+                    .foregroundColor(Color("DamusAdaptableGrey"))
             }
             .font(.footnote)
     }

--- a/damus/Views/Profile/ProfileView.swift
+++ b/damus/Views/Profile/ProfileView.swift
@@ -143,10 +143,6 @@ struct ProfileView: View {
     @Environment(\.openURL) var openURL
     @Environment(\.presentationMode) var presentationMode
     
-    func fillColor() -> Color {
-        colorScheme == .light ? Color("DamusLightGrey") : Color("DamusDarkGrey")
-    }
-    
     func imageBorderColor() -> Color {
         colorScheme == .light ? Color("DamusWhite") : Color("DamusBlack")
     }
@@ -496,10 +492,6 @@ struct KeyView: View {
     
     @State private var isCopied = false
     
-    func fillColor() -> Color {
-        colorScheme == .light ? Color("DamusLightGrey") : Color("DamusDarkGrey")
-    }
-    
     func keyColor() -> Color {
         colorScheme == .light ? Color("DamusBlack") : Color("DamusWhite")
     }
@@ -538,7 +530,7 @@ struct KeyView: View {
             }
             .padding(2)
             .padding([.leading, .trailing], 3)
-            .background(RoundedRectangle(cornerRadius: 11).foregroundColor(fillColor()))
+            .background(RoundedRectangle(cornerRadius: 11).foregroundColor(Color("DamusAdaptableGrey")))
                         
             if isCopied != true {
                 Button {


### PR DESCRIPTION
This PR simplifies the common usage of light grey and dark grey colors that adapt to the environment by adding a single adaptable grey color that combines DamusLightGrey and DamusDarkGrey.

<img width="540" alt="damus_—_Assets_xcassets" src="https://user-images.githubusercontent.com/445882/227729925-4ba8a13a-3e69-40e7-af0f-853b7836c4a6.png">



This allows this code:
```swift
@Environment(\.colorScheme) var colorScheme

colorScheme == .light ? Color("DamusDarkGrey") : Color("DamusLightGrey")
```

to be replaced with this code:
```swift
Color("DamusAdaptableGrey")
```