### PR TITLE
Changelog-Fixed: Save Jacks soul

### DIFF
--- a/damus/Components/ZapButton.swift
+++ b/damus/Components/ZapButton.swift
@@ -47,7 +47,7 @@ struct ZapButton: View {
             return "bolt"
         }
         
-        return "bolt.horizontal.fill"
+        return "bolt.fill"
     }
     
     var zap_color: Color? {


### PR DESCRIPTION
Very minor amendment to stop the bouncing of the bolt symbol as you click it.

If particularly want it to switch to a horizontal bolt (I personally prefer keeping it vertical) you could probably also resolve using .frame().