### PR TITLE
simplify and fix issues with RelayStatus

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -239,7 +239,7 @@
 		4CE8794829941DA700F758CC /* RelayFilters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE8794729941DA700F758CC /* RelayFilters.swift */; };
 		4CE8794C2995B59E00F758CC /* RelayMetadatas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE8794B2995B59E00F758CC /* RelayMetadatas.swift */; };
 		4CE8794E2996B16A00F758CC /* RelayToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE8794D2996B16A00F758CC /* RelayToggle.swift */; };
-		4CE879502996B2BD00F758CC /* RelayStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE8794F2996B2BD00F758CC /* RelayStatus.swift */; };
+		4CE879502996B2BD00F758CC /* RelayStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE8794F2996B2BD00F758CC /* RelayStatusView.swift */; };
 		4CE879522996B68900F758CC /* RelayType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE879512996B68900F758CC /* RelayType.swift */; };
 		4CE879552996BAB900F758CC /* RelayPaidDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE879542996BAB900F758CC /* RelayPaidDetail.swift */; };
 		4CE879582996C45300F758CC /* ZapsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE879572996C45300F758CC /* ZapsView.swift */; };
@@ -682,7 +682,7 @@
 		4CE8794729941DA700F758CC /* RelayFilters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayFilters.swift; sourceTree = "<group>"; };
 		4CE8794B2995B59E00F758CC /* RelayMetadatas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayMetadatas.swift; sourceTree = "<group>"; };
 		4CE8794D2996B16A00F758CC /* RelayToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayToggle.swift; sourceTree = "<group>"; };
-		4CE8794F2996B2BD00F758CC /* RelayStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayStatus.swift; sourceTree = "<group>"; };
+		4CE8794F2996B2BD00F758CC /* RelayStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayStatusView.swift; sourceTree = "<group>"; };
 		4CE879512996B68900F758CC /* RelayType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayType.swift; sourceTree = "<group>"; };
 		4CE879542996BAB900F758CC /* RelayPaidDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayPaidDetail.swift; sourceTree = "<group>"; };
 		4CE879572996C45300F758CC /* ZapsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZapsView.swift; sourceTree = "<group>"; };
@@ -1165,7 +1165,7 @@
 				4CAAD8AF29888AD200060CEA /* RelayConfigView.swift */,
 				F7908E91298B0F0700AB113A /* RelayDetailView.swift */,
 				4CE8794D2996B16A00F758CC /* RelayToggle.swift */,
-				4CE8794F2996B2BD00F758CC /* RelayStatus.swift */,
+				4CE8794F2996B2BD00F758CC /* RelayStatusView.swift */,
 				4CE879512996B68900F758CC /* RelayType.swift */,
 				4CDA128929E9D10C0006FA5A /* SignalView.swift */,
 			);
@@ -1897,7 +1897,7 @@
 				4FE60CDD295E1C5E00105A1F /* Wallet.swift in Sources */,
 				3AA247FF297E3D900090C62D /* RepostsView.swift in Sources */,
 				3AE45AF6297BB2E700C1D842 /* LibreTranslateServer.swift in Sources */,
-				4CE879502996B2BD00F758CC /* RelayStatus.swift in Sources */,
+				4CE879502996B2BD00F758CC /* RelayStatusView.swift in Sources */,
 				4CC7AAF4297F18B400430951 /* ReplyDescription.swift in Sources */,
 				4C75EFA427FA577B0006080F /* PostView.swift in Sources */,
 				4C30AC7229A5677A00E2BD5A /* NotificationsView.swift in Sources */,

--- a/damus/Nostr/RelayConnection.swift
+++ b/damus/Nostr/RelayConnection.swift
@@ -37,9 +37,9 @@ public struct RelayURL: Hashable {
     }
 }
 
-final class RelayConnection {
-    private(set) var isConnected = false
-    private(set) var isConnecting = false
+final class RelayConnection: ObservableObject {
+    @Published private(set) var isConnected = false
+    @Published private(set) var isConnecting = false
     
     private(set) var last_connection_attempt: TimeInterval = 0
     private(set) var last_pong: Date? = nil

--- a/damus/Views/Relays/RelayDetailView.swift
+++ b/damus/Views/Relays/RelayDetailView.swift
@@ -75,11 +75,13 @@ struct RelayDetailView: View {
                         UserViewRow(damus_state: state, pubkey: pubkey)
                     }
                 }
-                Section(NSLocalizedString("Relay", comment: "Label to display relay address.")) {
-                    HStack {
-                        Text(relay)
-                        Spacer()
-                        RelayStatus(pool: state.pool, relay: relay)
+                if let relay_connection {
+                    Section(NSLocalizedString("Relay", comment: "Label to display relay address.")) {
+                        HStack {
+                            Text(relay)
+                            Spacer()
+                            RelayStatus(connection: relay_connection)
+                        }
                     }
                 }
                 if nip11.is_paid {
@@ -133,6 +135,10 @@ struct RelayDetailView: View {
             }
         }
         return attrString
+    }
+    
+    private var relay_connection: RelayConnection? {
+        state.pool.get_relay(relay)?.connection
     }
 }
 

--- a/damus/Views/Relays/RelayDetailView.swift
+++ b/damus/Views/Relays/RelayDetailView.swift
@@ -80,7 +80,7 @@ struct RelayDetailView: View {
                         HStack {
                             Text(relay)
                             Spacer()
-                            RelayStatus(connection: relay_connection)
+                            RelayStatusView(connection: relay_connection)
                         }
                     }
                 }

--- a/damus/Views/Relays/RelayStatus.swift
+++ b/damus/Views/Relays/RelayStatus.swift
@@ -8,58 +8,26 @@
 import SwiftUI
 
 struct RelayStatus: View {
-    let pool: RelayPool
-    let relay: String
-    
-    let timer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
-    
-    @State var conn_color: Color = .gray
-    @State var conn_image: String = "network"
-    @State var connecting: Bool = false
-    
-    func update_connection() {
-        for relay in pool.relays {
-            if relay.id == self.relay {
-                let c = relay.connection
-                if c.isConnected {
-                    conn_image = "globe"
-                    conn_color = .green
-                } else if c.isConnecting {
-                    connecting = true
-                } else {
-                    conn_image = "warning.fill"
-                    conn_color = .red
-                }
-            }
-        }
-    }
+    @ObservedObject var connection: RelayConnection
     
     var body: some View {
-        HStack {
-            if connecting {
+        Group {
+            if connection.isConnecting {
                 ProgressView()
-                    .frame(width: 20, height: 20)
-                    .padding(.trailing, 5)
             } else {
-                Image(conn_image)
+                Image(connection.isConnected ? "globe" : "warning.fill")
                     .resizable()
-                    .frame(width: 20, height: 20)
-                    .foregroundColor(conn_color)
-                    .padding(.trailing, 5)
+                    .foregroundColor(connection.isConnected ? .green : .red)
             }
         }
-        .onReceive(timer) { _ in
-            update_connection()
-        }
-        .onAppear() {
-            update_connection()
-        }
-        
+        .frame(width: 20, height: 20)
+        .padding(.trailing, 5)
     }
 }
 
-struct RelayStatus_Previews: PreviewProvider {
+struct RelayStatusView_Previews: PreviewProvider {
     static var previews: some View {
-        RelayStatus(pool: test_damus_state().pool, relay: "relay")
+        let connection = test_damus_state().pool.get_relay("relay")!.connection
+        RelayStatus(connection: connection)
     }
 }

--- a/damus/Views/Relays/RelayStatusView.swift
+++ b/damus/Views/Relays/RelayStatusView.swift
@@ -1,5 +1,5 @@
 //
-//  RelayStatus.swift
+//  RelayStatusView.swift
 //  damus
 //
 //  Created by William Casarin on 2023-02-10.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct RelayStatus: View {
+struct RelayStatusView: View {
     @ObservedObject var connection: RelayConnection
     
     var body: some View {
@@ -28,6 +28,6 @@ struct RelayStatus: View {
 struct RelayStatusView_Previews: PreviewProvider {
     static var previews: some View {
         let connection = test_damus_state().pool.get_relay("relay")!.connection
-        RelayStatus(connection: connection)
+        RelayStatusView(connection: connection)
     }
 }

--- a/damus/Views/Relays/RelayToggle.swift
+++ b/damus/Views/Relays/RelayToggle.swift
@@ -27,7 +27,7 @@ struct RelayToggle: View {
     var body: some View {
         HStack {
             if let relay_connection {
-                RelayStatus(connection: relay_connection)
+                RelayStatusView(connection: relay_connection)
             }
             RelayType(is_paid: state.relay_metadata.lookup(relay_id: relay_id)?.is_paid ?? false)
             Toggle(relay_id, isOn: toggle_binding(relay_id: relay_id))

--- a/damus/Views/Relays/RelayToggle.swift
+++ b/damus/Views/Relays/RelayToggle.swift
@@ -26,11 +26,17 @@ struct RelayToggle: View {
     
     var body: some View {
         HStack {
-            RelayStatus(pool: state.pool, relay: relay_id)
+            if let relay_connection {
+                RelayStatus(connection: relay_connection)
+            }
             RelayType(is_paid: state.relay_metadata.lookup(relay_id: relay_id)?.is_paid ?? false)
             Toggle(relay_id, isOn: toggle_binding(relay_id: relay_id))
                 .toggleStyle(SwitchToggleStyle(tint: .accentColor))
         }
+    }
+    
+    private var relay_connection: RelayConnection? {
+        state.pool.get_relay(relay_id)?.connection
     }
 }
 

--- a/damus/Views/Relays/RelayView.swift
+++ b/damus/Views/Relays/RelayView.swift
@@ -21,7 +21,7 @@ struct RelayView: View {
                         RemoveButton(privkey: privkey, showText: false)
                     }
                     else if let relay_connection {
-                        RelayStatus(connection: relay_connection)
+                        RelayStatusView(connection: relay_connection)
                     }
                 }
                 

--- a/damus/Views/Relays/RelayView.swift
+++ b/damus/Views/Relays/RelayView.swift
@@ -20,8 +20,8 @@ struct RelayView: View {
                     if showActionButtons {
                         RemoveButton(privkey: privkey, showText: false)
                     }
-                    else {
-                        RelayStatus(pool: state.pool, relay: relay)
+                    else if let relay_connection {
+                        RelayStatus(connection: relay_connection)
                     }
                 }
                 
@@ -65,6 +65,10 @@ struct RelayView: View {
                 RemoveButton(privkey: privkey, showText: true)
             }
         }
+    }
+    
+    private var relay_connection: RelayConnection? {
+        state.pool.get_relay(relay)?.connection
     }
     
     func CopyAction(relay: String) -> some View {


### PR DESCRIPTION
While attempting to debug the recent relay connection issues, I noticed some problems and improvement opportunities with `RelayStatus`.

This PR addresses these issues:
1. The console message "No image named 'network' found in asset catalog..." prints for every occurrence of `RelayStatus`, presumably because that image was removed with the iconography update.
2. The property `connecting` never gets set to false after being set to true, so you have to leave the view and come back for it to update. Otherwise it will always appear to be connecting even after it has reconnected.
3. The view uses a timer for polling the connection status every 2 seconds. This PR updates that to make `RelayConnection` observable.
4. `RelayStatus` was being passed the entire `RelayPool` when all it needs is a `RelayConnection` to track.

Lastly, in a separate commit, I changed the name of `RelayStatus` to `RelayStatusView`. IMO it makes code easier to read and maintain when view names end with the word "view".