### PR TITLE
Fix taps on mentions in note drafts to not redirect to other Nostr clients

### DIFF
--- a/damus/Views/Posting/UserSearch.swift
+++ b/damus/Views/Posting/UserSearch.swift
@@ -63,7 +63,8 @@ struct UserSearch: View {
 
         let tagAttributedString = NSMutableAttributedString(string: tagString,
                                    attributes: [NSAttributedString.Key.font: UIFont.systemFont(ofSize: 18.0),
-                                                NSAttributedString.Key.link: "nostr:\(pk)"])
+                                                // Add damus: URI so that taps within the post creation view redirect internally within Damus instead of redirecting to a different Nostr client. The damus: prefix will be stripped out prior to sending the note to relays.
+                                                NSAttributedString.Key.link: "damus:nostr:\(pk)"])
         tagAttributedString.removeAttribute(.link, range: NSRange(location: tagAttributedString.length - 2, length: 2))
         tagAttributedString.addAttributes([NSAttributedString.Key.foregroundColor: UIColor.label], range: NSRange(location: tagAttributedString.length - 2, length: 2))
         


### PR DESCRIPTION
Changelog-Fixed: Fix taps on mentions in note drafts to not redirect to other Nostr clients

Fixes https://github.com/damus-io/damus/issues/1279