### PR TITLE
don't show NIP-05 validation error message when field is empty

### DIFF
--- a/damus/Views/EditMetadataView.swift
+++ b/damus/Views/EditMetadataView.swift
@@ -201,8 +201,10 @@ struct EditMetadataView: View {
                 }, footer: {
                     if let parts = nip05_parts {
                         Text("'\(parts.username)' at '\(parts.host)' will be used for verification", comment: "Description of how the nip05 identifier would be used for verification.")
-                    } else {
+                    } else if !nip05.isEmpty {
                         Text("'\(nip05)' is an invalid NIP-05 identifier. It should look like an email.", comment: "Description of why the nip05 identifier is invalid.")
+                    } else {
+                        Text("")    // without this, the keyboard dismisses unnecessarily when the footer changes state
                     }
                 })
 


### PR DESCRIPTION
Fixes https://github.com/damus-io/damus/issues/851 where the NIP-05 validation error is shown even when the field is empty.

|Before|After|
|---|---|
|![broken](https://user-images.githubusercontent.com/445882/229302462-a6e1b3e4-39a0-428f-8bbc-bd5429f61fa4.gif)|![fixed](https://user-images.githubusercontent.com/445882/229302474-3b8a0322-d8ce-42d0-98c0-1603f0a5341d.gif)|
