### PR TITLE
convert damus.io links to @note and @npub to stay in Damus

### DIFF
--- a/damus/Components/TranslateView.swift
+++ b/damus/Components/TranslateView.swift
@@ -27,13 +27,15 @@ struct TranslateView: View {
     let event: NostrEvent
     let size: EventViewKind
     let currentLanguage: String
+    @Binding var tappedUniversalLink: URL?
     
     @State var translated: TranslateStatus
     
-    init(damus_state: DamusState, event: NostrEvent, size: EventViewKind) {
+    init(damus_state: DamusState, event: NostrEvent, size: EventViewKind, tappedUniversalLink: Binding<URL?>) {
         self.damus_state = damus_state
         self.event = event
         self.size = size
+        _tappedUniversalLink = tappedUniversalLink
         
         if #available(iOS 16, *) {
             self.currentLanguage = Locale.current.language.languageCode?.identifier ?? "en"
@@ -65,12 +67,7 @@ struct TranslateView: View {
                 .font(.footnote)
                 .padding([.top, .bottom], 10)
             
-            if self.size == .selected {
-                SelectableText(attributedString: artifacts.content.attributed, size: self.size)
-            } else {
-                artifacts.content.text
-                    .font(eventviewsize_to_font(self.size))
-            }
+            SelectableText(attributedString: artifacts.content.attributed, size: size, tappedUniversalLink: $tappedUniversalLink)
         }
     }
     
@@ -180,6 +177,6 @@ extension View {
 struct TranslateView_Previews: PreviewProvider {
     static var previews: some View {
         let ds = test_damus_state()
-        TranslateView(damus_state: ds, event: test_event, size: .normal)
+        TranslateView(damus_state: ds, event: test_event, size: .normal, tappedUniversalLink: .constant(nil))
     }
 }

--- a/damus/Components/TruncatedText.swift
+++ b/damus/Components/TruncatedText.swift
@@ -9,18 +9,15 @@ import SwiftUI
 
 struct TruncatedText: View {
     let text: CompatibleText
+    let size: EventViewKind
+    @Binding var tappedUniversalLink: URL?
     let maxChars: Int = 280
     
     var body: some View {
         let truncatedAttributedString: AttributedString? = getTruncatedString()
         
-        if let truncatedAttributedString {
-            Text(truncatedAttributedString)
-                .fixedSize(horizontal: false, vertical: true)
-        } else {
-            text.text
-                .fixedSize(horizontal: false, vertical: true)
-        }
+        SelectableText(attributedString: truncatedAttributedString ?? text.attributed, size: size, tappedUniversalLink: $tappedUniversalLink)
+            .fixedSize(horizontal: false, vertical: true)
         
         if truncatedAttributedString != nil {
             Spacer()
@@ -43,10 +40,10 @@ struct TruncatedText: View {
 struct TruncatedText_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 100) {
-            TruncatedText(text: CompatibleText(stringLiteral: "hello\nthere\none\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\neleven"))
+            TruncatedText(text: CompatibleText(stringLiteral: "hello\nthere\none\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\neleven"), size: .normal, tappedUniversalLink: .constant(nil))
                 .frame(width: 200, height: 200)
             
-            TruncatedText(text: CompatibleText(stringLiteral: "hello\nthere\none\ntwo\nthree\nfour"))
+            TruncatedText(text: CompatibleText(stringLiteral: "hello\nthere\none\ntwo\nthree\nfour"), size: .normal, tappedUniversalLink: .constant(nil))
                 .frame(width: 200, height: 200)
         }
     }


### PR DESCRIPTION
This PR converts damus.io links to @note... and @npub... so that the user stays in Damus rather than opening Safari to snort.social. Additionally, we will not render the link preview.

Strategy:  
Copy the pattern in `ContentView` for handling universal deep links (external damus.io links) into `NoteContentView` (I'd love to factor this into shared code, might try that next). Make use of `UITextViewDelegate` in `TextViewRepresentable` to intercept the tapped link and redirect it to stay in Damus. Pass a `Binding<URL?>` down the view hierarchy from `NoteContentView` and listen for changes there. I also made use of `SelectableText` in more cases because it already had the `TextViewRepresentable` in it, but if that causes other problems I can rework it.

|Before|After|
|---|---|
| feed||
|![feed-bad](https://user-images.githubusercontent.com/445882/230755317-ea5c37ec-ae2d-4850-a046-c4ab4857fb45.gif)|![feed-good](https://user-images.githubusercontent.com/445882/230755395-a0c96b5c-5b02-4cce-bd7e-d4dc51b2dea7.gif)|
| dm||
|![dm-bad](https://user-images.githubusercontent.com/445882/230755426-bc5a2067-f182-422a-922a-1442247c4770.gif)|![dm-good](https://user-images.githubusercontent.com/445882/230755432-cb724780-530b-48a1-b053-7be7f42eb90e.gif)|
| translate view||
|![translate-bad](https://user-images.githubusercontent.com/445882/230755457-487abc80-6892-4794-b53d-3ece3d400101.gif)|![translate-good](https://user-images.githubusercontent.com/445882/230755460-b7d5a196-5e95-4e82-b2fb-efcb64aac6db.gif)|

