### PR TITLE
fix: Show DM error rather than editing event content

### DIFF
--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -161,7 +161,7 @@ class NostrEvent: Codable, Identifiable, CustomStringConvertible, Equatable, Has
                 return decrypted_content
             } else {
                 self.decryptable = false
-                return "Error: failed to decrypt content"
+                return ""
             }
         }
         

--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -66,6 +66,7 @@ class NostrEvent: Codable, Identifiable, CustomStringConvertible, Equatable, Has
     let created_at: Int64
     let kind: Int
     let content: String
+    var decryptable: Bool = true
     
     var is_textlike: Bool {
         return kind == 1 || kind == 42
@@ -156,7 +157,12 @@ class NostrEvent: Codable, Identifiable, CustomStringConvertible, Equatable, Has
 
     func get_content(_ privkey: String?) -> String {
         if known_kind == .dm {
-            return decrypted(privkey: privkey) ?? "*failed to decrypt content*"
+            if let decrypted_content = decrypted(privkey: privkey) {
+                return decrypted_content
+            } else {
+                self.decryptable = false
+                return "Error: failed to decrypt content"
+            }
         }
         
         return content

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -106,7 +106,7 @@ struct NoteContentView: View {
     var MainContent: some View {
         VStack(alignment: .leading) {
             if !self.event.decryptable {
-                Text("Error: failed to decrypt content").italic().bold()
+                Text("Error: failed to decrypt content", comment: "Text error shown when Damus cannot decipher and understand a Direct message").italic().bold()
             } else {
                 if size == .selected {
                     if with_padding {

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -105,55 +105,58 @@ struct NoteContentView: View {
     
     var MainContent: some View {
         VStack(alignment: .leading) {
-            if size == .selected {
-                if with_padding {
-                    SelectableText(attributedString: artifacts.content.attributed, size: self.size)
-                        .padding(.horizontal)
-                } else {
-                    SelectableText(attributedString: artifacts.content.attributed, size: self.size)
-                }
+            if !self.event.decryptable {
+                Text("Error: failed to decrypt content").italic().bold()
             } else {
-                if with_padding {
-                    truncatedText
-                        .padding(.horizontal)
+                if size == .selected {
+                    if with_padding {
+                        SelectableText(attributedString: artifacts.content.attributed, size: self.size)
+                    } else {
+                        SelectableText(attributedString: artifacts.content.attributed, size: self.size)
+                    }
                 } else {
-                    truncatedText
+                    if with_padding {
+                        truncatedText
+                            .padding(.horizontal)
+                    } else {
+                        truncatedText
+                    }
                 }
-            }
-
-            if !options.contains(.no_translate) && (size == .selected || damus_state.settings.auto_translate) {
-                if with_padding {
-                    translateView
-                        .padding(.horizontal)
-                } else {
-                    translateView
+                
+                if !options.contains(.no_translate) && (size == .selected || damus_state.settings.auto_translate) {
+                    if with_padding {
+                        translateView
+                            .padding(.horizontal)
+                    } else {
+                        translateView
+                    }
                 }
-            }
-
-            if show_images && artifacts.media.count > 0 {
-                ImageCarousel(state: damus_state, evid: event.id, urls: artifacts.media)
-            } else if !show_images && artifacts.media.count > 0 {
-                ZStack {
+                
+                if show_images && artifacts.media.count > 0 {
                     ImageCarousel(state: damus_state, evid: event.id, urls: artifacts.media)
-                    Blur()
-                        .disabled(true)
+                } else if !show_images && artifacts.media.count > 0 {
+                    ZStack {
+                        ImageCarousel(state: damus_state, evid: event.id, urls: artifacts.media)
+                        Blur()
+                            .disabled(true)
+                    }
+                    //.cornerRadius(10)
                 }
-                //.cornerRadius(10)
-            }
-            
-            if artifacts.invoices.count > 0 {
+                
+                if artifacts.invoices.count > 0 {
+                    if with_padding {
+                        invoicesView
+                            .padding(.horizontal)
+                    } else {
+                        invoicesView
+                    }
+                }
+                
                 if with_padding {
-                    invoicesView
-                        .padding(.horizontal)
+                    previewView.padding(.horizontal)
                 } else {
-                    invoicesView
+                    previewView
                 }
-            }
-            
-            if with_padding {
-                previewView.padding(.horizontal)
-            } else {
-                previewView
             }
             
         }


### PR DESCRIPTION
When a DM event cannot be decrypted Damus currently edits the content of the DM to say `*failed to decrypt content*`. This is problematic for two reasons:

1. We shouldn't edit the content of an event to display an error to avoid actually dealing with that error
2. Damus no longer renders Markdown for events so `*failed to decrypt content*` is no longer correctly italicized.

To fix this I added a `decryptable` variable to the NostrEvent type that defaults to true but is set to false when a DM cannot be decrypted. This value is only read and used when displaying DMs and allows Damus to show a styled text event rather than broken Markdown plaintext so the user has more of a hint that the text is coming from Damus rather than a strange message by another user.

I also added the `too_big` variable into the `should_show_event` since they were already the same thing.