### PR TITLE
Fix Issue #1083 - Replied to count is incorrect [bug]

### DIFF
--- a/damus/Models/Reply.swift
+++ b/damus/Models/Reply.swift
@@ -14,19 +14,25 @@ struct ReplyDesc {
 
 func make_reply_description(_ tags: [[String]]) -> ReplyDesc {
     var c = 0
-    var ns: [String] = []
-    var i = tags.count - 1
-        
-    while i >= 0 {
-        let tag = tags[i]
-        if tag.count >= 2 && tag[0] == "p" {
-            c += 1
-            if ns.count < 2 {
-                ns.append(tag[1])
-            }
-        }
-        i -= 1
-    }
-        
-    return ReplyDesc(pubkeys: ns, others: c)
+     var ns: [String] = []
+     var i = tags.count - 1
+     var seenPubkeys = Set<String>()
+         
+     while i >= 0 {
+         let tag = tags[i]
+         if tag.count >= 2 && tag[0] == "p" {
+             if (!seenPubkeys.contains(tag[1])) {
+                 if ns.count < 2 {
+                     ns.append(tag[1])
+                 }
+                 c += 1
+             }
+             else {
+                 seenPubkeys.insert(tag[1])
+             }
+         }
+         i -= 1
+     }
+         
+     return ReplyDesc(pubkeys: ns, others: c)
 }


### PR DESCRIPTION
Adds pubkey deduplication to make_reply_description to handle events with multiple p tags pointing to the same user.