### PR TITLE
fix: npub search fails on the first try

### DIFF
--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -761,10 +761,11 @@ func guard_valid_event(events: EventCache, ev: NostrEvent, callback: @escaping (
     }
 }
 
-func process_metadata_event(events: EventCache, our_pubkey: String, profiles: Profiles, ev: NostrEvent) {
+func process_metadata_event(events: EventCache, our_pubkey: String, profiles: Profiles, ev: NostrEvent, completion: (() -> Void)? = nil) {
     guard_valid_event(events: events, ev: ev) {
         DispatchQueue.global(qos: .background).async {
             guard let profile: Profile = decode_data(Data(ev.content.utf8)) else {
+                completion?()
                 return
             }
             
@@ -772,6 +773,7 @@ func process_metadata_event(events: EventCache, our_pubkey: String, profiles: Pr
             
             DispatchQueue.main.async {
                 process_metadata_profile(our_pubkey: our_pubkey, profiles: profiles, profile: profile, ev: ev)
+                completion?()
             }
         }
     }

--- a/damus/Views/Search/SearchingEventView.swift
+++ b/damus/Views/Search/SearchingEventView.swift
@@ -92,10 +92,15 @@ struct SearchingEventView: View {
                 }
             }
         case .profile:
-            find_event(state: state, evid: evid, search_type: search_type, find_from: nil) { _ in
-                if state.profiles.lookup(id: evid) != nil {
-                    self.search_state = .found_profile(evid)
-                    return
+            find_event(state: state, evid: evid, search_type: search_type, find_from: nil) { ev in
+                if let ev {
+                    process_metadata_event(events: state.events, our_pubkey: state.pubkey, profiles: state.profiles, ev: ev) {
+                        if state.profiles.lookup(id: evid) != nil {
+                            self.search_state = .found_profile(evid)
+                        } else {
+                            self.search_state = .not_found
+                        }
+                    }
                 } else {
                     self.search_state = .not_found
                 }


### PR DESCRIPTION
This PR fixes the issue where npub search fails on the first try.

What was happening:
`SearchEventView` calls `find_event(state:evid:search_type:find_from:callback:)` to search for the entered npub. The search actually succeeded, but the call site was ignoring the returned event and never caching the profile. The reason it works the second time is because the `RelayPool` eventually got around to caching the profile. This is also why the other PR related to this issue works by adding a short delay.

How it's fixed:
Now `SearchingEventView` will call `process_metadata_event(events:our_pubkey:profiles:ev:)`, and upon completion, will update the view state with the successful result.