### PR TITLE
₿itcoin B hashtag

### DIFF
--- a/damus/Util/Hashtags.swift
+++ b/damus/Util/Hashtags.swift
@@ -30,6 +30,7 @@ struct CustomHashtag {
 let custom_hashtags: [String: CustomHashtag] = [
     "bitcoin": CustomHashtag.bitcoin,
     "btc": CustomHashtag.bitcoin,
+    "₿itcoin": CustomHashtag.bitcoin,
     "nostr": CustomHashtag.nostr,
     "coffee": CustomHashtag.coffee,
     "coffeechain": CustomHashtag.coffee,


### PR DESCRIPTION
Not sure much explanation is needed. But my phone autocorrects "bitcoin"  to "₿itcoin" so this would be neat.