### PR TITLE
in-text-mentioning

### DIFF
--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -425,8 +425,8 @@ func get_searching_string(_ word: String?) -> String? {
         return nil
     }
     
-    guard let firstWord = word.first,
-          firstWord == "@" else {
+    guard let firstCharacter = word.first,
+          firstCharacter == "@" else {
         return nil
     }
     

--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -43,6 +43,8 @@ struct PostView: View {
     @State var image_upload_confirm: Bool = false
     @State var originalReferences: [ReferencedId] = []
     @State var references: [ReferencedId] = []
+    @State var focusWordAttributes: (String?, NSRange?) = (nil, nil)
+    @State var newCursorIndex: Int?
 
     @State var mediaToUpload: MediaUpload? = nil
     
@@ -203,7 +205,10 @@ struct PostView: View {
     
     var TextEntry: some View {
         ZStack(alignment: .topLeading) {
-            TextViewWrapper(attributedText: $post)
+            TextViewWrapper(attributedText: $post, cursorIndex: newCursorIndex, getFocusWordForMention: { word, range in
+                focusWordAttributes = (word, range)
+                self.newCursorIndex = nil
+            })
                 .focused($focus)
                 .textInputAutocapitalization(.sentences)
                 .onChange(of: post) { p in
@@ -312,8 +317,7 @@ struct PostView: View {
     var body: some View {
         GeometryReader { (deviceSize: GeometryProxy) in
             VStack(alignment: .leading, spacing: 0) {
-
-                let searching = get_searching_string(post.string)
+                let searching = get_searching_string(focusWordAttributes.0)
                 
                 TopBar
                 
@@ -333,7 +337,7 @@ struct PostView: View {
                 
                 // This if-block observes @ for tagging
                 if let searching {
-                    UserSearch(damus_state: damus_state, search: searching, post: $post)
+                    UserSearch(damus_state: damus_state, search: searching, focusWordAttributes: $focusWordAttributes, newCursorIndex: $newCursorIndex, post: $post)
                         .frame(maxHeight: .infinity)
                 } else {
                     Divider()
@@ -412,25 +416,26 @@ struct PostView: View {
     }
 }
 
-func get_searching_string(_ post: String) -> String? {
-    guard let last_word = post.components(separatedBy: .whitespacesAndNewlines).last else {
+func get_searching_string(_ word: String?) -> String? {
+    guard let word = word else {
+        return nil
+    }
+
+    guard word.count >= 2 else {
         return nil
     }
     
-    guard last_word.count >= 2 else {
-        return nil
-    }
-    
-    guard last_word.first! == "@" else {
+    guard let firstWord = word.first,
+          firstWord == "@" else {
         return nil
     }
     
     // don't include @npub... strings
-    guard last_word.count != 64 else {
+    guard word.count != 64 else {
         return nil
     }
     
-    return String(last_word.dropFirst())
+    return String(word.dropFirst())
 }
 
 struct PostView_Previews: PreviewProvider {

--- a/damus/Views/TextViewWrapper.swift
+++ b/damus/Views/TextViewWrapper.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct TextViewWrapper: UIViewRepresentable {
     @Binding var attributedText: NSMutableAttributedString
+    let cursorIndex: Int?
+    var getFocusWordForMention: ((String?, NSRange?) -> Void)? = nil
     
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
@@ -29,21 +31,56 @@ struct TextViewWrapper: UIViewRepresentable {
     func updateUIView(_ uiView: UITextView, context: Context) {
         uiView.attributedText = attributedText
         TextViewWrapper.setTextProperties(uiView)
+        setCursorPosition(textView: uiView)
+    }
+
+    private func setCursorPosition(textView: UITextView) {
+        guard let index = cursorIndex, let newPosition = textView.position(from: textView.beginningOfDocument, offset: index) else {
+            return
+        }
+        textView.selectedTextRange = textView.textRange(from: newPosition, to: newPosition)
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(attributedText: $attributedText)
+        Coordinator(attributedText: $attributedText, getFocusWordForMention: getFocusWordForMention)
     }
 
     class Coordinator: NSObject, UITextViewDelegate {
         @Binding var attributedText: NSMutableAttributedString
+        var getFocusWordForMention: ((String?, NSRange?) -> Void)? = nil
 
-        init(attributedText: Binding<NSMutableAttributedString>) {
+        init(attributedText: Binding<NSMutableAttributedString>, getFocusWordForMention: ((String?, NSRange?) -> Void)?) {
             _attributedText = attributedText
+            self.getFocusWordForMention = getFocusWordForMention
         }
 
         func textViewDidChange(_ textView: UITextView) {
             attributedText = NSMutableAttributedString(attributedString: textView.attributedText)
+            processFocusedWordForMention(textView: textView)
+        }
+
+        private func processFocusedWordForMention(textView: UITextView) {
+            if let selectedRange = textView.selectedTextRange {
+                var val: (String?, NSRange?)
+                if let wordRange = textView.tokenizer.rangeEnclosingPosition(selectedRange.start, with: .word, inDirection: .init(rawValue: UITextLayoutDirection.left.rawValue)) {
+                    if let startPosition = textView.position(from: wordRange.start, offset: -1),
+                       let cursorPosition = textView.position(from: selectedRange.start, offset: 0) {
+                        let word = textView.text(in: textView.textRange(from: startPosition, to: cursorPosition)!)
+                        val = (word, convertToNSRange(startPosition, cursorPosition, textView))
+                    }
+                }
+                getFocusWordForMention?(val.0, val.1)
+            }
+        }
+
+        private func convertToNSRange( _ startPosition: UITextPosition, _ endPosition: UITextPosition, _ textView: UITextView) -> NSRange? {
+            let startOffset = textView.offset(from: textView.beginningOfDocument, to: startPosition)
+            let endOffset = textView.offset(from: textView.beginningOfDocument, to: endPosition)
+            let length = endOffset - startOffset
+            guard length >= 0, startOffset >= 0 else {
+                return nil
+            }
+            return NSRange(location: startOffset, length: length)
         }
     }
 }


### PR DESCRIPTION
By making this adjustment, we will be able to mention individuals by repositioning the cursor within the previously composed content of a post. Currently, we are only able to mention individuals at the end of a post and not during the editing process.

Demo video of in-text-mentioning:

https://nostr.build/av/41fa86e2c858ed2fefaeef56edaaf4cd001543c86e57fe76a9b97fdba3a2b1e0.mov