### PR TITLE
fix crash related to VideoPlayer and CMTime

### DIFF
--- a/damus/Views/Video/VideoPlayer.swift
+++ b/damus/Views/Video/VideoPlayer.swift
@@ -48,7 +48,8 @@ public class VideoPlayerModel: ObservableObject {
     @Published var has_audio: Bool? = nil
     @Published var contentMode: UIView.ContentMode = .scaleAspectFill
     
-    var time: CMTime = CMTime()
+    fileprivate var time: CMTime?
+    
     var handlers: [VideoHandler] = []
     
     init() {
@@ -262,8 +263,9 @@ extension VideoPlayer: UIViewRepresentable {
         uiView.isMuted = model.muted
         uiView.isAutoReplay = model.autoReplay
         
-        if let observerTime = context.coordinator.observerTime, model.time != observerTime {
-            uiView.seek(to: model.time, toleranceBefore: model.time, toleranceAfter: model.time, completion: { _ in })
+        if let observerTime = context.coordinator.observerTime, let modelTime = model.time,
+           modelTime != observerTime && modelTime.isValid && modelTime.isNumeric {
+            uiView.seek(to: modelTime, completion: { _ in })
         }
     }
     


### PR DESCRIPTION
Changelog-Fixed: fix crash related to VideoPlayer and CMTime

This PR fixes a crash related to VideoPlayer and CMTime.

The `VideoPlayerModel`s `time` property was initialized with an invalid `CMTime` (e.g. `CMTime()`), and then at some point the `VideoPlayer` tried to seek to that time.

The fix is to make that `CMTime` optional and to check if the time is valid using Apple's framework's built-in checks before seeking.

Another minor issue was that when seeking the `toleranceBefore` and `toleranceAfter` values were set to the same `CMTime` as the time being seeked to. This doesn't add much and isn't necessary, as we can call `AVPlayer.seek(to:completion:)` instead and not bother with the tolerances.