### PR TITLE
Deduplicate pubkeys in event group notifications and group anonymous zaps into one pubkey

### DIFF
--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -1076,7 +1076,7 @@ func zap_notification_title(_ zap: Zap) -> String {
 
 func zap_notification_body(profiles: Profiles, zap: Zap, locale: Locale = Locale.current) -> String {
     let src = zap.request.ev
-    let pk = zap.is_anon ? "anon" : src.pubkey
+    let pk = zap.is_anon ? ANON_PUBKEY : src.pubkey
     let profile = profiles.lookup(id: pk)
     let sats = NSNumber(value: (Double(zap.invoice.amount) / 1000.0))
     let formattedSats = format_msats_abbrev(zap.invoice.amount)

--- a/damus/Util/DisplayName.swift
+++ b/damus/Util/DisplayName.swift
@@ -38,7 +38,7 @@ enum DisplayName {
 
 
 func parse_display_name(profile: Profile?, pubkey: String) -> DisplayName {
-    if pubkey == "anon" {
+    if pubkey == ANON_PUBKEY {
         return .one(NSLocalizedString("Anonymous", comment: "Placeholder display name of anonymous user."))
     }
     

--- a/damus/Util/Keys.swift
+++ b/damus/Util/Keys.swift
@@ -9,6 +9,7 @@ import Foundation
 import secp256k1
 
 let PUBKEY_HRP = "npub"
+let ANON_PUBKEY = "anon"
 
 struct FullKeypair: Equatable {
     let pubkey: String

--- a/damus/Views/Events/TextEvent.swift
+++ b/damus/Views/Events/TextEvent.swift
@@ -132,7 +132,7 @@ struct TextEvent: View {
     
     func ProfileName(is_anon: Bool) -> some View {
         let profile = damus.profiles.lookup(id: pubkey)
-        let pk = is_anon ? "anon" : pubkey
+        let pk = is_anon ? ANON_PUBKEY : pubkey
         return EventProfileName(pubkey: pk, profile: profile, damus: damus, size: .normal)
     }
     

--- a/damus/Views/Profile/MaybeAnonPfpView.swift
+++ b/damus/Views/Profile/MaybeAnonPfpView.swift
@@ -38,6 +38,6 @@ struct MaybeAnonPfpView: View {
 
 struct MaybeAnonPfpView_Previews: PreviewProvider {
     static var previews: some View {
-        MaybeAnonPfpView(state: test_damus_state(), is_anon: true, pubkey: "anon", size: PFP_SIZE)
+        MaybeAnonPfpView(state: test_damus_state(), is_anon: true, pubkey: ANON_PUBKEY, size: PFP_SIZE)
     }
 }

--- a/damus/Views/Zaps/ZapUserView.swift
+++ b/damus/Views/Zaps/ZapUserView.swift
@@ -23,6 +23,6 @@ struct ZapUserView: View {
 
 struct ZapUserView_Previews: PreviewProvider {
     static var previews: some View {
-        ZapUserView(state: test_damus_state(), pubkey: "anon")
+        ZapUserView(state: test_damus_state(), pubkey: ANON_PUBKEY)
     }
 }

--- a/damusTests/EventGroupViewTests.swift
+++ b/damusTests/EventGroupViewTests.swift
@@ -18,6 +18,27 @@ final class EventGroupViewTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    func testEventAuthorName() {
+        let damusState = test_damus_state()
+        XCTAssertEqual(event_author_name(profiles: damusState.profiles, pubkey: "pk1"), "pk1:pk1")
+        XCTAssertEqual(event_author_name(profiles: damusState.profiles, pubkey: "pk2"), "pk2:pk2")
+        XCTAssertEqual(event_author_name(profiles: damusState.profiles, pubkey: "anon"), "Anonymous")
+    }
+
+    func testEventGroupUniquePubkeys() {
+        let damusState = test_damus_state()
+
+        let encodedPost = "{\"id\": \"8ba545ab96959fe0ce7db31bc10f3ac3aa5353bc4428dbf1e56a7be7062516db\",\"pubkey\": \"7e27509ccf1e297e1df164912a43406218f8bd80129424c3ef798ca3ef5c8444\",\"created_at\": 1677013417,\"kind\": 1,\"tags\": [],\"content\": \"hello\",\"sig\": \"93684f15eddf11f42afbdd81828ee9fc35350344d8650c78909099d776e9ad8d959cd5c4bff7045be3b0b255144add43d0feef97940794a1bc9c309791bebe4a\"}"
+        let repost1 = NostrEvent(id: "", content: encodedPost, pubkey: "pk1", kind: NostrKind.boost.rawValue, tags: [], createdAt: 1)
+        let repost2 = NostrEvent(id: "", content: encodedPost, pubkey: "pk2", kind: NostrKind.boost.rawValue, tags: [], createdAt: 1)
+        let repost3 = NostrEvent(id: "", content: encodedPost, pubkey: "pk3", kind: NostrKind.boost.rawValue, tags: [], createdAt: 1)
+
+        XCTAssertEqual(event_group_unique_pubkeys(profiles: damusState.profiles, group: .repost(EventGroup(events: []))), [])
+        XCTAssertEqual(event_group_unique_pubkeys(profiles: damusState.profiles, group: .repost(EventGroup(events: [repost1]))), ["pk1"])
+        XCTAssertEqual(event_group_unique_pubkeys(profiles: damusState.profiles, group: .repost(EventGroup(events: [repost1, repost2]))), ["pk1", "pk2"])
+        XCTAssertEqual(event_group_unique_pubkeys(profiles: damusState.profiles, group: .repost(EventGroup(events: [repost1, repost2, repost3]))), ["pk1", "pk2", "pk3"])
+    }
+
     func testReactingToText() throws {
         let enUsLocale = Locale(identifier: "en-US")
         let damusState = test_damus_state()
@@ -25,18 +46,19 @@ final class EventGroupViewTests: XCTestCase {
         let encodedPost = "{\"id\": \"8ba545ab96959fe0ce7db31bc10f3ac3aa5353bc4428dbf1e56a7be7062516db\",\"pubkey\": \"7e27509ccf1e297e1df164912a43406218f8bd80129424c3ef798ca3ef5c8444\",\"created_at\": 1677013417,\"kind\": 1,\"tags\": [],\"content\": \"hello\",\"sig\": \"93684f15eddf11f42afbdd81828ee9fc35350344d8650c78909099d776e9ad8d959cd5c4bff7045be3b0b255144add43d0feef97940794a1bc9c309791bebe4a\"}"
         let repost1 = NostrEvent(id: "", content: encodedPost, pubkey: "pk1", kind: NostrKind.boost.rawValue, tags: [], createdAt: 1)
         let repost2 = NostrEvent(id: "", content: encodedPost, pubkey: "pk2", kind: NostrKind.boost.rawValue, tags: [], createdAt: 1)
+        let repost3 = NostrEvent(id: "", content: encodedPost, pubkey: "pk3", kind: NostrKind.boost.rawValue, tags: [], createdAt: 1)
 
         let nozaps = true
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_event, nozaps: nozaps, locale: enUsLocale), "??")
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_event, nozaps: nozaps, locale: enUsLocale), "pk1:pk1 reposted a note you were tagged in")
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_event, nozaps: nozaps, locale: enUsLocale), "pk1:pk1 and pk2:pk2 reposted a note you were tagged in")
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost2])), ev: test_event, nozaps: nozaps, locale: enUsLocale), "pk1:pk1 and 2 others reposted a note you were tagged in")
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_event, nozaps: nozaps, pubkeys: [], locale: enUsLocale), "??")
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_event, nozaps: nozaps, pubkeys: ["pk1"], locale: enUsLocale), "pk1:pk1 reposted a note you were tagged in")
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_event, nozaps: nozaps, pubkeys: ["pk1", "pk2"], locale: enUsLocale), "pk1:pk1 and pk2:pk2 reposted a note you were tagged in")
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost2])), ev: test_event, nozaps: nozaps, pubkeys: ["pk1", "pk2", "pk3"], locale: enUsLocale), "pk1:pk1 and 2 others reposted a note you were tagged in")
 
         Bundle.main.localizations.map { Locale(identifier: $0) }.forEach {
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_event, nozaps: nozaps, locale: $0), "??")
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_event, nozaps: nozaps, locale: $0))
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_event, nozaps: nozaps, locale: $0))
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost2])), ev: test_event, nozaps: nozaps, locale: $0))
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_event, nozaps: nozaps, pubkeys: [], locale: $0), "??")
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_event, nozaps: nozaps, pubkeys: ["pk1"], locale: $0))
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_event, nozaps: nozaps, pubkeys: ["pk1", "pk2"], locale: $0))
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost3])), ev: test_event, nozaps: nozaps, pubkeys: ["pk1", "pk2", "pk3"], locale: $0))
         }
     }
 


### PR DESCRIPTION
Changelog-Fixed: Deduplicate pubkeys in event group notifications and group anonymous zaps into one pubkey

| Before | After |
| ------  | ----- |
| ![Simulator Screenshot - iPhone 14 Pro - 2023-06-25 at 23 37 05 Medium](https://github.com/damus-io/damus/assets/963907/7d4decdc-67b6-4e05-8199-6d51f23b16bd) | ![Simulator Screenshot - iPhone 14 Pro - 2023-06-25 at 23 35 20 Medium](https://github.com/damus-io/damus/assets/963907/6850f6b0-2502-4d51-89fe-eeffa3729016) |