### PR TITLE
[UX/UI] Following List in Last Added Order

### DIFF
--- a/damus/Views/FollowingView.swift
+++ b/damus/Views/FollowingView.swift
@@ -57,7 +57,7 @@ struct FollowingView: View {
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading) {
-                ForEach(following.contacts, id: \.self) { pk in
+                ForEach(following.contacts.reversed(), id: \.self) { pk in
                     FollowUserView(target: .pubkey(pk), damus_state: damus_state)
                 }
             }


### PR DESCRIPTION
Currently the following list is presented in Earliest order ( the contact array is just an append structure where the newest contact is added at the end ).

In my opinion this may be a UX issue because users coming from Twitter expect the opposite behaviour. TWT shows Newest to Earliest user. The typical user stories for this are:

Story A
--
 * You just added someone recently,
 * You don't remember his handle so you quickly jump into the list expecting it to see it first 

Story B
--
 - You added someone
 - You changed views and realized you don't want to follow that person anymore
 - You quickly jump into the list expecting it to see it first and unfollow there


Changes
---
This is a very small change and it doesn't have any impact on performance or the structure of the data. 
It uses the .reversed() method just before presenting the list. This method returns an reverse iterator without allocating any new space or doing any kind of mutation on the data.

![damus-screenshot](https://user-images.githubusercontent.com/115233399/230799526-cef233d2-9909-4611-b82a-bfc7425f8ddf.png)


