### PR TITLE
Add support for nostr: bech32 urls in posts and DMs

### DIFF
--- a/damus-c/bech32_mention.c
+++ b/damus-c/bech32_mention.c
@@ -1,0 +1,156 @@
+//
+//  bech32_mention.c
+//  damus
+//
+//  Created by Bartholomew Joyce on 2023-04-03.
+//
+
+#include "bech32_mention.h"
+#include "bech32.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define TLV_SPECIAL 0
+#define TLV_RELAY 1
+#define TLV_AUTHOR 2
+#define TLV_KIND 3
+
+int bech32_mention_parse(bech32_mention_t *mention, const char* str, int len) {
+
+    char prefix[len];
+    u8 words[len];
+    size_t words_len;
+    size_t max_input_len = len + 2;
+
+    if (bech32_decode(prefix, words, &words_len, str, max_input_len) == BECH32_ENCODING_NONE) {
+        return 0;
+    }
+
+    memset(mention, 0, sizeof(bech32_mention_t));
+    mention->kind = -1;
+    mention->buffer = (u8*)malloc(words_len);
+
+    size_t data_len = 0;
+    if (!bech32_convert_bits(mention->buffer, &data_len, 8, words, words_len, 5, 0)) {
+        goto fail;
+    }
+
+    // Parse type
+    if (strcmp(prefix, "note") == 0) {
+        mention->type = BECH32_MENTION_NOTE;
+    } else if (strcmp(prefix, "npub") == 0) {
+        mention->type = BECH32_MENTION_NPUB;
+    } else if (strcmp(prefix, "nprofile") == 0) {
+        mention->type = BECH32_MENTION_NPROFILE;
+    } else if (strcmp(prefix, "nevent") == 0) {
+        mention->type = BECH32_MENTION_NEVENT;
+    } else if (strcmp(prefix, "nrelay") == 0) {
+        mention->type = BECH32_MENTION_NRELAY;
+    } else if (strcmp(prefix, "naddr") == 0) {
+        mention->type = BECH32_MENTION_NADDR;
+    } else {
+        goto fail;
+    }
+
+    // Parse notes and npubs (non-TLV)
+    if (mention->type == BECH32_MENTION_NOTE || mention->type == BECH32_MENTION_NPUB) {
+        if (data_len != 32) goto fail;
+        if (mention->type == BECH32_MENTION_NOTE) {
+            mention->event_id = mention->buffer;
+        } else {
+            mention->pubkey = mention->buffer;
+        }
+        goto ok;
+    }
+
+    // Parse TLV entities
+    const int MAX_VALUES = 16;
+    int values_count = 0;
+    u8 Ts[MAX_VALUES];
+    u8 Ls[MAX_VALUES];
+    u8* Vs[MAX_VALUES];
+    for (int i = 0; i < data_len - 1;) {
+        if (values_count == MAX_VALUES) goto fail;
+
+        Ts[values_count] = mention->buffer[i++];
+        Ls[values_count] = mention->buffer[i++];
+        if (Ls[values_count] > data_len - i) goto fail;
+
+        Vs[values_count] = &mention->buffer[i];
+        i += Ls[values_count];
+        ++values_count;
+    }
+
+    // Decode and validate all TLV-type entities
+    if (mention->type == BECH32_MENTION_NPROFILE) {
+        for (int i = 0; i < values_count; ++i) {
+            if (Ts[i] == TLV_SPECIAL) {
+                if (Ls[i] != 32 || mention->pubkey) goto fail;
+                mention->pubkey = Vs[i];
+            } else if (Ts[i] == TLV_RELAY) {
+                if (mention->relays_count == MAX_RELAYS) goto fail;
+                Vs[i][Ls[i]] = 0;
+                mention->relays[mention->relays_count++] = (char*)Vs[i];
+            } else {
+                goto fail;
+            }
+        }
+        if (!mention->pubkey) goto fail;
+
+    } else if (mention->type == BECH32_MENTION_NEVENT) {
+        for (int i = 0; i < values_count; ++i) {
+            if (Ts[i] == TLV_SPECIAL) {
+                if (Ls[i] != 32 || mention->event_id) goto fail;
+                mention->event_id = Vs[i];
+            } else if (Ts[i] == TLV_RELAY) {
+                if (mention->relays_count == MAX_RELAYS) goto fail;
+                Vs[i][Ls[i]] = 0;
+                mention->relays[mention->relays_count++] = (char*)Vs[i];
+            } else if (Ts[i] == TLV_AUTHOR) {
+                if (Ls[i] != 32 || mention->pubkey) goto fail;
+                mention->pubkey = Vs[i];
+            } else {
+                goto fail;
+            }
+        }
+        if (!mention->event_id) goto fail;
+
+    } else if (mention->type == BECH32_MENTION_NRELAY) {
+        if (values_count != 1 || Ts[0] != TLV_SPECIAL) goto fail;
+        Vs[0][Ls[0]] = 0;
+        mention->relays[mention->relays_count++] = (char*)Vs[0];
+
+    } else { // entity.type == BECH32_MENTION_NADDR
+        for (int i = 0; i < values_count; ++i) {
+            if (Ts[i] == TLV_SPECIAL) {
+                Vs[i][Ls[i]] = 0;
+                mention->identifier = (char*)Vs[i];
+            } else if (Ts[i] == TLV_RELAY) {
+                if (mention->relays_count == MAX_RELAYS) goto fail;
+                Vs[i][Ls[i]] = 0;
+                mention->relays[mention->relays_count++] = (char*)Vs[i];
+            } else if (Ts[i] == TLV_AUTHOR) {
+                if (Ls[i] != 32 || mention->pubkey) goto fail;
+                mention->pubkey = Vs[i];
+            } else if (Ts[i] == TLV_KIND) {
+                if (Ls[i] != sizeof(int) || mention->kind != -1) goto fail;
+                mention->kind = *(int*)Vs[i];
+            } else {
+                goto fail;
+            }
+        }
+        if (!mention->identifier || mention->kind == -1 || !mention->pubkey) goto fail;
+    }
+
+ok:
+    return 1;
+
+fail:
+    free(mention->buffer);
+    return 0;
+}
+
+void bech32_mention_free(bech32_mention_t *mention) {
+    free(mention->buffer);
+    mention->buffer = 0;
+}

--- a/damus-c/bech32_mention.h
+++ b/damus-c/bech32_mention.h
@@ -1,0 +1,40 @@
+//
+//  bech32_mention.h
+//  damus
+//
+//  Created by Bartholomew Joyce on 2023-04-03.
+//
+
+#ifndef bech32_mention
+#define bech32_mention
+
+typedef unsigned char u8;
+
+#define MAX_RELAYS 10
+
+enum bech32_mention_type {
+    BECH32_MENTION_NOTE = 1,
+    BECH32_MENTION_NPUB = 2,
+    BECH32_MENTION_NPROFILE = 3,
+    BECH32_MENTION_NEVENT = 4,
+    BECH32_MENTION_NRELAY = 5,
+    BECH32_MENTION_NADDR = 6,
+};
+
+typedef struct bech32_mention {
+    enum bech32_mention_type type;
+
+    u8 *event_id;
+    u8 *pubkey;
+    char *identifier;
+    char *relays[MAX_RELAYS];
+    int relays_count;
+    int kind;
+
+    u8* buffer;
+} bech32_mention_t;
+
+int bech32_mention_parse(bech32_mention_t *mention, const char* str, int len);
+void bech32_mention_free(bech32_mention_t *mention);
+
+#endif /* bech32_mention */

--- a/damus-c/damus.c
+++ b/damus-c/damus.c
@@ -7,14 +7,9 @@
 
 #include "damus.h"
 #include "bolt11.h"
-#include "bech32.h"
+#include "bech32_mention.h"
 #include <stdlib.h>
 #include <string.h>
-
-#define TLV_SPECIAL 0
-#define TLV_RELAY 1
-#define TLV_AUTHOR 2
-#define TLV_KIND 3
 
 struct cursor {
     const u8 *p;
@@ -293,147 +288,22 @@ static int parse_mention_bech32(struct cursor *cur, struct block *block) {
 
     end = cur->p;
 
-    char str[end - start_entity + 1];
-    str[end - start_entity] = 0;
-    memcpy(str, start_entity, end - start_entity);
+    int len = (int)(end - start_entity);
+    char str[len + 1];
+    str[len] = 0;
+    memcpy(str, start_entity, len);
 
-    char prefix[end - start_entity];
-    u8 data[end - start_entity];
-    size_t data_len;
-    size_t max_input_len = end - start_entity + 2;
-
-    if (bech32_decode(prefix, data, &data_len, str, max_input_len) == BECH32_ENCODING_NONE) {
+    bech32_mention_t mention;
+    if (!bech32_mention_parse(&mention, str, len)) {
         cur->p = start;
         return 0;
     }
 
-    struct mention_bech32_block mention = { 0 };
-    mention.kind = -1;
-    mention.buffer = (u8*)malloc(data_len);
-    mention.str.start = (const char*)start;
-    mention.str.end = (const char*)end;
-
-    size_t len = 0;
-    if (!bech32_convert_bits(mention.buffer, &len, 8, data, data_len, 5, 0)) {
-        goto fail;
-    }
-
-    // Parse type
-    if (strcmp(prefix, "note") == 0) {
-        mention.type = NOSTR_BECH32_NOTE;
-    } else if (strcmp(prefix, "npub") == 0) {
-        mention.type = NOSTR_BECH32_NPUB;
-    } else if (strcmp(prefix, "nprofile") == 0) {
-        mention.type = NOSTR_BECH32_NPROFILE;
-    } else if (strcmp(prefix, "nevent") == 0) {
-        mention.type = NOSTR_BECH32_NEVENT;
-    } else if (strcmp(prefix, "nrelay") == 0) {
-        mention.type = NOSTR_BECH32_NRELAY;
-    } else if (strcmp(prefix, "naddr") == 0) {
-        mention.type = NOSTR_BECH32_NADDR;
-    } else {
-        goto fail;
-    }
-
-    // Parse notes and npubs (non-TLV)
-    if (mention.type == NOSTR_BECH32_NOTE || mention.type == NOSTR_BECH32_NPUB) {
-        if (len != 32) goto fail;
-        if (mention.type == NOSTR_BECH32_NOTE) {
-            mention.event_id = mention.buffer;
-        } else {
-            mention.pubkey = mention.buffer;
-        }
-        goto ok;
-    }
-
-    // Parse TLV entities
-    const int MAX_VALUES = 16;
-    int values_count = 0;
-    u8 Ts[MAX_VALUES];
-    u8 Ls[MAX_VALUES];
-    u8* Vs[MAX_VALUES];
-    for (int i = 0; i < len - 1;) {
-        if (values_count == MAX_VALUES) goto fail;
-
-        Ts[values_count] = mention.buffer[i++];
-        Ls[values_count] = mention.buffer[i++];
-        if (Ls[values_count] > len - i) goto fail;
-
-        Vs[values_count] = &mention.buffer[i];
-        i += Ls[values_count];
-        ++values_count;
-    }
-
-    // Decode and validate all TLV-type entities
-    if (mention.type == NOSTR_BECH32_NPROFILE) {
-        for (int i = 0; i < values_count; ++i) {
-            if (Ts[i] == TLV_SPECIAL) {
-                if (Ls[i] != 32 || mention.pubkey) goto fail;
-                mention.pubkey = Vs[i];
-            } else if (Ts[i] == TLV_RELAY) {
-                if (mention.relays_count == MAX_RELAYS) goto fail;
-                Vs[i][Ls[i]] = 0;
-                mention.relays[mention.relays_count++] = (char*)Vs[i];
-            } else {
-                goto fail;
-            }
-        }
-        if (!mention.pubkey) goto fail;
-
-    } else if (mention.type == NOSTR_BECH32_NEVENT) {
-        for (int i = 0; i < values_count; ++i) {
-            if (Ts[i] == TLV_SPECIAL) {
-                if (Ls[i] != 32 || mention.event_id) goto fail;
-                mention.event_id = Vs[i];
-            } else if (Ts[i] == TLV_RELAY) {
-                if (mention.relays_count == MAX_RELAYS) goto fail;
-                Vs[i][Ls[i]] = 0;
-                mention.relays[mention.relays_count++] = (char*)Vs[i];
-            } else if (Ts[i] == TLV_AUTHOR) {
-                if (Ls[i] != 32 || mention.pubkey) goto fail;
-                mention.pubkey = Vs[i];
-            } else {
-                goto fail;
-            }
-        }
-        if (!mention.event_id) goto fail;
-
-    } else if (mention.type == NOSTR_BECH32_NRELAY) {
-        if (values_count != 1 || Ts[0] != TLV_SPECIAL) goto fail;
-        Vs[0][Ls[0]] = 0;
-        mention.relays[mention.relays_count++] = (char*)Vs[0];
-
-    } else { // entity.type == NOSTR_BECH32_NADDR
-        for (int i = 0; i < values_count; ++i) {
-            if (Ts[i] == TLV_SPECIAL) {
-                Vs[i][Ls[i]] = 0;
-                mention.identifier = (char*)Vs[i];
-            } else if (Ts[i] == TLV_RELAY) {
-                if (mention.relays_count == MAX_RELAYS) goto fail;
-                Vs[i][Ls[i]] = 0;
-                mention.relays[mention.relays_count++] = (char*)Vs[i];
-            } else if (Ts[i] == TLV_AUTHOR) {
-                if (Ls[i] != 32 || mention.pubkey) goto fail;
-                mention.pubkey = Vs[i];
-            } else if (Ts[i] == TLV_KIND) {
-                if (Ls[i] != sizeof(int) || mention.kind != -1) goto fail;
-                mention.kind = *(int*)Vs[i];
-            } else {
-                goto fail;
-            }
-        }
-        if (!mention.identifier || mention.kind == -1 || !mention.pubkey) goto fail;
-    }
-
-ok:
     block->type = BLOCK_MENTION_BECH32;
-    block->block.mention_bech32 = mention;
+    block->block.mention_bech32.str.start = (const char*)start;
+    block->block.mention_bech32.str.end = (const char*)end;
+    block->block.mention_bech32.mention = mention;
     return 1;
-
-fail:
-    free(mention.buffer);
-    cur->p = start;
-    return 0;
 }
 
 static int add_text_then_block(struct cursor *cur, struct blocks *blocks, struct block block, const u8 **start, const u8 *pre_mention)
@@ -507,8 +377,7 @@ void blocks_free(struct blocks *blocks) {
 
     for (int i = 0; i < blocks->num_blocks; ++i) {
         if (blocks->blocks[i].type == BLOCK_MENTION_BECH32) {
-            free(blocks->blocks[i].block.mention_bech32.buffer);
-            blocks->blocks[i].block.mention_bech32.buffer = NULL;
+            bech32_mention_free(&blocks->blocks[i].block.mention_bech32.mention);
         }
     }
 

--- a/damus-c/damus.c
+++ b/damus-c/damus.c
@@ -7,10 +7,14 @@
 
 #include "damus.h"
 #include "bolt11.h"
+#include "bech32.h"
 #include <stdlib.h>
 #include <string.h>
 
-typedef unsigned char u8;
+#define TLV_SPECIAL 0
+#define TLV_RELAY 1
+#define TLV_AUTHOR 2
+#define TLV_KIND 3
 
 struct cursor {
     const u8 *p;
@@ -126,7 +130,7 @@ static int parse_str(struct cursor *cur, const char *str) {
     return 1;
 }
 
-static int parse_mention(struct cursor *cur, struct block *block) {
+static int parse_mention_index(struct cursor *cur, struct block *block) {
     int d1, d2, d3, ind;
     const u8 *start = cur->p;
     
@@ -151,8 +155,8 @@ static int parse_mention(struct cursor *cur, struct block *block) {
         return 0;
     }
     
-    block->type = BLOCK_MENTION;
-    block->block.mention = ind;
+    block->type = BLOCK_MENTION_INDEX;
+    block->block.mention_index = ind;
     
     return 1;
 }
@@ -274,6 +278,164 @@ static int parse_invoice(struct cursor *cur, struct block *block) {
     return 1;
 }
 
+static int parse_mention_bech32(struct cursor *cur, struct block *block) {
+    const u8 *start, *start_entity, *end;
+
+    start = cur->p;
+    if (!parse_str(cur, "nostr:"))
+        return 0;
+
+    start_entity = cur->p;
+    if (!consume_until_whitespace(cur, 1)) {
+        cur->p = start;
+        return 0;
+    }
+
+    end = cur->p;
+
+    char str[end - start_entity + 1];
+    str[end - start_entity] = 0;
+    memcpy(str, start_entity, end - start_entity);
+
+    char prefix[end - start_entity];
+    u8 data[end - start_entity];
+    size_t data_len;
+    size_t max_input_len = end - start_entity + 2;
+
+    if (bech32_decode(prefix, data, &data_len, str, max_input_len) == BECH32_ENCODING_NONE) {
+        cur->p = start;
+        return 0;
+    }
+
+    struct mention_bech32_block mention = { 0 };
+    mention.kind = -1;
+    mention.buffer = (u8*)malloc(data_len);
+    mention.str.start = (const char*)start;
+    mention.str.end = (const char*)end;
+
+    size_t len = 0;
+    if (!bech32_convert_bits(mention.buffer, &len, 8, data, data_len, 5, 0)) {
+        goto fail;
+    }
+
+    // Parse type
+    if (strcmp(prefix, "note") == 0) {
+        mention.type = NOSTR_BECH32_NOTE;
+    } else if (strcmp(prefix, "npub") == 0) {
+        mention.type = NOSTR_BECH32_NPUB;
+    } else if (strcmp(prefix, "nprofile") == 0) {
+        mention.type = NOSTR_BECH32_NPROFILE;
+    } else if (strcmp(prefix, "nevent") == 0) {
+        mention.type = NOSTR_BECH32_NEVENT;
+    } else if (strcmp(prefix, "nrelay") == 0) {
+        mention.type = NOSTR_BECH32_NRELAY;
+    } else if (strcmp(prefix, "naddr") == 0) {
+        mention.type = NOSTR_BECH32_NADDR;
+    } else {
+        goto fail;
+    }
+
+    // Parse notes and npubs (non-TLV)
+    if (mention.type == NOSTR_BECH32_NOTE || mention.type == NOSTR_BECH32_NPUB) {
+        if (len != 32) goto fail;
+        if (mention.type == NOSTR_BECH32_NOTE) {
+            mention.event_id = mention.buffer;
+        } else {
+            mention.pubkey = mention.buffer;
+        }
+        goto ok;
+    }
+
+    // Parse TLV entities
+    const int MAX_VALUES = 16;
+    int values_count = 0;
+    u8 Ts[MAX_VALUES];
+    u8 Ls[MAX_VALUES];
+    u8* Vs[MAX_VALUES];
+    for (int i = 0; i < len - 1;) {
+        if (values_count == MAX_VALUES) goto fail;
+
+        Ts[values_count] = mention.buffer[i++];
+        Ls[values_count] = mention.buffer[i++];
+        if (Ls[values_count] > len - i) goto fail;
+
+        Vs[values_count] = &mention.buffer[i];
+        i += Ls[values_count];
+        ++values_count;
+    }
+
+    // Decode and validate all TLV-type entities
+    if (mention.type == NOSTR_BECH32_NPROFILE) {
+        for (int i = 0; i < values_count; ++i) {
+            if (Ts[i] == TLV_SPECIAL) {
+                if (Ls[i] != 32 || mention.pubkey) goto fail;
+                mention.pubkey = Vs[i];
+            } else if (Ts[i] == TLV_RELAY) {
+                if (mention.relays_count == MAX_RELAYS) goto fail;
+                Vs[i][Ls[i]] = 0;
+                mention.relays[mention.relays_count++] = (char*)Vs[i];
+            } else {
+                goto fail;
+            }
+        }
+        if (!mention.pubkey) goto fail;
+
+    } else if (mention.type == NOSTR_BECH32_NEVENT) {
+        for (int i = 0; i < values_count; ++i) {
+            if (Ts[i] == TLV_SPECIAL) {
+                if (Ls[i] != 32 || mention.event_id) goto fail;
+                mention.event_id = Vs[i];
+            } else if (Ts[i] == TLV_RELAY) {
+                if (mention.relays_count == MAX_RELAYS) goto fail;
+                Vs[i][Ls[i]] = 0;
+                mention.relays[mention.relays_count++] = (char*)Vs[i];
+            } else if (Ts[i] == TLV_AUTHOR) {
+                if (Ls[i] != 32 || mention.pubkey) goto fail;
+                mention.pubkey = Vs[i];
+            } else {
+                goto fail;
+            }
+        }
+        if (!mention.event_id) goto fail;
+
+    } else if (mention.type == NOSTR_BECH32_NRELAY) {
+        if (values_count != 1 || Ts[0] != TLV_SPECIAL) goto fail;
+        Vs[0][Ls[0]] = 0;
+        mention.relays[mention.relays_count++] = (char*)Vs[0];
+
+    } else { // entity.type == NOSTR_BECH32_NADDR
+        for (int i = 0; i < values_count; ++i) {
+            if (Ts[i] == TLV_SPECIAL) {
+                Vs[i][Ls[i]] = 0;
+                mention.identifier = (char*)Vs[i];
+            } else if (Ts[i] == TLV_RELAY) {
+                if (mention.relays_count == MAX_RELAYS) goto fail;
+                Vs[i][Ls[i]] = 0;
+                mention.relays[mention.relays_count++] = (char*)Vs[i];
+            } else if (Ts[i] == TLV_AUTHOR) {
+                if (Ls[i] != 32 || mention.pubkey) goto fail;
+                mention.pubkey = Vs[i];
+            } else if (Ts[i] == TLV_KIND) {
+                if (Ls[i] != sizeof(int) || mention.kind != -1) goto fail;
+                mention.kind = *(int*)Vs[i];
+            } else {
+                goto fail;
+            }
+        }
+        if (!mention.identifier || mention.kind == -1 || !mention.pubkey) goto fail;
+    }
+
+ok:
+    block->type = BLOCK_MENTION_BECH32;
+    block->block.mention_bech32 = mention;
+    return 1;
+
+fail:
+    free(mention.buffer);
+    cur->p = start;
+    return 0;
+}
+
 static int add_text_then_block(struct cursor *cur, struct blocks *blocks, struct block block, const u8 **start, const u8 *pre_mention)
 {
     if (!add_text_block(blocks, *start, pre_mention))
@@ -303,7 +465,7 @@ int damus_parse_content(struct blocks *blocks, const char *content) {
         
         pre_mention = cur.p;
         if (cp == -1 || is_whitespace(cp)) {
-            if (c == '#' && (parse_mention(&cur, &block) || parse_hashtag(&cur, &block))) {
+            if (c == '#' && (parse_mention_index(&cur, &block) || parse_hashtag(&cur, &block))) {
                 if (!add_text_then_block(&cur, blocks, block, &start, pre_mention))
                     return 0;
                 continue;
@@ -312,6 +474,10 @@ int damus_parse_content(struct blocks *blocks, const char *content) {
                     return 0;
                 continue;
             } else if ((c == 'l' || c == 'L') && parse_invoice(&cur, &block)) {
+                if (!add_text_then_block(&cur, blocks, block, &start, pre_mention))
+                    return 0;
+                continue;
+            } else if (c == 'n' && parse_mention_bech32(&cur, &block)) {
                 if (!add_text_then_block(&cur, blocks, block, &start, pre_mention))
                     return 0;
                 continue;
@@ -335,8 +501,17 @@ void blocks_init(struct blocks *blocks) {
 }
 
 void blocks_free(struct blocks *blocks) {
-    if (blocks->blocks) {
-        free(blocks->blocks);
-        blocks->num_blocks = 0;
+    if (!blocks->blocks) {
+        return;
     }
+
+    for (int i = 0; i < blocks->num_blocks; ++i) {
+        if (blocks->blocks[i].type == BLOCK_MENTION_BECH32) {
+            free(blocks->blocks[i].block.mention_bech32.buffer);
+            blocks->blocks[i].block.mention_bech32.buffer = NULL;
+        }
+    }
+
+    free(blocks->blocks);
+    blocks->num_blocks = 0;
 }

--- a/damus-c/damus.h
+++ b/damus-c/damus.h
@@ -9,15 +9,27 @@
 #define damus_h
 
 #include <stdio.h>
+typedef unsigned char u8;
 
 #define MAX_BLOCKS 1024
+#define MAX_RELAYS 10
 
 enum block_type {
     BLOCK_HASHTAG = 1,
     BLOCK_TEXT = 2,
-    BLOCK_MENTION = 3,
-    BLOCK_URL = 4,
-    BLOCK_INVOICE = 5,
+    BLOCK_MENTION_INDEX = 3,
+    BLOCK_MENTION_BECH32 = 4,
+    BLOCK_URL = 5,
+    BLOCK_INVOICE = 6,
+};
+
+enum nostr_bech32_type {
+    NOSTR_BECH32_NOTE = 1,
+    NOSTR_BECH32_NPUB = 2,
+    NOSTR_BECH32_NPROFILE = 3,
+    NOSTR_BECH32_NEVENT = 4,
+    NOSTR_BECH32_NRELAY = 5,
+    NOSTR_BECH32_NADDR = 6,
 };
 
 typedef struct str_block {
@@ -32,12 +44,27 @@ typedef struct invoice_block {
     };
 } invoice_block_t;
 
+typedef struct mention_bech32_block {
+    struct str_block str;
+    enum nostr_bech32_type type;
+
+    u8 *event_id;
+    u8 *pubkey;
+    char *identifier;
+    char *relays[MAX_RELAYS];
+    int relays_count;
+    int kind;
+
+    u8* buffer;
+} mention_bech32_block_t;
+
 typedef struct block {
     enum block_type type;
     union {
         struct str_block str;
         struct invoice_block invoice;
-        int mention;
+        struct mention_bech32_block mention_bech32;
+        int mention_index;
     } block;
 } block_t;
 

--- a/damus-c/damus.h
+++ b/damus-c/damus.h
@@ -9,10 +9,9 @@
 #define damus_h
 
 #include <stdio.h>
-typedef unsigned char u8;
+#include "bech32_mention.h"
 
 #define MAX_BLOCKS 1024
-#define MAX_RELAYS 10
 
 enum block_type {
     BLOCK_HASHTAG = 1,
@@ -21,15 +20,6 @@ enum block_type {
     BLOCK_MENTION_BECH32 = 4,
     BLOCK_URL = 5,
     BLOCK_INVOICE = 6,
-};
-
-enum nostr_bech32_type {
-    NOSTR_BECH32_NOTE = 1,
-    NOSTR_BECH32_NPUB = 2,
-    NOSTR_BECH32_NPROFILE = 3,
-    NOSTR_BECH32_NEVENT = 4,
-    NOSTR_BECH32_NRELAY = 5,
-    NOSTR_BECH32_NADDR = 6,
 };
 
 typedef struct str_block {
@@ -46,16 +36,7 @@ typedef struct invoice_block {
 
 typedef struct mention_bech32_block {
     struct str_block str;
-    enum nostr_bech32_type type;
-
-    u8 *event_id;
-    u8 *pubkey;
-    char *identifier;
-    char *relays[MAX_RELAYS];
-    int relays_count;
-    int kind;
-
-    u8* buffer;
+    bech32_mention_t mention;
 } mention_bech32_block_t;
 
 typedef struct block {

--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		9609F058296E220800069BF3 /* BannerImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9609F057296E220800069BF3 /* BannerImageView.swift */; };
 		9C83F89329A937B900136C08 /* TextViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C83F89229A937B900136C08 /* TextViewWrapper.swift */; };
 		9CA876E229A00CEA0003B9A3 /* AttachMediaUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA876E129A00CE90003B9A3 /* AttachMediaUtility.swift */; };
+		A421C3A529DB541D0062AE12 /* bech32_mention.c in Sources */ = {isa = PBXBuildFile; fileRef = A421C3A329DB541D0062AE12 /* bech32_mention.c */; };
 		BA693074295D649800ADDB87 /* UserSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA693073295D649800ADDB87 /* UserSettingsStore.swift */; };
 		BAB68BED29543FA3007BA466 /* SelectWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */; };
 		DD597CBD2963D85A00C64D32 /* MarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD597CBC2963D85A00C64D32 /* MarkdownTests.swift */; };
@@ -635,6 +636,8 @@
 		9609F057296E220800069BF3 /* BannerImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerImageView.swift; sourceTree = "<group>"; };
 		9C83F89229A937B900136C08 /* TextViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextViewWrapper.swift; sourceTree = "<group>"; };
 		9CA876E129A00CE90003B9A3 /* AttachMediaUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachMediaUtility.swift; sourceTree = "<group>"; };
+		A421C3A329DB541D0062AE12 /* bech32_mention.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = bech32_mention.c; sourceTree = "<group>"; };
+		A421C3A429DB541D0062AE12 /* bech32_mention.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = bech32_mention.h; sourceTree = "<group>"; };
 		BA693073295D649800ADDB87 /* UserSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsStore.swift; sourceTree = "<group>"; };
 		BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectWalletView.swift; sourceTree = "<group>"; };
 		DD597CBC2963D85A00C64D32 /* MarkdownTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarkdownTests.swift; sourceTree = "<group>"; };
@@ -697,6 +700,8 @@
 		4C06670728FDE62900038D2A /* damus-c */ = {
 			isa = PBXGroup;
 			children = (
+				A421C3A329DB541D0062AE12 /* bech32_mention.c */,
+				A421C3A429DB541D0062AE12 /* bech32_mention.h */,
 				4C06670928FDE64700038D2A /* damus.h */,
 				4C06670A28FDE64700038D2A /* damus.c */,
 				4C06670828FDE64700038D2A /* damus-Bridging-Header.h */,
@@ -1620,6 +1625,7 @@
 				4C99737B28C92A9200E53835 /* ChatroomMetadata.swift in Sources */,
 				4CC7AAF4297F18B400430951 /* ReplyDescription.swift in Sources */,
 				4C75EFA427FA577B0006080F /* PostView.swift in Sources */,
+				A421C3A529DB541D0062AE12 /* bech32_mention.c in Sources */,
 				4C30AC7229A5677A00E2BD5A /* NotificationsView.swift in Sources */,
 				4C75EFB528049D790006080F /* Relay.swift in Sources */,
 				4CEE2AF1280B216B00AB5EEF /* EventDetailView.swift in Sources */,

--- a/damus/Models/EventRef.swift
+++ b/damus/Models/EventRef.swift
@@ -76,6 +76,8 @@ func build_mention_indices(_ blocks: [Block], type: MentionType) -> Set<Int> {
             if m.type == type {
                 acc.insert(m.index)
             }
+        case .mention_bech32:
+            return
         case .text:
             return
         case .hashtag:

--- a/damus/Models/EventRef.swift
+++ b/damus/Models/EventRef.swift
@@ -74,10 +74,10 @@ func build_mention_indices(_ blocks: [Block], type: MentionType) -> Set<Int> {
         switch block {
         case .mention(let m):
             if m.type == type {
-                acc.insert(m.index)
+                if let idx = m.index {
+                    acc.insert(idx)
+                }
             }
-        case .mention_bech32:
-            return
         case .text:
             return
         case .hashtag:

--- a/damus/Models/Mentions.swift
+++ b/damus/Models/Mentions.swift
@@ -317,26 +317,26 @@ func convert_invoice_block(_ b: invoice_block) -> Block? {
 
 func convert_mention_bech32_block(_ b: mention_bech32_block) -> Block?
 {
-    let relay_id = b.relays_count > 0 ? String(cString: b.relays.0!) : nil
+    let relay_id = b.mention.relays_count > 0 ? String(cString: b.mention.relays.0!) : nil
 
-    switch b.type {
-    case NOSTR_BECH32_NOTE:
+    switch b.mention.type {
+    case BECH32_MENTION_NOTE:
         fallthrough
-    case NOSTR_BECH32_NEVENT:
-        let event_id = hex_encode(Data(bytes: b.event_id, count: 32))
+    case BECH32_MENTION_NEVENT:
+        let event_id = hex_encode(Data(bytes: b.mention.event_id, count: 32))
         let event_id_ref = ReferencedId(ref_id: event_id, relay_id: relay_id, key: "e")
         return .mention(Mention(index: nil, type: .event, ref: event_id_ref))
 
-    case NOSTR_BECH32_NPUB:
+    case BECH32_MENTION_NPUB:
         fallthrough
-    case NOSTR_BECH32_NPROFILE:
-        let pubkey = hex_encode(Data(bytes: b.pubkey, count: 32))
+    case BECH32_MENTION_NPROFILE:
+        let pubkey = hex_encode(Data(bytes: b.mention.pubkey, count: 32))
         let pubkey_ref = ReferencedId(ref_id: pubkey, relay_id: relay_id, key: "p")
         return .mention(Mention(index: nil, type: .pubkey, ref: pubkey_ref))
 
-    case NOSTR_BECH32_NRELAY:
+    case BECH32_MENTION_NRELAY:
         fallthrough
-    case NOSTR_BECH32_NADDR:
+    case BECH32_MENTION_NADDR:
         return .text(strblock_to_string(b.str)!)
 
     default:

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -144,13 +144,6 @@ struct NoteContentView: View {
                         if m.type == .pubkey && m.ref.ref_id == profile.pubkey {
                             self.artifacts = render_note_content(ev: event, profiles: damus_state.profiles, privkey: damus_state.keypair.privkey)
                         }
-                    case .mention_bech32(let n):
-                        guard case .npub(let ref) = n.entity else {
-                            return
-                        }
-                        if ref.ref_id == profile.pubkey {
-                            self.artifacts = render_note_content(ev: event, profiles: damus_state.profiles, privkey: damus_state.keypair.privkey)
-                        }
                     case .text: return
                     case .hashtag: return
                     case .url: return
@@ -227,43 +220,6 @@ func mention_str(_ m: Mention, profiles: Profiles) -> AttributedString {
     }
 }
 
-func mention_bech32_str(_ n: MentionBech32, profiles: Profiles) -> AttributedString {
-    switch n.entity {
-    case .note(let ref):
-        let bevid = bech32_note_id(ref.ref_id) ?? ref.ref_id
-        var attributedString = AttributedString(stringLiteral: "@\(abbrev_pubkey(bevid))")
-        attributedString.link = URL(string: "damus:\(encode_event_id_uri(ref))")
-        attributedString.foregroundColor = Color("DamusPurple")
-        return attributedString
-    case .npub(let ref):
-        let pk = ref.ref_id
-        let profile = profiles.lookup(id: pk)
-        let disp = Profile.displayName(profile: profile, pubkey: pk).username
-        var attributedString = AttributedString(stringLiteral: "@\(disp)")
-        attributedString.link = URL(string: "damus:\(encode_pubkey_uri(ref))")
-        attributedString.foregroundColor = Color("DamusPurple")
-        return attributedString
-    case .nprofile(let ref):
-        let pk = ref.ref_id
-        let profile = profiles.lookup(id: pk)
-        let disp = Profile.displayName(profile: profile, pubkey: pk).username
-        var attributedString = AttributedString(stringLiteral: "@\(disp)")
-        attributedString.link = URL(string: "damus:\(encode_pubkey_uri(ref))")
-        attributedString.foregroundColor = Color("DamusPurple")
-        return attributedString
-    case .nevent(let ref, _):
-        let bevid = bech32_note_id(ref.ref_id) ?? ref.ref_id
-        var attributedString = AttributedString(stringLiteral: "@\(abbrev_pubkey(bevid))")
-        attributedString.link = URL(string: "damus:\(encode_event_id_uri(ref))")
-        attributedString.foregroundColor = Color("DamusPurple")
-        return attributedString
-    case .nrelay(_):
-        return AttributedString(stringLiteral: n.raw)
-    case .naddr(_, _, _):
-        return AttributedString(stringLiteral: n.raw)
-    }
-}
-
 struct NoteContentView_Previews: PreviewProvider {
     static var previews: some View {
         let state = test_damus_state()
@@ -323,8 +279,6 @@ func render_blocks(blocks: [Block], profiles: Profiles, privkey: String?) -> Not
                 link_urls.append(url)
                 return str + url_str(url)
             }
-        case .mention_bech32(let n):
-            return str + mention_bech32_str(n, profiles: profiles)
         }
     }
 


### PR DESCRIPTION
I've added the necessary C and Swift code to parse and display `nostr:npub` `nostr:note` `nostr:nevent` `nostr:nprofile` `nostr:naddr` and `nostr:nrelay` correctly in posts and DMs. The hope is to extend support for [NIP-27](https://github.com/nostr-protocol/nips/blob/master/27.md), where `p` and `e` tags are now optional. Users who want to publish notes referencing pubkeys or events in the content without having the references tagged can use the standard `nostr:` syntax instead of `#[idx]`.

This will come in handy later in order to remove `#[idx]` references entirely from DMs to stop mentions from leaking into the public.

