### PR TITLE
fix posts with no uploadedURLs always get two blank spaces at the end

### DIFF
--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -84,8 +84,10 @@ struct PostView: View {
         let imagesString = uploadedMedias.map { $0.uploadedURL.absoluteString }.joined(separator: " ")
         
         let img_meta_tags = uploadedMedias.compactMap { $0.metadata?.to_tag() }
-
-        content.append(" " + imagesString + " ")
+        
+        if !imagesString.isEmpty {
+            content.append(" " + imagesString + " ")
+        }
 
         if case .quoting(let ev) = action, let id = bech32_note_id(ev.id) {
             content.append(" nostr:" + id)


### PR DESCRIPTION
In the case where a new post does not contain `uploadedMedias`, the post will always get two blank spaces appended at the end.

<img width="615" alt="damus_—_PostView_swift" src="https://user-images.githubusercontent.com/445882/236623529-ea96c220-2975-4033-89ac-56d9b53323d7.png">
