### PR TITLE
Remove note zaps in appstore builds

### DIFF
--- a/damus/Components/InvoiceView.swift
+++ b/damus/Components/InvoiceView.swift
@@ -37,7 +37,7 @@ struct InvoiceView: View {
     var PayButton: some View {
         Button {
             if settings.show_wallet_selector {
-                showing_select_wallet = true
+                present_sheet(.select_wallet(invoice: invoice.string))
             } else {
                 open_with_wallet(wallet: settings.default_wallet.model, invoice: invoice.string)
             }
@@ -79,9 +79,6 @@ struct InvoiceView: View {
             }
             .padding(30)
         }
-        .sheet(isPresented: $showing_select_wallet, onDismiss: {showing_select_wallet = false}) {
-            SelectWalletView(default_wallet: settings.default_wallet, showingSelectWallet: $showing_select_wallet, our_pubkey: our_pubkey, invoice: invoice.string)
-        }
     }
 }
 
@@ -116,3 +113,7 @@ struct InvoiceView_Previews: PreviewProvider {
     }
 }
 
+
+func present_sheet(_ sheet: Sheets) {
+    notify(.present_sheet, sheet)
+}

--- a/damus/Components/ZapButton.swift
+++ b/damus/Components/ZapButton.swift
@@ -39,6 +39,10 @@ struct ZapButton: View {
     }
     
     var zap_img: String {
+        if damus_state.settings.nozaps {
+            return "zap"
+        }
+        
         switch our_zap {
         case .none:
             return "zap"
@@ -50,19 +54,16 @@ struct ZapButton: View {
     }
     
     var zap_color: Color {
+        if damus_state.settings.nozaps {
+            return Color.gray
+        }
+        
         if our_zap == nil {
             return Color.gray
         }
         
         // always orange !
         return Color.orange
-            /*
-        if our_zap.is_paid {
-            return Color.orange
-        } else {
-            return Color.yellow
-        }
-             */
     }
     
     func tap() {

--- a/damus/Components/ZapButton.swift
+++ b/damus/Components/ZapButton.swift
@@ -252,7 +252,10 @@ func send_zap(damus_state: DamusState, target: ZapTarget, lnurl: String, is_cust
                     })
                 }
                 
-                let nwc_req = nwc_pay(url: nwc_state.url,  pool: damus_state.pool, post: damus_state.postbox, invoice: inv, on_flush: flusher)
+                // we don't have a delay on one-tap nozaps (since this will be from customize zap view)
+                let delay = damus_state.settings.nozaps ? nil : 5.0
+                
+                let nwc_req = nwc_pay(url: nwc_state.url, pool: damus_state.pool, post: damus_state.postbox, invoice: inv, delay: delay, on_flush: flusher)
                 
                 guard let nwc_req, case .nwc(let pzap_state) = pending_zap_state else {
                     print("nwc: failed to send nwc request for zapreq \(reqid.reqid)")

--- a/damus/Components/ZapButton.swift
+++ b/damus/Components/ZapButton.swift
@@ -241,11 +241,12 @@ func send_zap(damus_state: DamusState, target: ZapTarget, lnurl: String, is_cust
                 }
                 
                 var flusher: OnFlush? = nil
-                // Don't donate on custom zaps
-                if !is_custom && damus_state.settings.donation_percent > 0 {
+                
+                // donations are only enabled on one-tap zaps and off appstore
+                if !damus_state.settings.nozaps && !is_custom && damus_state.settings.donation_percent > 0 {
                     flusher = .once({ pe in
                         // send donation zap when the pending zap is flushed, this allows user to cancel and not send a donation
-                        Task.init { @MainActor in
+                        Task { @MainActor in
                             await send_donation_zap(pool: damus_state.pool, postbox: damus_state.postbox, nwc: nwc_state.url, percent: damus_state.settings.donation_percent, base_msats: amount_msat)
                         }
                     })

--- a/damus/Components/ZapButton.swift
+++ b/damus/Components/ZapButton.swift
@@ -125,7 +125,7 @@ struct ZapButton: View {
                     .frame(width:20, height: 20)
             })
 
-            if zaps.zap_total > 0 {
+            if !damus_state.settings.nozaps && zaps.zap_total > 0 {
                 Text(verbatim: format_msats_abbrev(zaps.zap_total))
                     .font(.footnote)
                     .foregroundColor(zap_color)

--- a/damus/Models/DamusState.swift
+++ b/damus/Models/DamusState.swift
@@ -38,7 +38,8 @@ struct DamusState {
         let stored = self.events.store_zap(zap: zap)
         
         // thread zaps
-        if let ev = zap.event, zap.is_in_thread {
+        if let ev = zap.event, !settings.nozaps, zap.is_in_thread {
+            // [nozaps]: thread zaps are only available outside of the app store
             replies.count_replies(ev)
             events.add_replies(ev: ev)
         }

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -52,6 +52,7 @@ class HomeModel {
     var notifications = NotificationsModel()
     var notification_status = NotificationStatusModel()
     var events: EventHolder = EventHolder()
+    var zap_button: ZapButtonModel = ZapButtonModel()
     
     init() {
         self.damus_state = DamusState.empty

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -126,6 +126,10 @@ class UserSettingsStore: ObservableObject {
     @Setting(key: "truncate_timeline_text", default_value: false)
     var truncate_timeline_text: Bool
     
+    /// Nozaps mode gimps note zapping to fit into apple's content-tipping guidelines. It can not be configurable to end-users on the app store
+    @Setting(key: "nozaps", default_value: true)
+    var nozaps: Bool
+    
     @Setting(key: "truncate_mention_text", default_value: true)
     var truncate_mention_text: Bool
     

--- a/damus/Models/ZapButtonModel.swift
+++ b/damus/Models/ZapButtonModel.swift
@@ -10,6 +10,4 @@ import Foundation
 class ZapButtonModel: ObservableObject {
     var invoice: String? = nil
     @Published var zapping: String = ""
-    @Published var showing_select_wallet: Bool = false
-    @Published var showing_zap_customizer: Bool = false
 }

--- a/damus/Models/Zaps/CustomizeZapModel.swift
+++ b/damus/Models/Zaps/CustomizeZapModel.swift
@@ -15,7 +15,6 @@ class CustomizeZapModel: ObservableObject {
     @Published var zap_type: ZapType = .pub
     @Published var invoice: String = ""
     @Published var error: String? = nil
-    @Published var showing_wallet_selector: Bool = false
     @Published var zapping: Bool = false
     @Published var show_zap_types: Bool = false
     

--- a/damus/Nostr/Nostr.swift
+++ b/damus/Nostr/Nostr.swift
@@ -100,8 +100,8 @@ class Profile: Codable {
     }
     
     var damus_donation: Int? {
-        get { return int("damus_donation"); }
-        set(s) { set_int("damus_donation", s) }
+        get { return int("damus_donation_v2"); }
+        set(s) { set_int("damus_donation_v2", s) }
     }
     
     var picture: String? {

--- a/damus/Util/Notifications.swift
+++ b/damus/Util/Notifications.swift
@@ -77,6 +77,9 @@ extension Notification.Name {
     static var update_stats: Notification.Name {
         return Notification.Name("update_stats")
     }
+    static var present_sheet: Notification.Name {
+        return Notification.Name("present_sheet")
+    }
     static var zapping: Notification.Name {
         return Notification.Name("zapping")
     }

--- a/damus/Views/ActionBar/EventDetailBar.swift
+++ b/damus/Views/ActionBar/EventDetailBar.swift
@@ -19,7 +19,11 @@ struct EventDetailBar: View {
         self.target = target
         self.target_pk = target_pk
         self._bar = ObservedObject(wrappedValue: make_actionbar_model(ev: target, damus: state))
+    }
         
+    var ZapDetails: Text {
+        let noun = Text(verbatim: zapsCountString(bar.zaps)).foregroundColor(.gray)
+        return Text("\(Text(verbatim: bar.zaps.formatted()).font(.body.bold())) \(noun)", comment: "Sentence composed of 2 variables to describe how many zap payments there are on a post. In source English, the first variable is the number of zap payments, and the second variable is 'Zap' or 'Zaps'.")
     }
     
     var body: some View {
@@ -40,13 +44,11 @@ struct EventDetailBar: View {
                 .buttonStyle(PlainButtonStyle())
             }
             
-            if bar.zaps > 0 {
+            if !state.settings.nozaps && bar.zaps > 0 {
                 let dst = ZapsView(state: state, target: .note(id: target, author: target_pk))
                 NavigationLink(destination: dst) {
-                    let noun = Text(verbatim: zapsCountString(bar.zaps)).foregroundColor(.gray)
-                    Text("\(Text(verbatim: bar.zaps.formatted()).font(.body.bold())) \(noun)", comment: "Sentence composed of 2 variables to describe how many zap payments there are on a post. In source English, the first variable is the number of zap payments, and the second variable is 'Zap' or 'Zaps'.")
-                }
-                .buttonStyle(PlainButtonStyle())
+                    ZapDetails
+                }.buttonStyle(PlainButtonStyle())
             }
         }
     }

--- a/damus/Views/Notifications/EventGroupView.swift
+++ b/damus/Views/Notifications/EventGroupView.swift
@@ -56,8 +56,13 @@ enum ReactingTo {
     case your_profile
 }
 
-func determine_reacting_to(our_pubkey: String, ev: NostrEvent?) -> ReactingTo {
+func determine_reacting_to(our_pubkey: String, ev: NostrEvent?, group: EventGroupType, nozaps: Bool) -> ReactingTo {
     guard let ev else {
+        return .your_profile
+    }
+    
+    if nozaps && group.is_note_zap {
+        // ZAPPING NOTES IS NOT ALLOWED!!!! EVIL!!!
         return .your_profile
     }
     
@@ -125,13 +130,13 @@ func event_group_author_name(profiles: Profiles, ind: Int, group: EventGroupType
  "zapped_your_profile_2" - returned when 2 zaps occurred to the current user's profile
  "zapped_your_profile_3" - returned when 3 or more zaps occurred to the current user's profile
  */
-func reacting_to_text(profiles: Profiles, our_pubkey: String, group: EventGroupType, ev: NostrEvent?, locale: Locale? = nil) -> String {
+func reacting_to_text(profiles: Profiles, our_pubkey: String, group: EventGroupType, ev: NostrEvent?, nozaps: Bool, locale: Locale? = nil) -> String {
     if group.events.count == 0 {
         return "??"
     }
 
     let verb = reacting_to_verb(group: group)
-    let reacting_to = determine_reacting_to(our_pubkey: our_pubkey, ev: ev)
+    let reacting_to = determine_reacting_to(our_pubkey: our_pubkey, ev: ev, group: group, nozaps: nozaps)
     let localization_key = "\(verb)_\(reacting_to)_\(min(group.events.count, 3))"
     let format = localizedStringFormat(key: localization_key, locale: locale)
 
@@ -171,7 +176,7 @@ struct EventGroupView: View {
     let group: EventGroupType
     
     var GroupDescription: some View {
-        Text(verbatim: "\(reacting_to_text(profiles: state.profiles, our_pubkey: state.pubkey, group: group, ev: event))")
+        Text(verbatim: "\(reacting_to_text(profiles: state.profiles, our_pubkey: state.pubkey, group: group, ev: event, nozaps: state.settings.nozaps))")
     }
     
     func ZapIcon(_ zapgrp: ZapGroup) -> some View {
@@ -216,16 +221,18 @@ struct EventGroupView: View {
                 if let event {
                     let thread = ThreadModel(event: event, damus_state: state)
                     let dest = ThreadView(state: state, thread: thread)
-                    NavigationLink(destination: dest) {
-                        VStack(alignment: .leading) {
-                            GroupDescription
-                            EventBody(damus_state: state, event: event, size: .normal, options: [.truncate_content])
-                                .padding([.top], 1)
-                                .padding([.trailing])
-                                .foregroundColor(.gray)
+                    GroupDescription
+                    if !state.settings.nozaps || !group.is_note_zap {
+                        NavigationLink(destination: dest) {
+                            VStack(alignment: .leading) {
+                                EventBody(damus_state: state, event: event, size: .normal, options: [.truncate_content])
+                                    .padding([.top], 1)
+                                    .padding([.trailing])
+                                    .foregroundColor(.gray)
+                            }
                         }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
                 } else {
                     GroupDescription
                 }

--- a/damus/Views/Profile/EventProfileName.swift
+++ b/damus/Views/Profile/EventProfileName.swift
@@ -72,14 +72,11 @@ struct EventProfileName: View {
                     .font(eventviewsize_to_font(size))
             }
             
-            /*
             if let nip05 = current_nip05 {
                 NIP05Badge(nip05: nip05, pubkey: pubkey, contacts: damus_state.contacts, show_domain: false, clickable: false)
             }
-             */
             
-             
-            if let frend = friend_type {
+            if current_nip05 == nil, let frend = friend_type {
                 FriendIcon(friend: frend)
             }
             

--- a/damus/Views/Profile/ProfileName.swift
+++ b/damus/Views/Profile/ProfileName.swift
@@ -92,12 +92,10 @@ struct ProfileName: View {
             Text(verbatim: "\(prefix)\(name_choice)")
                 .font(.body)
                 .fontWeight(prefix == "@" ? .none : .bold)
-            /*
             if let nip05 = current_nip05 {
                 NIP05Badge(nip05: nip05, pubkey: pubkey, contacts: damus_state.contacts, show_domain: show_nip5_domain, clickable: true)
             }
-             */
-            if let friend = friend_type {
+            if let friend = friend_type, current_nip05 == nil {
                 FriendIcon(friend: friend)
             }
             if onlyzapper {

--- a/damus/Views/SelectWalletView.swift
+++ b/damus/Views/SelectWalletView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct SelectWalletView: View {
     let default_wallet: Wallet
-    @Binding var showingSelectWallet: Bool
+    @Binding var active_sheet: Sheets?
     let our_pubkey: String
     let invoice: String
     @State var invoice_copied: Bool = false
@@ -59,7 +59,7 @@ struct SelectWalletView: View {
                     }.padding(.vertical, 2.5)
                 }
             }.navigationBarTitle(Text("Pay the Lightning invoice", comment: "Navigation bar title for view to pay Lightning invoice."), displayMode: .inline).navigationBarItems(trailing: Button(action: {
-                self.showingSelectWallet = false
+                self.active_sheet = nil
             }) {
                 Text("Done", comment: "Button to dismiss wallet selection view for paying Lightning invoice.").bold()
             })
@@ -68,9 +68,9 @@ struct SelectWalletView: View {
 }
 
 struct SelectWalletView_Previews: PreviewProvider {
-    @State static var show: Bool = true
+    @State static var active_sheet: Sheets? = nil
     
     static var previews: some View {
-        SelectWalletView(default_wallet: .lnlink, showingSelectWallet: $show, our_pubkey: "", invoice: "")
+        SelectWalletView(default_wallet: .lnlink, active_sheet: $active_sheet, our_pubkey: "", invoice: "")
     }
 }

--- a/damus/Views/ThreadView.swift
+++ b/damus/Views/ThreadView.swift
@@ -11,16 +11,7 @@ struct ThreadView: View {
     let state: DamusState
     
     @ObservedObject var thread: ThreadModel
-    @ObservedObject var zaps: ZapsDataModel
-    
     @Environment(\.dismiss) var dismiss
-    
-    init(state: DamusState, thread: ThreadModel) {
-        self.state = state
-        self._thread = ObservedObject(wrappedValue: thread)
-        let zaps = state.events.get_cache_data(thread.event.id).zaps_model
-        self._zaps = ObservedObject(wrappedValue: zaps)
-    }
     
     var parent_events: [NostrEvent] {
         state.events.parent_events(event: thread.event)
@@ -31,27 +22,25 @@ struct ThreadView: View {
     }
     
     var body: some View {
-        let top_zap = get_top_zap(events: state.events, evid: thread.event.id)
+        //let top_zap = get_top_zap(events: state.events, evid: thread.event.id)
         ScrollViewReader { reader in
             ScrollView {
                 LazyVStack {
                     // MARK: - Parents events view
                     ForEach(parent_events, id: \.id) { parent_event in
-                        if top_zap?.event?.id != parent_event.id {
                             
-                            MutedEventView(damus_state: state,
-                                           event: parent_event,
-                                           selected: false)
-                            .padding(.horizontal)
-                            .onTapGesture {
-                                thread.set_active_event(parent_event)
-                                scroll_to_event(scroller: reader, id: parent_event.id, delay: 0.1, animate: false)
-                            }
-                            
-                            Divider()
-                                .padding(.top, 4)
-                                .padding(.leading, 25 * 2)
+                        MutedEventView(damus_state: state,
+                                       event: parent_event,
+                                       selected: false)
+                        .padding(.horizontal)
+                        .onTapGesture {
+                            thread.set_active_event(parent_event)
+                            scroll_to_event(scroller: reader, id: parent_event.id, delay: 0.1, animate: false)
                         }
+                        
+                        Divider()
+                            .padding(.top, 4)
+                            .padding(.leading, 25 * 2)
                         
                     }.background(GeometryReader { geometry in
                         // get the height and width of the EventView view
@@ -73,27 +62,27 @@ struct ThreadView: View {
                     )
                     .id(self.thread.event.id)
                     
+                    /*
                     if let top_zap {
                         ZapEvent(damus: state, zap: top_zap, is_top_zap: true)
                             .padding(.horizontal)
                     }
+                     */
                     
                     ForEach(child_events, id: \.id) { child_event in
-                        if top_zap?.event?.id != child_event.id {
-                            MutedEventView(
-                                damus_state: state,
-                                event: child_event,
-                                selected: false
-                            )
-                            .padding(.horizontal)
-                            .onTapGesture {
-                                thread.set_active_event(child_event)
-                                scroll_to_event(scroller: reader, id: child_event.id, delay: 0.1, animate: false)
-                            }
-                            
-                            Divider()
-                                .padding([.top], 4)
+                        MutedEventView(
+                            damus_state: state,
+                            event: child_event,
+                            selected: false
+                        )
+                        .padding(.horizontal)
+                        .onTapGesture {
+                            thread.set_active_event(child_event)
+                            scroll_to_event(scroller: reader, id: child_event.id, delay: 0.1, animate: false)
                         }
+                        
+                        Divider()
+                            .padding([.top], 4)
                     }
                 }
             }.navigationBarTitle(NSLocalizedString("Thread", comment: "Navigation bar title for note thread."))

--- a/damus/Views/Wallet/WalletView.swift
+++ b/damus/Views/Wallet/WalletView.swift
@@ -20,9 +20,11 @@ struct WalletView: View {
     
     func MainWalletView(nwc: WalletConnectURL) -> some View {
         VStack {
-            SupportDamus
-            
-            Spacer()
+            if !damus_state.settings.nozaps {
+                SupportDamus
+                
+                Spacer()
+            }
             
             Text(verbatim: nwc.relay.id)
             

--- a/damus/Views/Zaps/CustomizeZapView.swift
+++ b/damus/Views/Zaps/CustomizeZapView.swift
@@ -234,7 +234,7 @@ struct CustomizeZapView: View {
             ZapTypeButton()
                 .padding(.top, 50)
             
-            Spacer()
+            ZapUserView(state: state, pubkey: target.pubkey)
 
             CustomZapTextField
             

--- a/damus/Views/Zaps/CustomizeZapView.swift
+++ b/damus/Views/Zaps/CustomizeZapView.swift
@@ -168,14 +168,14 @@ struct CustomizeZapView: View {
             if model.zapping {
                 Text("Zapping...", comment: "Text to indicate that the app is in the process of sending a zap.")
             } else {
-                Button(NSLocalizedString("Zap", comment: "Button to send a zap.")) {
+                Button(NSLocalizedString("Zap User", comment: "Button to send a zap.")) {
                     let amount = model.custom_amount_sats
                     send_zap(damus_state: state, target: target, lnurl: lnurl, is_custom: true, comment: model.comment, amount_sats: amount, zap_type: model.zap_type)
                     model.zapping = true
                 }
                 .disabled(model.custom_amount_sats == 0 || model.custom_amount.isEmpty)
                 .font(.system(size: 28, weight: .bold))
-                .frame(width: 130, height: 50)
+                .frame(width: 180, height: 50)
                 .foregroundColor(.white)
                 .background(LINEAR_GRADIENT)
                 .opacity(model.custom_amount_sats == 0 || model.custom_amount.isEmpty ? 0.5 : 1.0)
@@ -231,20 +231,24 @@ struct CustomizeZapView: View {
     
     var body: some View {
         VStack(alignment: .center, spacing: 20) {
-            ZapTypeButton()
-                .padding(.top, 50)
-            
-            ZapUserView(state: state, pubkey: target.pubkey)
+            ScrollView {
+                HStack(alignment: .center) {
+                    UserView(damus_state: state, pubkey: target.pubkey)
+                    
+                    ZapTypeButton()
+                }
+                .padding([.horizontal, .top])
 
-            CustomZapTextField
-            
-            AmountPicker
-            
-            ZapReply
-            
-            ZapButton
-            
-            Spacer()
+                CustomZapTextField
+                
+                AmountPicker
+                
+                ZapReply
+                
+                ZapButton
+                
+                Spacer()
+            }
         }
         .sheet(isPresented: $model.show_zap_types) {
             if #available(iOS 16.0, *) {

--- a/damus/Views/Zaps/CustomizeZapView.swift
+++ b/damus/Views/Zaps/CustomizeZapView.swift
@@ -216,12 +216,11 @@ struct CustomizeZapView: View {
         case .got_zap_invoice(let inv):
             if state.settings.show_wallet_selector {
                 model.invoice = inv
-                model.showing_wallet_selector = true
+                present_sheet(.select_wallet(invoice: inv))
             } else {
                 end_editing()
                 let wallet = state.settings.default_wallet.model
                 open_with_wallet(wallet: wallet, invoice: inv)
-                model.showing_wallet_selector = false
                 dismiss()
             }
         case .sent_from_nwc:
@@ -258,9 +257,6 @@ struct CustomizeZapView: View {
             } else {
                 ZapPicker
             }
-        }
-        .sheet(isPresented: $model.showing_wallet_selector) {
-            SelectWalletView(default_wallet: state.settings.default_wallet, showingSelectWallet: $model.showing_wallet_selector, our_pubkey: state.pubkey, invoice: model.invoice)
         }
         .onAppear {
             model.set_defaults(settings: state.settings)

--- a/damus/Views/Zaps/ZapUserView.swift
+++ b/damus/Views/Zaps/ZapUserView.swift
@@ -14,7 +14,7 @@ struct ZapUserView: View {
     var body: some View {
         HStack(alignment: .center) {
             Text("Zap")
-                .font(.largeTitle)
+                .font(.title2)
             
             UserView(damus_state: state, pubkey: pubkey, spacer: false)
         }

--- a/damusTests/EventGroupViewTests.swift
+++ b/damusTests/EventGroupViewTests.swift
@@ -26,16 +26,17 @@ final class EventGroupViewTests: XCTestCase {
         let repost1 = NostrEvent(id: "", content: encodedPost, pubkey: "pk1", kind: NostrKind.boost.rawValue, tags: [], createdAt: 1)
         let repost2 = NostrEvent(id: "", content: encodedPost, pubkey: "pk2", kind: NostrKind.boost.rawValue, tags: [], createdAt: 1)
 
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_event, locale: enUsLocale), "??")
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_event, locale: enUsLocale), "pk1:pk1 reposted a note you were tagged in")
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_event, locale: enUsLocale), "pk1:pk1 and pk2:pk2 reposted a note you were tagged in")
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost2])), ev: test_event, locale: enUsLocale), "pk1:pk1 and 2 others reposted a note you were tagged in")
+        let nozaps = true
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_event, nozaps: nozaps, locale: enUsLocale), "??")
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_event, nozaps: nozaps, locale: enUsLocale), "pk1:pk1 reposted a note you were tagged in")
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_event, nozaps: nozaps, locale: enUsLocale), "pk1:pk1 and pk2:pk2 reposted a note you were tagged in")
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost2])), ev: test_event, nozaps: nozaps, locale: enUsLocale), "pk1:pk1 and 2 others reposted a note you were tagged in")
 
         Bundle.main.localizations.map { Locale(identifier: $0) }.forEach {
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_event, locale: $0), "??")
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_event, locale: $0))
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_event, locale: $0))
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost2])), ev: test_event, locale: $0))
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_event, nozaps: nozaps, locale: $0), "??")
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_event, nozaps: nozaps, locale: $0))
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_event, nozaps: nozaps, locale: $0))
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost2])), ev: test_event, nozaps: nozaps, locale: $0))
         }
     }
 

--- a/damusTests/RequestTests.swift
+++ b/damusTests/RequestTests.swift
@@ -17,6 +17,7 @@ final class RequestTests: XCTestCase {
         XCTAssertEqual(result, expectedResult)
     }
     
+    /* FIXME: these tests depend on order of json fields which is undefined
     func testMakePushEvent() {
         let now = Int64(Date().timeIntervalSince1970)
         let event = NostrEvent(id: "59c1cf11a3e9e128c6fd5402f41e8ae0c0c7fbab570203d7410518be68c3115f",
@@ -36,4 +37,5 @@ final class RequestTests: XCTestCase {
         let expectedResult = "[\"REQ\",\"31C737B7-C8F9-41DD-8707-325974F279A4\",{\"kinds\":[3],\"authors\":[\"d9fa34214aa9d151c4f4db843e9c2af4f246bab4205137731f91bcfa44d66a62\"],\"limit\":1}]"
         XCTAssertEqual(result, expectedResult)
     }
+     */
 }


### PR DESCRIPTION
This PR introduces a new non-user-configurable nozaps setting which disables note zapping. We can re-enable this setting in macOS desktop builds.