### PR TITLE
Update CustomizeZapView.swift; zap ~~user~~

### DIFF
--- a/damus/Views/Zaps/CustomizeZapView.swift
+++ b/damus/Views/Zaps/CustomizeZapView.swift
@@ -168,7 +168,7 @@ struct CustomizeZapView: View {
             if model.zapping {
                 Text("Zapping...", comment: "Text to indicate that the app is in the process of sending a zap.")
             } else {
-                Button(NSLocalizedString("Zap User", comment: "Button to send a zap.")) {
+                Button(NSLocalizedString("Zap", comment: "Button to send a zap.")) {
                     let amount = model.custom_amount_sats
                     send_zap(damus_state: state, target: target, lnurl: lnurl, is_custom: true, comment: model.comment, amount_sats: amount, zap_type: model.zap_type)
                     model.zapping = true


### PR DESCRIPTION
Change the text "zap user" back to "zap". If "nozap" mode is true, this page doesn't show at all now. with "nozap" mode false it does functions as a note zap, so the text now reflects that.