### PR TITLE
Improved parsing of bech32 entities

### DIFF
--- a/damus-c/cursor.h
+++ b/damus-c/cursor.h
@@ -10,6 +10,7 @@
 
 #include <ctype.h>
 #include <string.h>
+#include "bech32.h"
 
 typedef unsigned char u8;
 
@@ -29,6 +30,10 @@ static inline int is_boundary(char c) {
 
 static inline int is_invalid_url_ending(char c) {
     return c == '!' || c == '?' || c == ')' || c == '.' || c == ',' || c == ';';
+}
+
+static inline int is_bech32_character(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || bech32_charset_rev[c] != -1;
 }
 
 static inline void make_cursor(struct cursor *c, const u8 *content, size_t len)
@@ -67,6 +72,23 @@ static inline int consume_until_whitespace(struct cursor *cur, int or_end) {
         consumedAtLeastOne = 1;
     }
     
+    return or_end;
+}
+
+static inline int consume_until_non_bech32_character(struct cursor *cur, int or_end) {
+    char c;
+    int consumedAtLeastOne = 0;
+
+    while (cur->p < cur->end) {
+        c = *cur->p;
+
+        if (!is_bech32_character(c))
+            return consumedAtLeastOne;
+
+        cur->p++;
+        consumedAtLeastOne = 1;
+    }
+
     return or_end;
 }
 

--- a/damus-c/nostr_bech32.c
+++ b/damus-c/nostr_bech32.c
@@ -222,7 +222,7 @@ int parse_nostr_bech32(struct cursor *cur, struct nostr_bech32 *obj) {
     
     start = cur->p;
     
-    if (!consume_until_whitespace(cur, 1)) {
+    if (!consume_until_non_bech32_character(cur, 1)) {
         cur->p = start;
         return 0;
     }


### PR DESCRIPTION
Replaced `consume_until_whitespace()` from the original implementation with `consume_until_non_bech32_character()` to allow for punctuation marks or any other non-bech32 characters to follow a `nostr:` entity without upsetting the parser.

Now things like `Hey, nostr:npub1xtscya34g58tk0z605fvr788k263gsu6cy9x0mhnm87echrgufzsevkk5s!` are parsed correctly.