### PR TITLE
fix issue where new events don't show when the app resumes

### DIFF
--- a/damus/Views/TimelineView.swift
+++ b/damus/Views/TimelineView.swift
@@ -17,6 +17,7 @@ struct TimelineView: View {
     @Binding var loading: Bool
     @State var offset = CGFloat.zero
     
+    @Environment(\.scenePhase) var scenePhase
     @Environment(\.colorScheme) var colorScheme
 
     let damus: DamusState
@@ -59,6 +60,16 @@ struct TimelineView: View {
         }
         .onAppear {
             events.flush()
+        }
+        .onChange(of: scenePhase) { phase in
+            switch phase {
+            case .active:
+                events.flush()
+            case .background, .inactive:
+                break
+            @unknown default:
+                break
+            }
         }
     }
 }


### PR DESCRIPTION
This is an attempt to fix the issue where new events don't always load when Damus is resumed. Before this change, you could change the main tab and go back to the timeline view and events would load as expected. After the change, you shouldn't have to do that.