### PR TITLE
added nokyctranslate dropdown option to settings

### DIFF
--- a/damus/Models/TranslationService.swift
+++ b/damus/Models/TranslationService.swift
@@ -19,6 +19,7 @@ enum TranslationService: String, CaseIterable, Identifiable {
     case none
     case libretranslate
     case deepl
+    case nokyctranslate
 
     var model: Model {
         switch self {
@@ -28,6 +29,8 @@ enum TranslationService: String, CaseIterable, Identifiable {
             return .init(tag: self.rawValue, displayName: NSLocalizedString("LibreTranslate (Open Source)", comment: "Dropdown option for selecting LibreTranslate as the translation service."))
         case .deepl:
             return .init(tag: self.rawValue, displayName: NSLocalizedString("DeepL (Proprietary, Higher Accuracy)", comment: "Dropdown option for selecting DeepL as the translation service."))
+        case .nokyctranslate:
+            return .init(tag: self.rawValue, displayName: NSLocalizedString("NoKYCTranslate.com (Prepay with BTC)", comment: "Dropdown option for selecting NoKYCTranslate.com as the translation service."))
         }
     }
 

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -264,6 +264,20 @@ class UserSettingsStore: ObservableObject {
         }
     }
     
+    @Published var nokyctranslate_api_key: String {
+        didSet {
+            do {
+                if nokyctranslate_api_key == "" {
+                    try clearNoKYCTranslateApiKey()
+                } else {
+                    try saveNoKYCTranslateApiKey(nokyctranslate_api_key)
+                }
+            } catch {
+                // No-op.
+            }
+        }
+    }
+    
     @Published var disable_animation: Bool {
         didSet {
             UserDefaults.standard.set(disable_animation, forKey: "disable_animation")
@@ -333,6 +347,13 @@ class UserSettingsStore: ObservableObject {
         } catch {
             deepl_api_key = ""
         }
+        
+        do {
+            nokyctranslate_api_key = try Vault.getPrivateKey(keychainConfiguration: DamusNoKYCTranslateKeychainConfiguration())
+        } catch {
+            nokyctranslate_api_key = ""
+        }
+        
     }
 
     private func saveLibreTranslateApiKey(_ apiKey: String) throws {
@@ -343,6 +364,14 @@ class UserSettingsStore: ObservableObject {
         try Vault.deletePrivateKey(keychainConfiguration: DamusLibreTranslateKeychainConfiguration())
     }
 
+    private func saveNoKYCTranslateApiKey(_ apiKey: String) throws {
+        try Vault.savePrivateKey(apiKey, keychainConfiguration: DamusNoKYCTranslateKeychainConfiguration())
+    }
+    
+    private func clearNoKYCTranslateApiKey() throws {
+        try Vault.deletePrivateKey(keychainConfiguration: DamusNoKYCTranslateKeychainConfiguration())
+    }
+    
     private func saveDeepLApiKey(_ apiKey: String) throws {
         try Vault.savePrivateKey(apiKey, keychainConfiguration: DamusDeepLKeychainConfiguration())
     }
@@ -359,6 +388,8 @@ class UserSettingsStore: ObservableObject {
             return URLComponents(string: libretranslate_url) != nil
         case .deepl:
             return deepl_api_key != ""
+        case .nokyctranslate:
+            return nokyctranslate_api_key != ""
         }
     }
 }
@@ -373,4 +404,10 @@ struct DamusDeepLKeychainConfiguration: KeychainConfiguration {
     var serviceName = "damus"
     var accessGroup: String? = nil
     var accountName = "deepl_apikey"
+}
+
+struct DamusNoKYCTranslateKeychainConfiguration: KeychainConfiguration {
+    var serviceName = "damus"
+    var accessGroup: String? = nil
+    var accountName = "nokyctranslate_apikey"
 }

--- a/damus/Util/Translator.swift
+++ b/damus/Util/Translator.swift
@@ -24,6 +24,8 @@ public struct Translator {
         switch userSettingsStore.translation_service {
         case .libretranslate:
             return try await translateWithLibreTranslate(text, from: sourceLanguage, to: targetLanguage)
+        case .nokyctranslate:
+            return try await translateWithNoKYCTranslate(text, from: sourceLanguage, to: targetLanguage)
         case .deepl:
             return try await translateWithDeepL(text, from: sourceLanguage, to: targetLanguage)
         case .none:
@@ -84,6 +86,29 @@ public struct Translator {
 
         let response: Response = try await decodedData(for: request)
         return response.translations.map { $0.text }.joined(separator: " ")
+    }
+    
+    private func translateWithNoKYCTranslate(_ text: String, from sourceLanguage: String, to targetLanguage: String) async throws -> String? {
+        let url = try makeURL("https://translate.nokyctranslate.com", path: "/translate")
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        struct RequestBody: Encodable {
+            let q: String
+            let source: String
+            let target: String
+            let api_key: String?
+        }
+        let body = RequestBody(q: text, source: sourceLanguage, target: targetLanguage, api_key: userSettingsStore.nokyctranslate_api_key)
+        request.httpBody = try encoder.encode(body)
+
+        struct Response: Decodable {
+            let translatedText: String
+        }
+        let response: Response = try await decodedData(for: request)
+        return response.translatedText
     }
 
     private func makeURL(_ baseUrl: String, path: String) throws -> URL {

--- a/damus/Views/Settings/TranslationSettingsView.swift
+++ b/damus/Views/Settings/TranslationSettingsView.swift
@@ -65,6 +65,17 @@ struct TranslationSettingsView: View {
                     }
                 }
 
+                if settings.translation_service == .nokyctranslate {
+                    SecureField(NSLocalizedString("API Key (required)", comment: "Prompt for optional entry of API Key to use translation server."), text: $settings.nokyctranslate_api_key)
+                        .disableAutocorrection(true)
+                        .disabled(settings.translation_service != .nokyctranslate)
+                        .autocapitalization(UITextAutocapitalizationType.none)
+                    
+                    if settings.nokyctranslate_api_key == "" {
+                        Link(NSLocalizedString("Get API Key with BTC/Lightning", comment: "Button to navigate to nokyctranslate website to get a translation API key."), destination: URL(string: "https://nokyctranslate.com")!)
+                    }
+                }
+                
                 if settings.translation_service != .none {
                     Toggle(NSLocalizedString("Automatically translate notes", comment: "Toggle to automatically translate notes."), isOn: $settings.auto_translate)
                         .toggleStyle(.switch)


### PR DESCRIPTION
Makes it easier for people to use nokyctranslate.com translation service by removing the need to enter a custom url via libtre translate, and instead new dropdown menu item for nokyctranslate.com with a button linking to the website. Verified that translations are working when this option is selected and API Key is given. 

I think I got everything and the merge should be easy, could one of you take a quick peek and let me know if I did something wrong? I don't do much swift development
@tyiu @jb55 