### PR TITLE
Fixed nav bar color on login, eula, and account creation

### DIFF
--- a/damus/Views/CreateAccountView.swift
+++ b/damus/Views/CreateAccountView.swift
@@ -104,10 +104,11 @@ struct LoginPrompt: View {
 }
 
 struct BackNav: View {
+    @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
     var body: some View {
         Image("chevron-left")
-            .foregroundColor(.white)
+            .foregroundColor(colorScheme == .light ? DamusColors.black : DamusColors.white)
         .onTapGesture {
             self.dismiss()
         }

--- a/damus/Views/CreateAccountView.swift
+++ b/damus/Views/CreateAccountView.swift
@@ -104,11 +104,10 @@ struct LoginPrompt: View {
 }
 
 struct BackNav: View {
-    @Environment(\.colorScheme) var colorScheme
     @Environment(\.dismiss) var dismiss
     var body: some View {
         Image("chevron-left")
-            .foregroundColor(colorScheme == .light ? DamusColors.black : DamusColors.white)
+            .foregroundColor(DamusColors.adaptableBlack)
         .onTapGesture {
             self.dismiss()
         }


### PR DESCRIPTION
Previously the Navigate back arrow was not visible in the entry views due to same color

<img src="https://github.com/damus-io/damus/assets/14004132/6dde8060-4b84-4ee7-b671-fcfe64edd09e" width="400"> 
<img src="https://github.com/damus-io/damus/assets/14004132/67c0eb3b-7d5f-4959-97da-c6fb4e59d61d" width="400"> 
<img src="https://github.com/damus-io/damus/assets/14004132/94791b10-beda-4119-af63-dc9e17937271" width="400"> 
<img src="https://github.com/damus-io/damus/assets/14004132/fff1b519-476e-43b4-a732-2d3cbc53bcb9" width="400"> 
<img src="https://github.com/damus-io/damus/assets/14004132/0991a296-0493-44dd-9457-14d03374bdc2" width="400"> 
<img src="https://github.com/damus-io/damus/assets/14004132/65bb145c-4610-4bbb-97b2-f1cbf53a3d6e" width="400"> 
