### PR TITLE
[FIX][UI] Undismissable Keyboard in CustomizeZapView

### DIFF
--- a/damus/Views/Zaps/CustomizeZapView.swift
+++ b/damus/Views/Zaps/CustomizeZapView.swift
@@ -200,7 +200,6 @@ struct CustomizeZapView: View {
                     Text("Comment", comment: "Header text to indicate that the text field below it is a comment that will be used to send as part of a zap to the user.")
                 })
             }
-            .dismissKeyboardOnTap()
                 
             Section(content: {
                 ZapTypePicker
@@ -228,6 +227,7 @@ struct CustomizeZapView: View {
             }
         
         }
+        .dismissKeyboardOnTap()
     }
     
     var MainContent: some View {

--- a/damus/Views/Zaps/CustomizeZapView.swift
+++ b/damus/Views/Zaps/CustomizeZapView.swift
@@ -59,6 +59,8 @@ struct CustomizeZapView: View {
     @State var error: String?
     @State var showing_wallet_selector: Bool
     @State var zapping: Bool
+    @State var zap_button_previous_element_y_coordinate: CGFloat = 0.0
+
     
     let zap_amounts: [ZapAmountItem]
     
@@ -171,7 +173,6 @@ struct CustomizeZapView: View {
     
     var TheForm: some View {
         Form {
-                
             Group {
                 Section(content: {
                     AmountPicker
@@ -200,11 +201,15 @@ struct CustomizeZapView: View {
                     Text("Comment", comment: "Header text to indicate that the text field below it is a comment that will be used to send as part of a zap to the user.")
                 })
             }
-                
             Section(content: {
                 ZapTypePicker
             }, header: {
-                Text("Zap Type", comment: "Header text to indicate that the picker below it is to choose the type of zap to send.")
+                GeometryReader{ geo in
+                    Text("Zap Type", comment: "Header text to indicate that the picker below it is to choose the type of zap to send.")
+                        .onAppear {
+                            self.zap_button_previous_element_y_coordinate = geo.frame(in: .global).maxY
+                        }
+                }
             }, footer: {
                 Text(zap_type_desc)
             })
@@ -225,9 +230,13 @@ struct CustomizeZapView: View {
                 Text(error)
                     .foregroundColor(.red)
             }
-        
         }
-        .dismissKeyboardOnTap()
+        .overlay(
+            Color.clear
+                .frame(width: UIScreen.main.bounds.width, height: self.zap_button_previous_element_y_coordinate, alignment: .top)
+                .contentShape(Rectangle())
+                .dismissKeyboardOnTap()
+            , alignment: .top)
     }
     
     var MainContent: some View {


### PR DESCRIPTION
Dismissing the keyboard on CustomizeZapView was not as easy. 

It required tapping a very narrow label, or confunsingly, having to switch to the other textfield or selecting one of the default zaps.

This fix allows the user to dismiss the keyboard by tapping in any area ( specially important given that default behaviour is tapping an  empty area to dismiss ).

Before/After
---
![undismissable_keyboardgif](https://user-images.githubusercontent.com/115233399/231603145-7f679daf-eaf9-41ea-9e4c-1d6e07e41bc5.gif)
