### PR TITLE
removed-zero-width-character

### DIFF
--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -55,8 +55,8 @@ struct PostView: View {
         }
 
         var content = post.string
-        content = content.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
         content = content.replacingOccurrences(of: "\u{200B}", with: "")
+        content = content.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
         let new_post = NostrPost(content: content, references: references, kind: kind)
 
         NotificationCenter.default.post(name: .post, object: NostrPostResult.post(new_post))

--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -54,7 +54,9 @@ struct PostView: View {
             }
         }
 
-        let content = self.post.string.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        var content = post.string
+        content = content.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        content = content.replacingOccurrences(of: "\u{200B}", with: "")
         let new_post = NostrPost(content: content, references: references, kind: kind)
 
         NotificationCenter.default.post(name: .post, object: NostrPostResult.post(new_post))


### PR DESCRIPTION
This removes zero-width-character u{200B} before submitting the post. The reason it is being used is because it allows user to place comma or hyphen immediately next to @mentions without passing the link attributes to these characters while composing their post in post view