### PR TITLE
video: improve precision & sensitivity of auto-pause mechanism

### DIFF
--- a/damus/damusApp.swift
+++ b/damus/damusApp.swift
@@ -20,11 +20,13 @@ struct damusApp: App {
 struct MainView: View {
     @State var needs_setup = false;
     @State var keypair: Keypair? = nil;
+    @StateObject private var orientationTracker = OrientationTracker()
     
     var body: some View {
         Group {
             if let kp = keypair, !needs_setup {
                 ContentView(keypair: kp)
+                    .environmentObject(orientationTracker)
             } else {
                 SetupView()
                     .onReceive(handle_notify(.login)) { notif in
@@ -38,7 +40,11 @@ struct MainView: View {
             try? clear_keypair()
             keypair = nil
         }
+        .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+            orientationTracker.setDeviceMajorAxis()
+        }
         .onAppear {
+            orientationTracker.setDeviceMajorAxis()
             keypair = get_saved_keypair()
         }
     }
@@ -61,5 +67,16 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         let notification = LossyLocalNotification.from_user_info(user_info: userInfo)
         notify(.local_notification, notification)
         completionHandler()
+    }
+}
+
+class OrientationTracker: ObservableObject {
+    var deviceMajorAxis: CGFloat = 0
+    func setDeviceMajorAxis() {
+        let bounds = UIScreen.main.bounds
+        let height = max(bounds.height, bounds.width) /// device's longest dimension
+        let width = min(bounds.height, bounds.width)  /// device's shortest dimension
+        let orientation = UIDevice.current.orientation
+        deviceMajorAxis = (orientation == .portrait || orientation == .unknown) ? height : width
     }
 }


### PR DESCRIPTION
Address Issue #1303 

-Make video auto-pause mechanism uniform and precise regardless of video size or device orientation
-Automatically pauses a video when it is scrolled out of view, and plays it when it is back in view
_-Side note - Initially gave it even more precision, by using GeometryReaders to get exact TabView-bottom & TabBar-top y-values; but judged that it added excessive complexity (especially making it work with the device rotation handling done here)_


Demo (turn the sound on)

https://github.com/damus-io/damus/assets/47217795/02eb9c1c-c636-410b-a3c8-57318aa61768



