### PR TITLE
[UX] Fix Issue 1238: Videos sounds can play over each other

### DIFF
--- a/damus/Views/Video/DamusVideoPlayer.swift
+++ b/damus/Views/Video/DamusVideoPlayer.swift
@@ -43,25 +43,34 @@ struct DamusVideoPlayer: View {
     }
     
     var body: some View {
-        ZStack(alignment: .bottomTrailing) {
-            VideoPlayer(url: url, model: model)
-                .onAppear {
-                    model.start()
+        GeometryReader { geo in
+            let localFrame = geo.frame(in: .local)
+            let localCenter = CGPoint(x: localFrame.midX, y: localFrame.midY)
+            let globalCenter = geo.frame(in: .global).origin.applying(.init(translationX: localCenter.x, y: localCenter.y))
+            let centerY = globalCenter.y
+
+            ZStack(alignment: .bottomTrailing) {
+                VideoPlayer(url: url, model: model)
+                if model.has_audio == true {
+                    MuteIcon
+                        .zIndex(11.0)
+                        .onTapGesture {
+                            self.model.muted = !self.model.muted
+                        }
                 }
-            
-            if model.has_audio == true {
-                MuteIcon
-                    .zIndex(11.0)
-                    .onTapGesture {
-                        self.model.muted = !self.model.muted
-                    }
             }
-        }
-        .onChange(of: model.size) { size in
-            guard let size else {
-                return
+            .onChange(of: model.size) { size in
+                guard let size else {
+                    return
+                }
+                video_size = size
             }
-            video_size = size
+            .onChange(of: centerY) { _ in
+                let screenHeight = UIScreen.main.bounds.height
+                let screenMidY = screenHeight / 2
+                let tol = 0.20 * screenHeight /// tolerance - can vary  to taste ie.,  %  of screen height of a centered box in which video plays
+                model.play = centerY > screenMidY - tol && centerY < screenMidY + tol /// video plays when inside tolerance box
+            }
         }
     }
 }


### PR DESCRIPTION
Fix issue #1238 - make videos automatically pause after scrolling away from a post containing a video

Fix
-Auto-pause triggered in an .onChange that compares the y-coordinate of the center of a video with the screen visible area
-Tolerance can be set according to design preferences (ie. how far user needs to scroll before it pauses) 

Demo

https://github.com/damus-io/damus/assets/47217795/2cb126db-9b55-4c78-975f-3d692a0b0a9d

*handy account that posts quite a few videos (i just spun up a new account & followed only this one) :
npub1ztdt0nvu8324tg40g4ts8d6englps8w6574zyq2gkdvcrx364y0qd9x9za
