### PR TITLE
damus-notification-settings

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -761,7 +761,7 @@ func update_filters_with_since(last_of_kind: [Int: NostrEvent], filters: [NostrF
 
 
 
-func setup_notifications() {
+func setup_notifications(showAlert: Binding<Bool>? = nil) {
     
     UIApplication.shared.registerForRemoteNotifications()
     let center = UNUserNotificationCenter.current()
@@ -771,7 +771,11 @@ func setup_notifications() {
             center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
                 
             }
-            
+
+            if let al = showAlert {
+                al.wrappedValue = true
+            }
+
             return
         }
     }

--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -392,26 +392,76 @@ struct ConfigView: View {
 
 struct NotificationView: View {
     @ObservedObject var settings: UserSettingsStore
+    @State private var showAlert = false
 
     var body: some View {
         Form {
             Section(header: Text(NSLocalizedString("Local Notifications", comment: "Section header for damus local notifications user configuration"))) {
                 Toggle(NSLocalizedString("Zaps", comment: "Setting to enable Zap Local Notification"), isOn: $settings.zap_notification)
                     .toggleStyle(.switch)
+                    .onChange(of: settings.zap_notification) { newValue in
+                        if newValue {
+                            setup_notifications(showAlert: $showAlert)
+                        }
+                    }
+
                 Toggle(NSLocalizedString("Mentions", comment: "Setting to enable Mention Local Notification"), isOn: $settings.mention_notification)
                     .toggleStyle(.switch)
+                    .onChange(of: settings.mention_notification) { newValue in
+                        if newValue {
+                            setup_notifications(showAlert: $showAlert)
+                        }
+                    }
+
                 Toggle(NSLocalizedString("Reposts", comment: "Setting to enable Repost Local Notification"), isOn: $settings.repost_notification)
                     .toggleStyle(.switch)
+                    .onChange(of: settings.repost_notification) { newValue in
+                        if newValue {
+                            setup_notifications(showAlert: $showAlert)
+                        }
+                    }
+
                 Toggle(NSLocalizedString("Likes", comment: "Setting to enable Like Local Notification"), isOn: $settings.like_notification)
                     .toggleStyle(.switch)
+                    .onChange(of: settings.like_notification) { newValue in
+                        if newValue {
+                            setup_notifications(showAlert: $showAlert)
+                        }
+                    }
+
                 Toggle(NSLocalizedString("DMs", comment: "Setting to enable DM Local Notification"), isOn: $settings.dm_notification)
                     .toggleStyle(.switch)
+                    .onChange(of: settings.dm_notification) { newValue in
+                        if newValue {
+                            setup_notifications(showAlert: $showAlert)
+                        }
+                    }
             }
 
             Section(header: Text(NSLocalizedString("Notification Preference", comment: "Section header for Notification Preferences"))) {
                 Toggle(NSLocalizedString("Show only from users you follow", comment: "Setting to Show notifications only associated to users your follow"), isOn: $settings.notification_only_from_following)
                     .toggleStyle(.switch)
+                    .onChange(of: settings.notification_only_from_following) { newValue in
+                        if newValue {
+                            setup_notifications(showAlert: $showAlert)
+                        }
+                    }
             }
+        }
+        .alert(isPresented: $showAlert) {
+            Alert(
+                title: Text(NSLocalizedString("Notifications Disabled", comment: "Notifications Disabled heading of alert view")),
+                message: Text(NSLocalizedString("Please enable notifications to receive important updates.", comment: "Description of alert view")),
+                primaryButton: .default(Text(NSLocalizedString("Settings", comment: "Settings button")), action: {
+                    guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
+                        return
+                    }
+                    if UIApplication.shared.canOpenURL(settingsUrl) {
+                        UIApplication.shared.open(settingsUrl)
+                    }
+                }),
+                secondaryButton: .cancel()
+            )
         }
     }
 }


### PR DESCRIPTION
(Only when system notification was turned off)

Guide to Damus's system iOS Notifications settings page when trying to turn on the local notifications

https://user-images.githubusercontent.com/120697811/229975404-ae028d08-ed0d-4fff-81e3-50db06357516.mov

