### PR TITLE
Update to PostView.swift to fix broken nostr link

### DIFF
--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -195,7 +195,8 @@ struct PostView: View {
         }
         
         let profile = damus_state.profiles.lookup(id: pubkey)
-        return user_tag_attr_string(profile: profile, pubkey: pubkey)
+        let bech32_pubkey = bech32_pubkey(pubkey) ?? ""
+        return user_tag_attr_string(profile: profile, pubkey: bech32_pubkey)
     }
     
     func clear_draft() {


### PR DESCRIPTION
Fix for second part of issue #1352 where if you submit a reply from the + on a profile, it uses the hex nostr url rather than the bech32 version. When typing the @ manually it uses the bech32 so updated to mirror this.