### PR TITLE
Added command feature extraction for DM bot interactions

### DIFF
--- a/damus-c/block.h
+++ b/damus-c/block.h
@@ -20,6 +20,7 @@ enum block_type {
     BLOCK_MENTION_BECH32 = 4,
     BLOCK_URL = 5,
     BLOCK_INVOICE = 6,
+    BLOCK_COMMAND = 7,
 };
 
 

--- a/damus/Models/EventRef.swift
+++ b/damus/Models/EventRef.swift
@@ -88,6 +88,8 @@ func build_mention_indices(_ blocks: [Block], type: MentionType) -> Set<Int> {
             return
         case .invoice:
             return
+        case .command:
+          return
         }
     }
 }

--- a/damus/Models/Mentions.swift
+++ b/damus/Models/Mentions.swift
@@ -71,6 +71,8 @@ enum Block: Equatable {
             return a == b
         case (.invoice(let a), .invoice(let b)):
             return a.string == b.string
+        case (.command(let a), .command(let b)):
+          return a == b
         case (_, _):
             return false
         }
@@ -82,6 +84,7 @@ enum Block: Equatable {
     case url(URL)
     case invoice(Invoice)
     case relay(String)
+    case command(String)
     
     var is_invoice: Invoice? {
         if case .invoice(let invoice) = self {
@@ -126,6 +129,13 @@ enum Block: Equatable {
         }
         return false
     }
+  
+    var is_command: Bool {
+      if case .command = self {
+        return true
+      }
+      return false
+    }
 }
 
 func render_blocks(blocks: [Block]) -> String {
@@ -151,6 +161,8 @@ func render_blocks(blocks: [Block]) -> String {
             return str + url.absoluteString
         case .invoice(let inv):
             return str + inv.string
+        case .command(let cmd):
+            return str + cmd
         }
     }
 }
@@ -213,6 +225,8 @@ func convert_block(_ b: block_t, tags: [[String]]) -> Block? {
         return convert_invoice_block(b.block.invoice)
     } else if b.type == BLOCK_MENTION_BECH32 {
         return convert_mention_bech32_block(b.block.mention_bech32)
+    } else if b.type == BLOCK_COMMAND {
+        return convert_command_block(b.block.str)
     }
 
     return nil
@@ -226,6 +240,13 @@ func convert_url_block(_ b: str_block) -> Block? {
         return .text(str)
     }
     return .url(url)
+}
+
+func convert_command_block(_ b: str_block) -> Block? {
+  guard let str = strblock_to_string(b) else {
+      return nil
+  }
+  return .command(str)
 }
 
 func maybe_pointee<T>(_ p: UnsafeMutablePointer<T>!) -> T? {

--- a/damus/Views/DMChatView.swift
+++ b/damus/Views/DMChatView.swift
@@ -36,6 +36,14 @@ struct DMChatView: View {
                 }
             }
         }
+        .onOpenURL { url in
+            let s = url.absoluteString
+            let cmd = s.replacingOccurrences(of: "damus:", with: "")
+            if cmd.starts(with: "/") {
+              dms.draft = cmd
+              send_message()
+            }
+        }
     }
 
     var Header: some View {

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -200,6 +200,7 @@ struct NoteContentView: View {
                     case .hashtag: return
                     case .url: return
                     case .invoice: return
+                    case .command: return
                     }
                 }
             }
@@ -230,6 +231,15 @@ func url_str(_ url: URL) -> CompatibleText {
     
     return CompatibleText(attributed: attributedString)
  }
+
+func command_str(_ cmd: String) -> CompatibleText {
+  var attributedString = AttributedString(stringLiteral: cmd)
+  attributedString.foregroundColor = DamusColors.purple
+  attributedString.link = URL(string: "damus:" + cmd)
+  attributedString.font = UIFont.boldSystemFont(ofSize: UIFont.labelFontSize)
+  
+  return CompatibleText(attributed: attributedString)
+}
 
 func mention_str(_ m: Mention, profiles: Profiles) -> CompatibleText {
     switch m.type {
@@ -372,6 +382,8 @@ func render_blocks(blocks: [Block], profiles: Profiles, privkey: String?) -> Not
                 link_urls.append(url)
                 return str + url_str(url)
             }
+          case .command(let cmd):
+            return str + command_str(cmd)
         }
     }
 


### PR DESCRIPTION
**Title:** Add command recognition and clickable commands in DMs

**Problem:**
Prior to this PR, users were unable to interact with simple slash / bot commands like through Direct Messages (DMs), leading to a suboptimal user experience.

**Changes:**
- Updated the codebase to include command regex feature extraction.
- Highlighted commands in DMs for better visibility.
- Made commands clickable, allowing users to interact with the bot more easily through DMs.

**How it works:**
The added command regex feature extraction identifies bot commands and highlights them in DMs. Users can now simply click on a command to interact with the bot, improving the overall user experience.

Please review the changes and let me know if any modifications are required. Thank you for considering this pull request!


| Before | After |
|--------|--------|
| ![Before](https://user-images.githubusercontent.com/22292011/236446408-50637c62-12bf-479a-b686-52bba65d38a3.png) | ![After](https://user-images.githubusercontent.com/22292011/236446969-5f02563e-fbe2-4428-a1e1-97bfc2c047f5.png) | 

https://user-images.githubusercontent.com/22292011/236447688-e3273863-38c6-43dd-abbc-cb99613d9648.mp4


