### PR TITLE
Center and Pad buttons in EULA

### DIFF
--- a/damus/Views/EULAView.swift
+++ b/damus/Views/EULAView.swift
@@ -68,14 +68,14 @@ struct EULAView: View {
                 Markdown(eula)
                     .padding()
             }
-            .padding(EdgeInsets(top: 20, leading: 10, bottom: 50, trailing: 10))
-            
+            .padding(EdgeInsets(top: 20, leading: 10, bottom: 60, trailing: 10))
+
             VStack {
                 Spacer()
-                
+
                 HStack {
                     Spacer()
-                    
+
                     Button(action: {
                         dismiss()
                     }) {
@@ -91,7 +91,9 @@ struct EULAView: View {
                                 .fill(DamusColors.darkGrey, strokeBorder: DamusColors.mediumGrey, lineWidth: 1)
                         }
                     }
-                    
+
+                    Spacer()
+
                     Button(action: {
                         nav.push(route: Route.Login)
                     }) {
@@ -102,9 +104,11 @@ struct EULAView: View {
                         .frame(minWidth: 75, maxHeight: 12, alignment: .center)
                     }
                     .buttonStyle(GradientButtonStyle())
+
+                    Spacer()
                 }
-                .padding(.trailing, 30)
             }
+            .padding(.bottom, 5)
         }
         .background(
             Image("eula-bg")


### PR DESCRIPTION
EULA buttons have no padding on iPhone SE. I am not exactly sure what the intended layout is, but I added some padding and centered simply because I thought it looked cleaner.

![Screenshot 2023-07-24 at 3 35 53 PM](https://github.com/damus-io/damus/assets/5034446/1452f0ef-b226-4bf7-8f11-2ce987402419) ![Screenshot 2023-07-24 at 3 36 14 PM](https://github.com/damus-io/damus/assets/5034446/30f95e04-67d8-4cf2-a91e-c51f1e69988f)
