### PR TITLE
fix broken testDMSortOrder

### DIFF
--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -950,13 +950,8 @@ func handle_incoming_dms(prev_events: NewEventsBits, dms: DirectMessagesModel, o
     }
     
     if inserted {
-        Task.init {
-            let new_dms = Array(dms.dms.filter({ $0.events.count > 0 })).sorted { a, b in
-                return a.events.last!.created_at > b.events.last!.created_at
-            }
-            DispatchQueue.main.async {
-                dms.dms = new_dms
-            }
+        dms.dms = dms.dms.filter({ $0.events.count > 0 }).sorted { a, b in
+            return a.events.last!.created_at > b.events.last!.created_at
         }
     }
     


### PR DESCRIPTION
This reverts a small part of the recent change which delayed the value of `dms.dms` changing, which caused the test to fail.

Before this quick fix I tried making `handle_incoming_dms` an `async` function, but it caused way too many changes that I was unsure of.