### PR TITLE
Updated blocked phrasing to muted

### DIFF
--- a/damus/Views/Events/MutedEventView.swift
+++ b/damus/Views/Events/MutedEventView.swift
@@ -10,37 +10,37 @@ import SwiftUI
 struct MutedEventView: View {
     let damus_state: DamusState
     let event: NostrEvent
-    
+
     let selected: Bool
     @State var shown: Bool
-    
+
     init(damus_state: DamusState, event: NostrEvent, selected: Bool) {
         self.damus_state = damus_state
         self.event = event
         self.selected = selected
         self._shown = State(initialValue: should_show_event(contacts: damus_state.contacts, ev: event))
     }
-    
+
     var should_mute: Bool {
         return !should_show_event(contacts: damus_state.contacts, ev: event)
     }
-    
+
     var MutedBox: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 20)
                 .foregroundColor(DamusColors.adaptableGrey)
-            
+
             HStack {
-                Text("Post from a user you've blocked", comment: "Text to indicate that what is being shown is a post from a user who has been blocked.")
+                Text("Post from a user you've muted", comment: "Text to indicate that what is being shown is a post from a user who has been muted.")
                 Spacer()
-                Button(shown ? NSLocalizedString("Hide", comment: "Button to hide a post from a user who has been blocked.") : NSLocalizedString("Show", comment: "Button to show a post from a user who has been blocked.")) {
+                Button(shown ? NSLocalizedString("Hide", comment: "Button to hide a post from a user who has been muted.") : NSLocalizedString("Show", comment: "Button to show a post from a user who has been muted.")) {
                     shown.toggle()
                 }
             }
             .padding(10)
         }
     }
-    
+
     var Event: some View {
         Group {
             if selected {
@@ -50,7 +50,7 @@ struct MutedEventView: View {
             }
         }
     }
-    
+
     var body: some View {
         Group {
             if should_mute {
@@ -64,7 +64,7 @@ struct MutedEventView: View {
             guard let mutes = notif.object as? [String] else {
                 return
             }
-            
+
             if mutes.contains(event.pubkey) {
                 shown = false
             }
@@ -73,7 +73,7 @@ struct MutedEventView: View {
             guard let unmutes = notif.object as? [String] else {
                 return
             }
-            
+
             if unmutes.contains(event.pubkey) {
                 shown = true
             }
@@ -84,9 +84,9 @@ struct MutedEventView: View {
 struct MutedEventView_Previews: PreviewProvider {
     @State static var nav_target: NostrEvent = test_event
     @State static var navigating: Bool = false
-    
+
     static var previews: some View {
-        
+
         MutedEventView(damus_state: test_damus_state(), event: test_event, selected: false)
             .frame(width: .infinity, height: 50)
     }

--- a/damus/en-US.xcloc/Localized Contents/en-US.xliff
+++ b/damus/en-US.xcloc/Localized Contents/en-US.xliff
@@ -582,7 +582,7 @@ Sentence composed of 2 variables to describe how many people are following a use
       <trans-unit id="Hide" xml:space="preserve">
         <source>Hide</source>
         <target>Hide</target>
-        <note>Button to hide a post from a user who has been blocked.</note>
+        <note>Button to hide a post from a user who has been muted.</note>
       </trans-unit>
       <trans-unit id="Hide API Key" xml:space="preserve">
         <source>Hide API Key</source>
@@ -863,10 +863,10 @@ Sentence composed of 2 variables to describe how many people are following a use
         <target>Post</target>
         <note>Button to post a note.</note>
       </trans-unit>
-      <trans-unit id="Post from a user you've blocked" xml:space="preserve">
-        <source>Post from a user you've blocked</source>
-        <target>Post from a user you've blocked</target>
-        <note>Text to indicate that what is being shown is a post from a user who has been blocked.</note>
+      <trans-unit id="Post from a user you've muted" xml:space="preserve">
+        <source>Post from a user you've muted</source>
+        <target>Post from a user you've muted</target>
+        <note>Text to indicate that what is being shown is a post from a user who has been muted.</note>
       </trans-unit>
       <trans-unit id="Posts" xml:space="preserve">
         <source>Posts</source>


### PR DESCRIPTION
`Blocked` phrasing was changed to `muting / muted` in the past, however these were missed. I'm unsure how to update the transifex site, or project related `Localizable.strings` files, as many of them still have `blocked`.