### PR TITLE
Add a Divider in the Follows List for Large Screens

### DIFF
--- a/damus/Views/FollowingView.swift
+++ b/damus/Views/FollowingView.swift
@@ -33,6 +33,7 @@ struct FollowersView: View {
             LazyVStack(alignment: .leading) {
                 ForEach(followers.contacts ?? [], id: \.self) { pk in
                     FollowUserView(target: .pubkey(pk), damus_state: damus_state)
+                    Divider()
                 }
             }
             .padding()
@@ -45,7 +46,6 @@ struct FollowersView: View {
             followers.unsubscribe()
         }
     }
-    
 }
 
 struct FollowingView: View {


### PR DESCRIPTION
Hard to see which follow button is for who on large screens without a divider.

| (Before) Light | (Before) Dark | (After) Light | (After) Dark |
| - | - | - | - |
| ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-29 at 19 17 56](https://user-images.githubusercontent.com/264977/228711557-ebb7bbca-c680-41c4-80fa-1996f5dfae29.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-29 at 19 17 46](https://user-images.githubusercontent.com/264977/228711635-906930d5-10d6-47ba-b8b8-1d96c8bf4ae1.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-29 at 19 14 56](https://user-images.githubusercontent.com/264977/228711693-978f30ce-8aa9-4242-a78b-3ad10059d169.png) | ![Simulator Screen Shot - iPad Pro (12 9-inch) (6th generation) - 2023-03-29 at 19 15 27](https://user-images.githubusercontent.com/264977/228711742-b72c6d5e-d628-456d-a784-c63c694c9244.png) |