### PR TITLE
Refactor profile zaps to reuse same BOLT11 Lightning invoice logic as note zaps, which fixes profile zaps from Cash App and Muun wallets

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3169CAE6294E69C000EE4006 /* EmptyTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3169CAE5294E69C000EE4006 /* EmptyTimelineView.swift */; };
 		3169CAED294FCCFC00EE4006 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3169CAEC294FCCFC00EE4006 /* Constants.swift */; };
 		31D2E847295218AF006D67F8 /* Shimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31D2E846295218AF006D67F8 /* Shimmer.swift */; };
+		3A23838E2A297DD200E5AA2E /* ZapButtonModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A23838D2A297DD200E5AA2E /* ZapButtonModel.swift */; };
 		3A3040ED29A5CB86008A0F29 /* ReplyDescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3040EC29A5CB86008A0F29 /* ReplyDescriptionTests.swift */; };
 		3A3040EF29A8FEE9008A0F29 /* EventDetailBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3040EE29A8FEE9008A0F29 /* EventDetailBarTests.swift */; };
 		3A3040F129A8FF97008A0F29 /* LocalizationUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A3040F029A8FF97008A0F29 /* LocalizationUtil.swift */; };
@@ -337,6 +338,7 @@
 		3A185A04297F2C3800F4BDC0 /* lv-LV */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "lv-LV"; path = "lv-LV.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		3A185A05297F2C3800F4BDC0 /* lv-LV */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "lv-LV"; path = "lv-LV.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		3A185A06297F2C3800F4BDC0 /* lv-LV */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "lv-LV"; path = "lv-LV.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
+		3A23838D2A297DD200E5AA2E /* ZapButtonModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZapButtonModel.swift; sourceTree = "<group>"; };
 		3A25EF132992DA5D008ABE69 /* el-GR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "el-GR"; path = "el-GR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		3A25EF142992DA5D008ABE69 /* el-GR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "el-GR"; path = "el-GR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		3A25EF152992DA5D008ABE69 /* el-GR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "el-GR"; path = "el-GR.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
@@ -903,6 +905,7 @@
 				4CD348EE29C3659D00497EB2 /* ImageUploadModel.swift */,
 				3A48E7AF29DFBE9D006E787E /* MutedThreadsManager.swift */,
 				4C7D09772A0B0CC900943473 /* WalletModel.swift */,
+				3A23838D2A297DD200E5AA2E /* ZapButtonModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1790,6 +1793,7 @@
 				4CE0E2B629A3ED5500DB4CA2 /* InnerTimelineView.swift in Sources */,
 				4C363A8828236948006E126D /* BlocksView.swift in Sources */,
 				4C06670628FCB08600038D2A /* ImageCarousel.swift in Sources */,
+				3A23838E2A297DD200E5AA2E /* ZapButtonModel.swift in Sources */,
 				F79C7FAD29D5E9620000F946 /* EditProfilePictureControl.swift in Sources */,
 				4C9F18E229AA9B6C008C55EC /* CustomizeZapView.swift in Sources */,
 				4C2859602A12A2BE004746F7 /* SupporterBadge.swift in Sources */,

--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -456,6 +456,11 @@ struct ContentView: View {
                 let damus_state else {
                 return
             }
+
+            if local.type == .profile_zap {
+                open_profile(id: local.event_id)
+                return
+            }
             
             guard let target = damus_state.events.lookup(local.event_id) else {
                 return
@@ -471,6 +476,9 @@ struct ContentView: View {
             case .mention: fallthrough
             case .repost:
                 open_event(ev: target)
+            case .profile_zap:
+                // Handled separately above.
+                break
             }
         }
         .onReceive(handle_notify(.onlyzaps_mode)) { notif in

--- a/damus/Models/ZapButtonModel.swift
+++ b/damus/Models/ZapButtonModel.swift
@@ -1,0 +1,15 @@
+//
+//  ZapButtonModel.swift
+//  damus
+//
+//  Created by Terry Yiu on 6/1/23.
+//
+
+import Foundation
+
+class ZapButtonModel: ObservableObject {
+    var invoice: String? = nil
+    @Published var zapping: String = ""
+    @Published var showing_select_wallet: Bool = false
+    @Published var showing_zap_customizer: Bool = false
+}

--- a/damus/Util/LocalNotification.swift
+++ b/damus/Util/LocalNotification.swift
@@ -44,4 +44,5 @@ enum LocalNotificationType: String {
     case mention
     case repost
     case zap
+    case profile_zap
 }

--- a/damus/Views/ActionBar/EventActionBar.swift
+++ b/damus/Views/ActionBar/EventActionBar.swift
@@ -88,7 +88,7 @@ struct EventActionBar: View {
 
             if let lnurl = self.lnurl {
                 Spacer()
-                ZapButton(damus_state: damus_state, event: event, lnurl: lnurl, zaps: self.damus_state.events.get_cache_data(self.event.id).zaps_model)
+                ZapButton(damus_state: damus_state, target: ZapTarget.note(id: event.id, author: event.pubkey), lnurl: lnurl, zaps: self.damus_state.events.get_cache_data(self.event.id).zaps_model)
             }
 
             Spacer()


### PR DESCRIPTION
Changelog-Fixed: Refactor profile zaps to reuse same BOLT11 Lightning invoice logic as note zaps, which fixes profile zaps from Cash App and Muun wallets
Fixes: #1067

Video of profile zaps using Nostr Wallet Connect
https://void.cat/D4MPLR7MAXUwfZKaWxaqGi

Wallet Selector (note the `lnbc1` prefix instead of `lnurl`)
https://github.com/damus-io/damus/assets/963907/0e316d5c-5c05-4783-86d0-e0f14401c64e

Profile Zap Notifications
![Simulator Screenshot - iPhone 14 Pro - 2023-06-02 at 20 15 38 Medium](https://github.com/damus-io/damus/assets/963907/9cefc201-35f9-4a4b-96fc-e5467b79fb0d)