### PR TITLE
UI: Issue #1202 - prevent cursor disappearing after Return at screen bottom

### DIFF
--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -209,11 +209,11 @@ struct PostView: View {
     
     func TextEntry(scrollViewGeometry: GeometryProxy) -> some View {
         GeometryReader { (geometry: GeometryProxy) in
-        ZStack(alignment: .topLeading) {
-            TextViewWrapper(attributedText: $post, postTextViewCanScroll: $postTextViewCanScroll, cursorIndex: newCursorIndex, getFocusWordForMention: { word, range in
-                focusWordAttributes = (word, range)
-                self.newCursorIndex = nil
-            })
+            ZStack(alignment: .topLeading) {
+                TextViewWrapper(attributedText: $post, postTextViewCanScroll: $postTextViewCanScroll, cursorIndex: newCursorIndex, getFocusWordForMention: { word, range in
+                    focusWordAttributes = (word, range)
+                    self.newCursorIndex = nil
+                })
                 .environmentObject(tagModel)
                 .frame(maxHeight: scrollViewGeometry.size.height)
                 .position(x: geometry.frame(in: .local).midX, y: scrollViewGeometry.frame(in: .local).midY)
@@ -222,15 +222,15 @@ struct PostView: View {
                 .onChange(of: post) { p in
                     post_changed(post: p, media: uploadedMedias)
                 }
-            
-            if post.string.isEmpty {
-                Text(POST_PLACEHOLDER)
-                    .padding(.top, 8)
-                    .padding(.leading, 4)
-                    .foregroundColor(Color(uiColor: .placeholderText))
-                    .allowsHitTesting(false)
+                
+                if post.string.isEmpty {
+                    Text(POST_PLACEHOLDER)
+                        .padding(.top, 8)
+                        .padding(.leading, 4)
+                        .foregroundColor(Color(uiColor: .placeholderText))
+                        .allowsHitTesting(false)
+                }
             }
-        }
         }
     }
     
@@ -332,18 +332,17 @@ struct PostView: View {
                 
                 ScrollViewReader { scroller in
                     GeometryReader { (geometry: GeometryProxy) in
-                    ScrollView {
-                        if case .replying_to(let replying_to) = self.action {
-                            ReplyView(replying_to: replying_to, damus: damus_state, originalReferences: $originalReferences, references: $references)
+                        ScrollView {
+                            if case .replying_to(let replying_to) = self.action {
+                                ReplyView(replying_to: replying_to, damus: damus_state, originalReferences: $originalReferences, references: $references)
+                            }
+                            
+                            Editor(deviceSize: deviceSize, scrollViewGeometry: geometry)
                         }
-                        
-                        /// `scrollViewGeometry` is passed to TextEntry's .frame & .position modifiers
-                        Editor(deviceSize: deviceSize, scrollViewGeometry: geometry)
-                    }
-                    .frame(maxHeight: searching == nil ? .infinity : 70)
-                    .onAppear {
-                        scroll_to_event(scroller: scroller, id: "post", delay: 1.0, animate: true, anchor: .top)
-                    }
+                        .frame(maxHeight: searching == nil ? .infinity : 70)
+                        .onAppear {
+                            scroll_to_event(scroller: scroller, id: "post", delay: 1.0, animate: true, anchor: .top)
+                        }
                     }
                 }
                 

--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -207,13 +207,16 @@ struct PostView: View {
         }
     }
     
-    var TextEntry: some View {
+    func TextEntry(scrollViewGeometry: GeometryProxy) -> some View {
+        GeometryReader { (geometry: GeometryProxy) in
         ZStack(alignment: .topLeading) {
             TextViewWrapper(attributedText: $post, postTextViewCanScroll: $postTextViewCanScroll, cursorIndex: newCursorIndex, getFocusWordForMention: { word, range in
                 focusWordAttributes = (word, range)
                 self.newCursorIndex = nil
             })
                 .environmentObject(tagModel)
+                .frame(maxHeight: scrollViewGeometry.size.height)
+                .position(x: geometry.frame(in: .local).midX, y: scrollViewGeometry.frame(in: .local).midY)
                 .focused($focus)
                 .textInputAutocapitalization(.sentences)
                 .onChange(of: post) { p in
@@ -227,6 +230,7 @@ struct PostView: View {
                     .foregroundColor(Color(uiColor: .placeholderText))
                     .allowsHitTesting(false)
             }
+        }
         }
     }
     
@@ -297,12 +301,12 @@ struct PostView: View {
         }
     }
     
-    func Editor(deviceSize: GeometryProxy) -> some View {
+    func Editor(deviceSize: GeometryProxy, scrollViewGeometry: GeometryProxy) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(alignment: .top) {
                 ProfilePicView(pubkey: damus_state.pubkey, size: PFP_SIZE, highlight: .none, profiles: damus_state.profiles, disable_animation: damus_state.settings.disable_animation)
                 
-                TextEntry
+                TextEntry(scrollViewGeometry: scrollViewGeometry)
             }
             .frame(height: deviceSize.size.height * multiply_factor)
             .id("post")
@@ -327,16 +331,19 @@ struct PostView: View {
                 TopBar
                 
                 ScrollViewReader { scroller in
+                    GeometryReader { (geometry: GeometryProxy) in
                     ScrollView {
                         if case .replying_to(let replying_to) = self.action {
                             ReplyView(replying_to: replying_to, damus: damus_state, originalReferences: $originalReferences, references: $references)
                         }
                         
-                        Editor(deviceSize: deviceSize)
+                        /// `scrollViewGeometry` is passed to TextEntry's .frame & .position modifiers
+                        Editor(deviceSize: deviceSize, scrollViewGeometry: geometry)
                     }
                     .frame(maxHeight: searching == nil ? .infinity : 70)
                     .onAppear {
                         scroll_to_event(scroller: scroller, id: "post", delay: 1.0, animate: true, anchor: .top)
+                    }
                     }
                 }
                 


### PR DESCRIPTION
See Issue #1202 - Keep cursor in view at all times, ie., after a line-wrap beyond a post’s visible area

(For Reviewer convenience: 1st of 2 commits shows the _whole_ UI change; 2nd is just re-indenting etc)

Changes:
-Wrap PostView body’s ScrollView in a GeometryReader & use its GeometryProxy to set 2 TextViewWrapper modifiers: .frame(maxHeight:) & .position(x:y:) [y-component*]
-*For x-component of latter modifier, use proxy from a 2nd GeometryReader wrapping TextViewWrapper & its ZStack

Demo - 'before'

https://github.com/damus-io/damus/assets/47217795/10a09875-522e-4349-97bb-f1c924f1334e

Demo - 'after'

https://github.com/damus-io/damus/assets/47217795/90370d25-af87-4a35-b017-85a9e0756c73




