### PR TITLE
[UX] Fix Issue 1256 - iPhone SE & 12 mini: explainer text cuts off when logging in with npub 

### DIFF
--- a/damus/Views/LoginView.swift
+++ b/damus/Views/LoginView.swift
@@ -83,6 +83,7 @@ struct LoginView: View {
                     Text("This is a public key, you will not be able to make posts or interact in any way. This is used for viewing accounts from their perspective.", comment: "Warning that the inputted account key is a public key and the result of what happens because of it.")
                         .foregroundColor(Color.orange)
                         .bold()
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 if let p = parsed {


### PR DESCRIPTION
FIx issue: #1256 

Fix:
Add a `.fixedSize` modifier to the Text("This is a public key[...]) so that all text will show

Before             |  After
:-------------------------:|:-------------------------:
![Before](https://github.com/damus-io/damus/assets/47217795/1db21bc5-e3b6-4e56-b31b-7d4374efc316)  |  ![After](https://github.com/damus-io/damus/assets/47217795/1b47f0d3-c3e5-4f7d-a701-8ea33b4d02a6)



