### PR TITLE
Fix Typo in DamusColors

### DIFF
--- a/damus/Components/DamusColors.swift
+++ b/damus/Components/DamusColors.swift
@@ -14,7 +14,7 @@ class DamusColors {
     static let black = Color("DamusBlack")
     static let lightGrey = Color("DamusLightGrey")
     static let mediumGrey = Color("DamusMediumGrey")
-    static let darkGrey = Color("DamusDarkGray")
+    static let darkGrey = Color("DamusDarkGrey")
     static let green = Color("DamusGreen")
     static let purple = Color("DamusPurple")
     static let blue = Color("DamusBlue")


### PR DESCRIPTION
Was seeing this in the console: `No color named 'DamusDarkGray' found in asset catalog for main bundle`