### PR TITLE
Fix for broken hashtags on first load of a thread

### DIFF
--- a/damus/Views/ThreadView.swift
+++ b/damus/Views/ThreadView.swift
@@ -58,7 +58,7 @@ struct ThreadView: View {
                     MutedEventView(
                         damus_state: state,
                         event: self.thread.event,
-                        selected: true
+                        selected: false
                     )
                     .id(self.thread.event.id)
                     


### PR DESCRIPTION
Fixes: Hashtags don’t work from search result with replies #1362 