### PR TITLE
fix user notifications from old events immediately shown on install and login

### DIFF
--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -24,6 +24,9 @@ struct NewEventsBits: OptionSet {
 }
 
 class HomeModel: ObservableObject {
+    // Don't trigger a user notification for events older than a certain age
+    static let event_max_age_for_notification: TimeInterval = 12 * 60 * 60
+    
     var damus_state: DamusState
 
     var has_event: [String: Set<String>] = [:]
@@ -547,7 +550,8 @@ class HomeModel: ObservableObject {
     
     func got_new_dm(notifs: NewEventsBits, ev: NostrEvent) {
         self.new_events = notifs
-        if damus_state.settings.dm_notification {
+        
+        if damus_state.settings.dm_notification && ev.age < HomeModel.event_max_age_for_notification {
             let convo = ev.decrypted(privkey: self.damus_state.keypair.privkey) ?? NSLocalizedString("New encrypted direct message", comment: "Notification that the user has received a new direct message")
             let notify = LocalNotification(type: .dm, event: ev, target: ev, content: convo)
             create_local_notification(profiles: damus_state.profiles, notify: notify)
@@ -1116,6 +1120,11 @@ func process_local_notification(damus_state: DamusState, event ev: NostrEvent) {
 
     // Don't show notifications from muted threads.
     if damus_state.muted_threads.isMutedThread(ev, privkey: damus_state.keypair.privkey) {
+        return
+    }
+    
+    // Don't show notifications for old events
+    guard ev.age < HomeModel.event_max_age_for_notification else {
         return
     }
 

--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -383,6 +383,11 @@ class NostrEvent: Codable, Identifiable, CustomStringConvertible, Equatable, Has
     func sign(privkey: String) {
         self.sig = sign_event(privkey: privkey, ev: self)
     }
+    
+    var age: TimeInterval {
+        let event_date = Date(timeIntervalSince1970: TimeInterval(created_at))
+        return Date.now.timeIntervalSince(event_date)
+    }
 }
 
 func sign_event(privkey: String, ev: NostrEvent) -> String {


### PR DESCRIPTION
In this PR I propose that we don't show user notifications for incoming events that are more than 12 hours old.

Other alternatives:
1. Change the threshold (6 hours, 24 hours, etc)
2. Never show notifications from before the app was running
3. Make this only apply specifically to the session in which the user logged in.