### PR TITLE
Most recent conversations are not sorted to the top instantaneously

### DIFF
--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -938,7 +938,11 @@ func handle_incoming_dms(prev_events: NewEventsBits, dms: DirectMessagesModel, o
 
     // Do this everytime when new message is received or sent (being inserted returning always false except restart)
     dms.dms = dms.dms.filter({ $0.events.count > 0 }).sorted { a, b in
-        return a.events.last!.created_at > b.events.last!.created_at
+        guard let created_date_last_ev_dm_a = a.events.last?.created_at,
+              let created_date_last_ev_dm_b = b.events.last?.created_at else {
+            return false
+        }
+        return created_date_last_ev_dm_a > created_date_last_ev_dm_b
     }
     
     return new_events

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -935,11 +935,10 @@ func handle_incoming_dms(prev_events: NewEventsBits, dms: DirectMessagesModel, o
             new_events = new
         }
     }
-    
-    if inserted {
-        dms.dms = dms.dms.filter({ $0.events.count > 0 }).sorted { a, b in
-            return a.events.last!.created_at > b.events.last!.created_at
-        }
+
+    // Do this everytime when new message is received or sent (being inserted returning always false except restart)
+    dms.dms = dms.dms.filter({ $0.events.count > 0 }).sorted { a, b in
+        return a.events.last!.created_at > b.events.last!.created_at
     }
     
     return new_events

--- a/damus/Views/DirectMessagesView.swift
+++ b/damus/Views/DirectMessagesView.swift
@@ -30,8 +30,8 @@ struct DirectMessagesView: View {
                     EmptyTimelineView()
                 } else {
                     let dms = requests ? model.message_requests : model.friend_dms
-                    ForEach(dms, id: \.pubkey) { tup in
-                        MaybeEvent(tup)
+                    ForEach(dms, id: \.pubkey) { dm in
+                        MaybeEvent(dm)
                             .padding(.top, 10)
                     }
                 }

--- a/damus/Views/DirectMessagesView.swift
+++ b/damus/Views/DirectMessagesView.swift
@@ -18,17 +18,6 @@ struct DirectMessagesView: View {
     @State var dm_type: DMType = .friend
     @ObservedObject var model: DirectMessagesModel
     @ObservedObject var settings: UserSettingsStore
-
-    func getSortedDms(requests: Bool) -> [DirectMessageModel] {
-        let dms = requests ? model.message_requests : model.friend_dms
-        return dms.lazy.sorted { a, b in
-            guard let created_date_last_ev_dm_a = a.events.last?.created_at,
-                  let created_date_last_ev_dm_b = b.events.last?.created_at else {
-                return false
-            }
-            return created_date_last_ev_dm_a > created_date_last_ev_dm_b
-        }
-    }
     
     func MainContent(requests: Bool) -> some View {
         ScrollView {
@@ -41,7 +30,7 @@ struct DirectMessagesView: View {
                     EmptyTimelineView()
                 } else {
                     let dms = requests ? model.message_requests : model.friend_dms
-                    ForEach(getSortedDms(requests: requests), id: \.pubkey) { tup in
+                    ForEach(dms, id: \.pubkey) { tup in
                         MaybeEvent(tup)
                             .padding(.top, 10)
                     }

--- a/damus/Views/DirectMessagesView.swift
+++ b/damus/Views/DirectMessagesView.swift
@@ -18,6 +18,17 @@ struct DirectMessagesView: View {
     @State var dm_type: DMType = .friend
     @ObservedObject var model: DirectMessagesModel
     @ObservedObject var settings: UserSettingsStore
+
+    func getSortedDms(requests: Bool) -> [DirectMessageModel] {
+        let dms = requests ? model.message_requests : model.friend_dms
+        return dms.lazy.sorted { a, b in
+            guard let created_date_last_ev_dm_a = a.events.last?.created_at,
+                  let created_date_last_ev_dm_b = b.events.last?.created_at else {
+                return false
+            }
+            return created_date_last_ev_dm_a > created_date_last_ev_dm_b
+        }
+    }
     
     func MainContent(requests: Bool) -> some View {
         ScrollView {
@@ -30,8 +41,8 @@ struct DirectMessagesView: View {
                     EmptyTimelineView()
                 } else {
                     let dms = requests ? model.message_requests : model.friend_dms
-                    ForEach(dms, id: \.pubkey) { dm in
-                        MaybeEvent(dm)
+                    ForEach(getSortedDms(requests: requests), id: \.pubkey) { tup in
+                        MaybeEvent(tup)
                             .padding(.top, 10)
                     }
                 }


### PR DESCRIPTION
This resolves the issue like below where William should have shown ahead of Swift because of the recency of conversation which was just 25 seconds ago comparing with 12 hours ago one.
![IMG_7758](https://user-images.githubusercontent.com/120697811/234054230-757d0b61-9d62-4448-8f56-457b20ceca50.jpg)
