### PR TITLE
Fix Issue #1044 : "npub search fails on initial attempt, succeeds on subsequent attempt"

### DIFF
--- a/damus/Views/Search/SearchingEventView.swift
+++ b/damus/Views/Search/SearchingEventView.swift
@@ -93,11 +93,13 @@ struct SearchingEventView: View {
             }
         case .profile:
             find_event(state: state, evid: evid, search_type: search_type, find_from: nil) { _ in
-                if state.profiles.lookup(id: evid) != nil {
-                    self.search_state = .found_profile(evid)
-                    return
-                } else {
-                    self.search_state = .not_found
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1 ) {
+                    if state.profiles.lookup(id: evid) != nil {
+                        self.search_state = .found_profile(evid)
+                        return
+                    } else {
+                        self.search_state = .not_found
+                    }
                 }
             }
         }


### PR DESCRIPTION
-Fix issue #1044

#### Change:
-Wrap the `find_event(...)` callback in the `.profile` case in a dispatch to the main queue w/ a slight time delay

#### Findings:
-Time delay value =0 does not fix
-To replicate bug, needed to use a new npub (eg my account created for testing, `npub1j6rzjsn0pgvf85cfa32glnx7djmuk6t5pz4c3yrly370z2cvfhussmdg8y`)

 #### Demo

Before:

https://user-images.githubusercontent.com/47217795/235339653-854e2d7e-a0bc-47ca-a98d-cb631f654bc5.mov


After:

https://user-images.githubusercontent.com/47217795/235339659-0b202b48-faf7-4381-bbc9-9b7936030f44.mov






