### PR TITLE
Improve sats numeric entry for zaps

### DIFF
--- a/damus/Components/ZapButton.swift
+++ b/damus/Components/ZapButton.swift
@@ -173,7 +173,7 @@ func send_zap(damus_state: DamusState, event: NostrEvent, lnurl: String, is_cust
             damus_state.lnurls.endpoints[target.pubkey] = payreq
         }
         
-        let zap_amount = amount_sats ?? get_default_zap_amount(pubkey: damus_state.pubkey) ?? 1000
+        let zap_amount = amount_sats ?? get_default_zap_amount(pubkey: damus_state.pubkey)
         
         guard let inv = await fetch_zap_invoice(payreq, zapreq: zapreq, sats: zap_amount, zap_type: zap_type, comment: comment) else {
             DispatchQueue.main.async {

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -26,11 +26,13 @@ func set_default_zap_amount(pubkey: String, amount: Int) {
     UserDefaults.standard.setValue(amount, forKey: key)
 }
 
-func get_default_zap_amount(pubkey: String) -> Int? {
+let fallback_zap_amount = 1000
+
+func get_default_zap_amount(pubkey: String) -> Int {
     let key = default_zap_setting_key(pubkey: pubkey)
     let amt = UserDefaults.standard.integer(forKey: key)
     if amt == 0 {
-        return nil
+        return fallback_zap_amount
     }
     return amt
 }

--- a/damus/Views/ConfigView.swift
+++ b/damus/Views/ConfigView.swift
@@ -144,14 +144,15 @@ struct ConfigView_Previews: PreviewProvider {
 
 
 func handle_string_amount(new_value: String) -> Int? {
-    let digits = Set("0123456789")
-    let filtered = new_value.filter { digits.contains($0) }
+    let filtered = new_value.filter {
+        $0.isNumber
+    }
 
     if filtered == "" {
         return nil
     }
 
-    guard let amt = Int(filtered) else {
+    guard let amt = NumberFormatter().number(from: filtered) as? Int else {
         return nil
     }
     

--- a/damus/Views/Settings/ZapSettingsView.swift
+++ b/damus/Views/Settings/ZapSettingsView.swift
@@ -14,10 +14,10 @@ struct ZapSettingsView: View {
     
     @State var default_zap_amount: String
     @Environment(\.dismiss) var dismiss
-    
+
     init(pubkey: String, settings: UserSettingsStore) {
         self.pubkey = pubkey
-        let zap_amt = get_default_zap_amount(pubkey: pubkey).map({ "\($0)" }) ?? "1000"
+        let zap_amt = get_default_zap_amount(pubkey: pubkey).formatted()
         _default_zap_amount = State(initialValue: zap_amt)
         self._settings = ObservedObject(initialValue: settings)
     }
@@ -42,12 +42,15 @@ struct ZapSettingsView: View {
             }
             
             Section(NSLocalizedString("Default Zap Amount in sats", comment: "Title for section in zap settings that controls the default zap amount in sats.")) {
-                TextField(String("1000"), text: $default_zap_amount)
+                TextField(fallback_zap_amount.formatted(), text: $default_zap_amount)
                     .keyboardType(.numberPad)
                     .onReceive(Just(default_zap_amount)) { newValue in
                         if let parsed = handle_string_amount(new_value: newValue) {
-                            self.default_zap_amount = String(parsed)
+                            self.default_zap_amount = parsed.formatted()
                             set_default_zap_amount(pubkey: self.pubkey, amount: parsed)
+                        } else {
+                            self.default_zap_amount = ""
+                            set_default_zap_amount(pubkey: self.pubkey, amount: 0)
                         }
                     }
             }

--- a/damus/Views/Zaps/CustomizeZapView.swift
+++ b/damus/Views/Zaps/CustomizeZapView.swift
@@ -25,7 +25,7 @@ struct ZapAmountItem: Identifiable, Hashable {
 }
 
 func get_default_zap_amount_item(_ pubkey: String) -> ZapAmountItem {
-    let def = get_default_zap_amount(pubkey: pubkey) ?? 1000
+    let def = get_default_zap_amount(pubkey: pubkey)
     return ZapAmountItem(amount: def, icon: "🤙")
 }
 
@@ -181,13 +181,17 @@ struct CustomizeZapView: View {
                 })
                 
                 Section(content: {
-                    TextField(String("100000"), text: $custom_amount)
+                    // Use the selected sats amount as the placeholder text so that the UI is less confusing.
+                    // User can type in their custom amount, which hides the placeholder.
+                    TextField(selected_amount.amount.formatted(), text: $custom_amount)
                         .keyboardType(.numberPad)
                         .onReceive(Just(custom_amount)) { newValue in
-                            
                             if let parsed = handle_string_amount(new_value: newValue) {
-                                self.custom_amount = String(parsed)
+                                self.custom_amount = parsed.formatted()
                                 self.custom_amount_sats = parsed
+                            } else {
+                                self.custom_amount = ""
+                                self.custom_amount_sats = nil
                             }
                         }
                 }, header: {

--- a/damusTests/damusTests.swift
+++ b/damusTests/damusTests.swift
@@ -97,9 +97,9 @@ class damusTests: XCTestCase {
     
     func testSaveDefaultZapAmount() {
         let pubkey = "test_pubkey"
-        let amt = 1000
+        let amt = 1234
         set_default_zap_amount(pubkey: pubkey, amount: amt)
-        let loaded = get_default_zap_amount(pubkey: pubkey)!
+        let loaded = get_default_zap_amount(pubkey: pubkey)
         XCTAssertEqual(loaded, amt)
     }
     


### PR DESCRIPTION
Changelog-Changed: Add number formatting for sats entry and use selected zaps amount from picker as placeholder
Changelog-Fixed: Do not allow non-numeric characters for sats amount and fix numeric entry for other number systems for all locales

![Simulator Screen Recording - iPhone 14 Pro - 2023-04-16 at 18 13 03](https://user-images.githubusercontent.com/963907/232325917-06356e2b-ddd7-4a32-ae33-66b601e4352c.gif)
