### PR TITLE
fix:resolve profiles in local feed

### DIFF
--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -322,6 +322,8 @@ class HomeModel: ObservableObject {
                     load_profiles(profiles_subid: profiles_subid, relay_id: relay_id, load: .from_events(dms), damus_state: damus_state)
                 } else if sub_id == notifications_subid {
                     load_profiles(profiles_subid: profiles_subid, relay_id: relay_id, load: .from_keys(notifications.uniq_pubkeys()), damus_state: damus_state)
+                } else if sub_id == home_subid {
+                    load_profiles(profiles_subid: profiles_subid, relay_id: relay_id, load: .from_events(events.events), damus_state: damus_state)
                 }
                 
                 self.loading = false

--- a/damus/Models/ProfileModel.swift
+++ b/damus/Models/ProfileModel.swift
@@ -140,6 +140,9 @@ class ProfileModel: ObservableObject, Equatable {
             case .notice(let notice):
                 notify(.notice, notice)
             case .eose:
+                if resp.subid == sub_id {
+                    load_profiles(profiles_subid: prof_subid, relay_id: relay_id, load: .from_events(events.events), damus_state: damus)
+                }
                 progress += 1
                 break
             }

--- a/damus/Models/SearchHomeModel.swift
+++ b/damus/Models/SearchHomeModel.swift
@@ -129,10 +129,8 @@ func find_profiles_to_fetch_from_events(profiles: Profiles, events: [NostrEvent]
     
     for ev in events {
         // lookup profiles from boosted events
-        if let bev = ev.inner_event {
-            if profiles.lookup(id: bev.pubkey) == nil {
-                pubkeys.insert(bev.pubkey)
-            }
+        if let bev = ev.inner_event, profiles.lookup(id: bev.pubkey) == nil {
+            pubkeys.insert(bev.pubkey)
         }
         
         if profiles.lookup(id: ev.pubkey) == nil {

--- a/damus/Models/SearchHomeModel.swift
+++ b/damus/Models/SearchHomeModel.swift
@@ -128,11 +128,16 @@ func find_profiles_to_fetch_from_events(profiles: Profiles, events: [NostrEvent]
     var pubkeys = Set<String>()
     
     for ev in events {
-        if profiles.lookup(id: ev.pubkey) != nil {
-            continue
+        // lookup profiles from boosted events
+        if let bev = ev.inner_event {
+            if profiles.lookup(id: bev.pubkey) == nil {
+                pubkeys.insert(bev.pubkey)
+            }
         }
         
-        pubkeys.insert(ev.pubkey)
+        if profiles.lookup(id: ev.pubkey) == nil {
+            pubkeys.insert(ev.pubkey)
+        }
     }
     
     return Array(pubkeys)


### PR DESCRIPTION
## Scope

This PR fixes the issue of missing profile information of boosted events in the local feed. 

In the process, I discovered that profiles were also missing from boosted events in the profile view, i.e. when you're navigating to your own or other people's profiles, and I decided to add that issue to the scope.

Closes #898 

## Implementation

The proposed solution tries to achieve the desired outcome with minimal code changes. Especially since this is the first Swift code I write and I'm still understanding how to write idiomatic Swift code. I also tried to mimic the patterns I've seen while familiarising myself with the code base.

The main change is addition of the following code in the function `find_profiles_to_fetch_from_events`.

~~~swift
  // lookup profiles from boosted events
  if let bev = ev.inner_event {
      if profiles.lookup(id: bev.pubkey) == nil {
          pubkeys.insert(bev.pubkey)
      }
  }
~~~        

The two other changes simply initiate the lookup from both the home model and the profile model.

## How to test

**Local feed**
1. Click on the **Home** button at the bottom of the screen to load the local feed
2. Click **Posts & Replies**
3. Scroll down until you see a boosted event
4. Notice that the profile of the booster has been resolved/looked up
![image](https://user-images.githubusercontent.com/943039/232484570-78bbdcde-ecf4-434d-87df-e39779774343.png)

**Profile view**
1. Click on the **Magnifying glass** at the bottom of the screen to load the global feed
2. Search for `npub1pnqv7krwhm2a26p3tdv9pzwgfveqkrp60um6hxaf63vqxsrlhwwqkddhfc`
3. Scroll down until you see a boosted event
![image](https://user-images.githubusercontent.com/943039/232485146-e9d0be69-37e5-4405-b5d9-82413b5976d0.png)

I also tested by importing the following public keys, who have many followers and follow many people, to try to break the solution.

`@jack npub1sg6plzptd64u62a878hep2kev88swjh3tw00gjsfl8f237lmu63q0uf63m`
`@jb55 npub1xtscya34g58tk0z605fvr788k263gsu6cy9x0mhnm87echrgufzsevkk5s`



