### PR TITLE
save keys when logging in and when creating new account

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -253,6 +253,7 @@
 		4FE60CDD295E1C5E00105A1F /* Wallet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE60CDC295E1C5E00105A1F /* Wallet.swift */; };
 		50088DA129E8271A008A1FDF /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50088DA029E8271A008A1FDF /* WebSocket.swift */; };
 		50A50A8D29A09E1C00C01BE7 /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50A50A8C29A09E1C00C01BE7 /* RequestTests.swift */; };
+		50B5685329F97CB400A23243 /* CredentialHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B5685229F97CB400A23243 /* CredentialHandler.swift */; };
 		5C42E78C29DB76D90086AAC1 /* EmptyUserSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C42E78B29DB76D90086AAC1 /* EmptyUserSearchView.swift */; };
 		5C513FBA297F72980072348F /* CustomPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C513FB9297F72980072348F /* CustomPicker.swift */; };
 		5C513FCC2984ACA60072348F /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C513FCB2984ACA60072348F /* QRCodeView.swift */; };
@@ -669,6 +670,7 @@
 		4FE60CDC295E1C5E00105A1F /* Wallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wallet.swift; sourceTree = "<group>"; };
 		50088DA029E8271A008A1FDF /* WebSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocket.swift; sourceTree = "<group>"; };
 		50A50A8C29A09E1C00C01BE7 /* RequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
+		50B5685229F97CB400A23243 /* CredentialHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialHandler.swift; sourceTree = "<group>"; };
 		5C42E78B29DB76D90086AAC1 /* EmptyUserSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyUserSearchView.swift; sourceTree = "<group>"; };
 		5C513FB9297F72980072348F /* CustomPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPicker.swift; sourceTree = "<group>"; };
 		5C513FCB2984ACA60072348F /* QRCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeView.swift; sourceTree = "<group>"; };
@@ -1017,6 +1019,7 @@
 				4C8D00CB29DF92DF0036AF10 /* Hashtags.swift */,
 				4CDA128B29EB19C40006FA5A /* LocalNotification.swift */,
 				4CA5588229F33F5B00DC6A45 /* StringCodable.swift */,
+				50B5685229F97CB400A23243 /* CredentialHandler.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -1713,6 +1716,7 @@
 				4CF0ABEC29844B4700D66079 /* AnyDecodable.swift in Sources */,
 				4C5F9118283D88E40052CD1C /* FollowingModel.swift in Sources */,
 				4C1A9A1A29DCA17E00516EAC /* ReplyCounter.swift in Sources */,
+				50B5685329F97CB400A23243 /* CredentialHandler.swift in Sources */,
 				643EA5C8296B764E005081BB /* RelayFilterView.swift in Sources */,
 				4C3EA67D28FFBBA300C48A62 /* InvoicesView.swift in Sources */,
 				4C363A8E28236FE4006E126D /* NoteContentView.swift in Sources */,

--- a/damus/Util/CredentialHandler.swift
+++ b/damus/Util/CredentialHandler.swift
@@ -1,0 +1,48 @@
+//
+//  CredentialHandler.swift
+//  damus
+//
+//  Created by Bryan Montz on 4/26/23.
+//
+
+import Foundation
+import AuthenticationServices
+
+final class CredentialHandler: NSObject, ASAuthorizationControllerDelegate {
+    
+    func check_credentials() {
+        let requests: [ASAuthorizationRequest] = [ASAuthorizationPasswordProvider().createRequest()]
+        let authorizationController = ASAuthorizationController(authorizationRequests: requests)
+        authorizationController.delegate = self
+        authorizationController.performRequests()
+    }
+    
+    func save_credential(pubkey: String, privkey: String) {
+        SecAddSharedWebCredential("damus.io" as CFString, pubkey as CFString, privkey as CFString, { error in
+            if let error {
+                print("⚠️ An error occurred while saving credentials: \(error)")
+            }
+        })
+    }
+    
+    // MARK: - ASAuthorizationControllerDelegate
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let cred = authorization.credential as? ASPasswordCredential,
+              let parsedKey = parse_key(cred.password) else {
+            return
+        }
+        
+        Task {
+            switch parsedKey {
+            case .pub, .priv:
+                try? await process_login(parsedKey, is_pubkey: false)
+            default:
+                break
+            }
+        }
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        print("⚠️ Warning: authentication failed with error: \(error)")
+    }
+}

--- a/damus/Views/SaveKeysView.swift
+++ b/damus/Views/SaveKeysView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Security
 
 struct SaveKeysView: View {
     let account: CreateAccountModel
@@ -15,6 +16,8 @@ struct SaveKeysView: View {
     @State var priv_copied: Bool = false
     @State var loading: Bool = false
     @State var error: String? = nil
+    
+    @State private var credential_handler = CredentialHandler()
 
     @FocusState var pubkey_focused: Bool
     @FocusState var privkey_focused: Bool
@@ -96,6 +99,8 @@ struct SaveKeysView: View {
         }
 
         self.pool.register_handler(sub_id: "signup", handler: handle_event)
+        
+        credential_handler.save_credential(pubkey: account.pubkey_bech32, privkey: account.privkey_bech32)
         
         self.loading = true
         


### PR DESCRIPTION
This PR implements iOS' iCloud Keychain password saving (shared web credentials). It will prompt the user to see if they want to save their keys when they either create a new account or log in with an existing account.

|Create Account|Login|
|---|---|
|![Simulator Screen Recording - iPhone 14 Pro - 2023-04-28 at 14 27 25](https://user-images.githubusercontent.com/445882/235236567-d707fd4a-3f36-4365-9dfc-46e1a8d62f47.gif)|![Simulator Screen Recording - iPhone 14 Pro - 2023-04-28 at 14 32 59](https://user-images.githubusercontent.com/445882/235237012-2d794452-30bd-407c-84ff-67d7db66623b.gif)|

After you do this, you can see the entry(entries) in iOS Settings -> Passwords:
<img src="https://user-images.githubusercontent.com/445882/235237260-c876af93-3ee3-4b61-9a63-78f6cd0b2dc7.png" alt="test" width="320"/>

Then the next time you go to log in, you'll get prompted with whatever accounts you already have:
<img src="https://user-images.githubusercontent.com/445882/235238257-6806e7d0-ed8b-4432-907e-9e0b2e9c90e4.png" alt="test" width="320"/>

I wasn't able to test this ^ part, because it only works on device and I can't run Damus on my devices without changing the bundle id, which breaks shared web credentials. So you'll need to test it, or you could add me as a developer on your App Store Connect team so that I could get a dev cert to build it on my device.

However, there's another way that it does work in the sim:  
<img src="https://user-images.githubusercontent.com/445882/235238755-aa4d9707-e26d-4303-80ef-25b91a0c2bf1.gif" alt="test" width="320"/>