### PR TITLE
Fix side menu label size so that translations in longer languages fit without wrapping

### DIFF
--- a/damus/Views/SideMenuView.swift
+++ b/damus/Views/SideMenuView.swift
@@ -57,6 +57,7 @@ struct SideMenuView: View {
                         .font(.title2)
                         .foregroundColor(textColor())
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .dynamicTypeSize(.xSmall)
                 }
             }
              
@@ -144,6 +145,7 @@ struct SideMenuView: View {
                                 .font(.title3)
                                 .foregroundColor(textColor())
                                 .frame(maxWidth: .infinity, alignment: .leading)
+                                .dynamicTypeSize(.xSmall)
                         })
                         
                         Spacer()
@@ -154,6 +156,7 @@ struct SideMenuView: View {
                             Label("", systemImage: "qrcode")
                                 .font(.title)
                                 .foregroundColor(textColor())
+                                .dynamicTypeSize(.xSmall)
                         }).fullScreenCover(isPresented: $showQRCode) {
                             QRCodeView(damus_state: damus_state, pubkey: damus_state.pubkey)
                         }
@@ -188,6 +191,7 @@ struct SideMenuView: View {
             .font(.title2)
             .foregroundColor(textColor())
             .frame(maxWidth: .infinity, alignment: .leading)
+            .dynamicTypeSize(.xSmall)
     }
     
     struct SideMenuLabelStyle: LabelStyle {


### PR DESCRIPTION
Changelog-Fixed: Fix side menu label size so that translations in longer languages fit without wrapping


**iPhone SE 3**
| German Before | German After |
| --------------- | -------------- |
| ![sidemenu_before_german_iphonese3](https://github.com/damus-io/damus/assets/963907/831095b0-ae04-497d-af1e-e6384e74ab3f) | ![german_after_iphonese3](https://github.com/damus-io/damus/assets/963907/3f918fe7-152b-4831-b0ea-2340f3aa945f) |

| English Before | English After |
| --------------- | -------------- |
| ![sidemenu_before_english_iphonese3](https://github.com/damus-io/damus/assets/963907/00e78617-11c9-41e4-8f23-cfd4e57d617b) | ![english_after_iphonese3](https://github.com/damus-io/damus/assets/963907/533aa5a4-1086-4ce7-a2bb-c1fd4baa857e) |

**iPhone 14 Pro**
| German Before | German After |
| --------------- | -------------- |
| ![sidemenu_before_german_iphone14](https://github.com/damus-io/damus/assets/963907/bf4a2c0a-bb7e-4c72-bfa1-e9b5eb8c1a3c) | ![german_after_iphone14pro](https://github.com/damus-io/damus/assets/963907/293a6a4a-a8d8-48d9-b766-ec4ee77ae3fd) |

| English Before | English After |
| --------------- | -------------- |
| ![sidemenu_before_english_iphone14](https://github.com/damus-io/damus/assets/963907/2dc71b15-3417-42b3-b55f-f3c3314a42a5) | ![english_after_iphone14pro](https://github.com/damus-io/damus/assets/963907/95aa282f-5e11-4f2e-8ddc-afe5bba95101) |