### PR TITLE
Fix bug with reaction notifications referencing the wrong event

### DIFF
--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -1107,7 +1107,7 @@ func process_local_notification(damus_state: DamusState, event ev: NostrEvent) {
         let notify = LocalNotification(type: .repost, event: ev, target: inner_ev, content: inner_ev.content)
         create_local_notification(profiles: damus_state.profiles, notify: notify)
     } else if type == .like && damus_state.settings.like_notification,
-              let evid = ev.referenced_ids.first?.ref_id,
+              let evid = ev.referenced_ids.last?.ref_id,
               let liked_event = damus_state.events.lookup(evid)
     {
         let notify = LocalNotification(type: .like, event: ev, target: liked_event, content: liked_event.content)


### PR DESCRIPTION
Changelog-Fixed: Fix bug with reaction notifications referencing the wrong event

NIP-25 says that it should be the last tag in the list, not the first.
https://github.com/nostr-protocol/nips/blob/master/25.md#tags