### PR TITLE
Replace deprecated NIP-08 indexed mentions with NIP-27 nostr: prefixed URI text note references on writes

### DIFF
--- a/damus/Models/Mentions.swift
+++ b/damus/Models/Mentions.swift
@@ -10,7 +10,7 @@ import Foundation
 enum MentionType {
     case pubkey
     case event
-    
+
     var ref: String {
         switch self {
         case .pubkey:
@@ -495,14 +495,17 @@ func make_post_tags(post_blocks: [PostBlock], tags: [[String]], silent_mentions:
                 continue
             }
             
-            if let ind = find_tag_ref(type: ref.key, id: ref.ref_id, tags: tags) {
-                let mention = Mention(index: ind, type: mention_type, ref: ref)
+            if find_tag_ref(type: ref.key, id: ref.ref_id, tags: tags) != nil {
+                // Mention index is nil because indexed mentions from NIP-08 is deprecated.
+                // It has been replaced with NIP-27 text note references with nostr: prefixed URIs.
+                let mention = Mention(index: nil, type: mention_type, ref: ref)
                 let block = Block.mention(mention)
                 blocks.append(block)
             } else {
-                let ind = new_tags.count
                 new_tags.append(refid_to_tag(ref))
-                let mention = Mention(index: ind, type: mention_type, ref: ref)
+                // Mention index is nil because indexed mentions from NIP-08 is deprecated.
+                // It has been replaced with NIP-27 text note references with nostr: prefixed URIs.
+                let mention = Mention(index: nil, type: mention_type, ref: ref)
                 let block = Block.mention(mention)
                 blocks.append(block)
             }

--- a/damus/Models/Post.swift
+++ b/damus/Models/Post.swift
@@ -21,7 +21,6 @@ struct NostrPost {
     }
 }
 
-// TODO: parse nostr:{e,p}:pubkey uris as well
 func parse_post_mention_type(_ p: Parser) -> MentionType? {
     if parse_char(p, "@") {
         return .pubkey

--- a/damus/Nostr/NostrLink.swift
+++ b/damus/Nostr/NostrLink.swift
@@ -22,18 +22,6 @@ func encode_event_id_uri(_ ref: ReferencedId) -> String {
     return "e:" + ref.ref_id
 }
 
-func parse_nostr_ref_uri_type(_ p: Parser) -> String? {
-    if parse_char(p, "p") {
-        return "p"
-    }
-    
-    if parse_char(p, "e") {
-        return "e"
-    }
-    
-    return nil
-}
-
 func parse_hexstr(_ p: Parser, len: Int) -> String? {
     var i: Int = 0
     
@@ -60,24 +48,13 @@ func parse_nostr_ref_uri(_ p: Parser) -> ReferencedId? {
     if !parse_str(p, "nostr:") {
         return nil
     }
-    
-    guard let typ = parse_nostr_ref_uri_type(p) else {
+
+    guard let ref = parse_post_bech32_mention(p) else {
         p.pos = start
         return nil
     }
-    
-    if !parse_char(p, ":") {
-        p.pos = start
-        return nil
-    }
-    
-    guard let pk = parse_hexstr(p, len: 64) else {
-        p.pos = start
-        return nil
-    }
-    
-    // TODO: parse relays from nostr uris
-    return ReferencedId(ref_id: pk, relay_id: nil, key: typ)
+
+    return ref
 }
 
 func decode_universal_link(_ s: String) -> NostrLink? {

--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -83,7 +83,9 @@ struct PostView: View {
             }
         }
 
-        var content = self.post.string.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        var content = self.post.string
+            .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+            .replacingOccurrences(of: "\u{200B}", with: "") // these characters are added when adding mentions.
 
         let imagesString = uploadedMedias.map { $0.uploadedURL.absoluteString }.joined(separator: " ")
         

--- a/damus/Views/Posting/UserSearch.swift
+++ b/damus/Views/Posting/UserSearch.swift
@@ -63,7 +63,7 @@ struct UserSearch: View {
 
         let tagAttributedString = NSMutableAttributedString(string: tagString,
                                    attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 18.0),
-                                                NSAttributedString.Key.link: "@\(pk)"])
+                                                NSAttributedString.Key.link: "nostr:\(pk)"])
         tagAttributedString.removeAttribute(.link, range: NSRange(location: tagAttributedString.length - 2, length: 2))
         tagAttributedString.addAttributes([NSAttributedString.Key.foregroundColor: UIColor.label], range: NSRange(location: tagAttributedString.length - 2, length: 2))
         

--- a/damusTests/ReplyTests.swift
+++ b/damusTests/ReplyTests.swift
@@ -246,7 +246,7 @@ class ReplyTests: XCTestCase {
         XCTAssertEqual(ev.tags.count, 2)
         XCTAssertEqual(blocks.count, 3)
         XCTAssertEqual(blocks[1].is_ref, ReferencedId(ref_id: hex_pk, relay_id: nil, key: "p"))
-        XCTAssertEqual(ev.content, "this is a #[1] mention")
+        XCTAssertEqual(ev.content, "this is a nostr:npub1xtscya34g58tk0z605fvr788k263gsu6cy9x0mhnm87echrgufzsevkk5s mention")
     }
     
     func testNoteMention() throws {
@@ -279,7 +279,7 @@ class ReplyTests: XCTestCase {
         XCTAssertEqual(ev.tags.count, 2)
         XCTAssertEqual(blocks.count, 3)
         XCTAssertEqual(blocks[1].is_ref, ReferencedId(ref_id: hex_pk, relay_id: nil, key: "p"))
-        XCTAssertEqual(ev.content, "this is a #[1] mention")
+        XCTAssertEqual(ev.content, "this is a nostr:npub1enu46e5x2qtcmm72ttzsx6fmve5wkauftassz78l3mvluh8efqhqejf3v4 mention")
     }
     
     func testPostWithMentions() throws {
@@ -291,7 +291,7 @@ class ReplyTests: XCTestCase {
         let ev = post_to_event(post: post, privkey: evid, pubkey: pk)
         
         XCTAssertEqual(ev.tags.count, 2)
-        XCTAssertEqual(ev.content, "this is a #[1] mention")
+        XCTAssertEqual(ev.content, "this is a nostr:npub1xtscya34g58tk0z605fvr788k263gsu6cy9x0mhnm87echrgufzsevkk5s mention")
     }
     
     func testPostTags() throws {
@@ -320,7 +320,7 @@ class ReplyTests: XCTestCase {
         let post = NostrPost(content: "this is a (@\(pubkey)) mention", references: refs)
         let ev = post_to_event(post: post, privkey: privkey, pubkey: pubkey)
         
-        XCTAssertEqual(ev.content, "this is a (#[2]) mention")
+        XCTAssertEqual(ev.content, "this is a (nostr:npub1xrrdrhrl0s2k0986z5z4uegmwk9xrwvl2r70wkw7tyuxq59ldt3qh09eay) mention")
         XCTAssertEqual(ev.tags[2][1], pubkey)
     }
     
@@ -397,7 +397,8 @@ class ReplyTests: XCTestCase {
     
     func testParsePostUriPubkeyReference() throws {
         let id = "6fec2ee6cfff779fe8560976b3d9df782b74577f0caefa7a77c0ed4c3749b5de"
-        let parsed = parse_post_blocks(content: "this is a nostr:p:\(id) event mention")
+        let npub = try XCTUnwrap(bech32_pubkey(id))
+        let parsed = parse_post_blocks(content: "this is a nostr:\(npub) event mention")
         
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
@@ -428,7 +429,8 @@ class ReplyTests: XCTestCase {
     
     func testParsePostUriReference() throws {
         let id = "6fec2ee6cfff779fe8560976b3d9df782b74577f0caefa7a77c0ed4c3749b5de"
-        let parsed = parse_post_blocks(content: "this is a nostr:e:\(id) event mention")
+        let note_id = try XCTUnwrap(bech32_note_id(id))
+        let parsed = parse_post_blocks(content: "this is a nostr:\(note_id) event mention")
         
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)


### PR DESCRIPTION
Changelog-Fixed: Replace deprecated NIP-08 indexed mentions with NIP-27 nostr: prefixed URI text note references on writes

https://github.com/damus-io/damus/assets/963907/3325c5e9-986b-423c-af4b-69bfa127c721

