### PR TITLE
Fix Issue #1038 - "User tag autocomplete message area blocks text input"

### DIFF
--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -45,6 +45,7 @@ struct PostView: View {
     @State var references: [ReferencedId] = []
     @State var focusWordAttributes: (String?, NSRange?) = (nil, nil)
     @State var newCursorIndex: Int?
+    @State var postTextViewCanScroll: Bool = true
 
     @State var mediaToUpload: MediaUpload? = nil
     
@@ -203,7 +204,7 @@ struct PostView: View {
     
     var TextEntry: some View {
         ZStack(alignment: .topLeading) {
-            TextViewWrapper(attributedText: $post, cursorIndex: newCursorIndex, getFocusWordForMention: { word, range in
+            TextViewWrapper(attributedText: $post, postTextViewCanScroll: $postTextViewCanScroll, cursorIndex: newCursorIndex, getFocusWordForMention: { word, range in
                 focusWordAttributes = (word, range)
                 self.newCursorIndex = nil
             })
@@ -335,7 +336,7 @@ struct PostView: View {
                 
                 // This if-block observes @ for tagging
                 if let searching {
-                    UserSearch(damus_state: damus_state, search: searching, focusWordAttributes: $focusWordAttributes, newCursorIndex: $newCursorIndex, post: $post)
+                    UserSearch(damus_state: damus_state, search: searching, focusWordAttributes: $focusWordAttributes, newCursorIndex: $newCursorIndex, postTextViewCanScroll: $postTextViewCanScroll, post: $post)
                         .frame(maxHeight: .infinity)
                 } else {
                     Divider()

--- a/damus/Views/Posting/UserSearch.swift
+++ b/damus/Views/Posting/UserSearch.swift
@@ -22,6 +22,7 @@ struct UserSearch: View {
     let search: String
     @Binding var focusWordAttributes: (String?, NSRange?)
     @Binding var newCursorIndex: Int?
+    @Binding var postTextViewCanScroll: Bool
 
     @Binding var post: NSMutableAttributedString
     
@@ -92,7 +93,14 @@ struct UserSearch: View {
                 .padding()
             }
         }
+        .onAppear() {
+            postTextViewCanScroll = false
+        }
+        .onDisappear() {
+            postTextViewCanScroll = true
+        }
     }
+        
 }
 
 struct UserSearch_Previews: PreviewProvider {
@@ -100,9 +108,10 @@ struct UserSearch_Previews: PreviewProvider {
     @State static var post: NSMutableAttributedString = NSMutableAttributedString(string: "some @jb55")
     @State static var word: (String?, NSRange?) = (nil, nil)
     @State static var newCursorIndex: Int?
+    @State static var postTextViewCanScroll: Bool = false
     
     static var previews: some View {
-        UserSearch(damus_state: test_damus_state(), search: search, focusWordAttributes: $word, newCursorIndex: $newCursorIndex, post: $post)
+        UserSearch(damus_state: test_damus_state(), search: search, focusWordAttributes: $word, newCursorIndex: $newCursorIndex, postTextViewCanScroll: $postTextViewCanScroll, post: $post)
     }
 }
 

--- a/damus/Views/TextViewWrapper.swift
+++ b/damus/Views/TextViewWrapper.swift
@@ -15,6 +15,7 @@ struct TextViewWrapper: UIViewRepresentable {
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
         textView.delegate = context.coordinator
+        textView.isScrollEnabled = false
         textView.showsVerticalScrollIndicator = false
         TextViewWrapper.setTextProperties(textView)
         return textView

--- a/damus/Views/TextViewWrapper.swift
+++ b/damus/Views/TextViewWrapper.swift
@@ -9,13 +9,14 @@ import SwiftUI
 
 struct TextViewWrapper: UIViewRepresentable {
     @Binding var attributedText: NSMutableAttributedString
+    @Binding var postTextViewCanScroll: Bool
     let cursorIndex: Int?
     var getFocusWordForMention: ((String?, NSRange?) -> Void)? = nil
     
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
         textView.delegate = context.coordinator
-        textView.isScrollEnabled = false
+        textView.isScrollEnabled = postTextViewCanScroll
         textView.showsVerticalScrollIndicator = false
         TextViewWrapper.setTextProperties(textView)
         return textView
@@ -30,6 +31,7 @@ struct TextViewWrapper: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UITextView, context: Context) {
+        uiView.isScrollEnabled = postTextViewCanScroll
         uiView.attributedText = attributedText
         TextViewWrapper.setTextProperties(uiView)
         setCursorPosition(textView: uiView)


### PR DESCRIPTION
Fix Issue #1038

 Fix:
 -Cursor in a post/reply now remains visible (regardless of initial location) even when search/autocomplete view is present

 Change:
 -Conditionally set the `.isScrollEnabled` in `TextViewWrapper` (ie, default true; & false only when `UserSearch` is present)

Demo:

https://github.com/damus-io/damus/assets/47217795/374e298c-0f81-4306-94c1-97244d0e4cd5



