### PR TITLE
Auto-fill-previous-zap-comment-for-the-same-zap-amount

### DIFF
--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -96,6 +96,9 @@ class UserSettingsStore: ObservableObject {
     
     @Setting(key: "default_zap_amount", default_value: fallback_zap_amount)
     var default_zap_amount: Int
+
+    @Setting(key: "default_zap_comment", default_value: [:])
+    var default_zap_comment: [String:String]
     
     @Setting(key: "mention_notification", default_value: true)
     var mention_notification: Bool

--- a/damus/Views/Zaps/CustomizeZapView.swift
+++ b/damus/Views/Zaps/CustomizeZapView.swift
@@ -147,6 +147,9 @@ struct CustomizeZapView: View {
                    self.custom_amount_sats = nil
                }
             }
+            .onChange(of: custom_amount) { newValue in
+                comment = state.settings.default_zap_comment[custom_amount] ?? ""
+            }
             Text("sats", comment: "Shortened form of satoshi, display unit of measure where 1,000,000,000 satoshis is 1 Bitcoin. Used to indicate how many sats will be zapped to a note, configured through the custom zap view.")
                 .font(.system(size: 18, weight: .heavy))
         }
@@ -181,6 +184,7 @@ struct CustomizeZapView: View {
                     let amount = custom_amount_sats
                     send_zap(damus_state: state, event: event, lnurl: lnurl, is_custom: true, comment: comment, amount_sats: amount, zap_type: zap_type)
                     self.zapping = true
+                    state.settings.default_zap_comment[custom_amount] = comment
                 }
                 .disabled(custom_amount_sats == 0 || custom_amount.isEmpty)
                 .font(.system(size: 28, weight: .bold))


### PR DESCRIPTION
This pr is about persisting zap comment against the zap amount. If I zap an amount with a message, I will see that message as a comment next time when I select the same amount.

Demo video:
https://nostr.build/av/c3f300b038403d255e3e5fad4466cef887c3c9aeb7696542ff11f94c60d6dcc1.mov 