### PR TITLE
FIX: Profile View pushed in the navigation infinitely #104

### DIFF
--- a/damus/Views/Events/EventShell.swift
+++ b/damus/Views/Events/EventShell.swift
@@ -52,21 +52,16 @@ struct EventShell<Content: View>: View {
     }
 
     func Pfp(is_anon: Bool) -> some View {
-        // Prevent navigation from pfp if on profile
-        var preventNavLink = false
+        var profilePubKey: String?
         
         // Look at nav stack to determine if last (current) view is a profile, via its route,
         // then compare pubKeys
         if let route = state.nav.path.last {
             switch route {
-            case .ProfileByKey(let profilePubKey):
-                if profilePubKey == pubkey {
-                    preventNavLink = true
-                }
+            case .ProfileByKey(let profileKey):
+                profilePubKey = profileKey
             case .Profile(let profileModel, _):
-                if profileModel.pubkey == pubkey {
-                    preventNavLink = true
-                }
+                profilePubKey = profileModel.pubkey
             default:
                 break
             }
@@ -77,7 +72,7 @@ struct EventShell<Content: View>: View {
             is_anon: is_anon,
             pubkey: pubkey,
             size: options.contains(.small_pfp) ? eventview_pfp_size(.small) : PFP_SIZE,
-            preventNavLink: preventNavLink
+            preventNavLink: profilePubKey == pubkey
         )
     }
 

--- a/damus/Views/Events/EventShell.swift
+++ b/damus/Views/Events/EventShell.swift
@@ -52,7 +52,33 @@ struct EventShell<Content: View>: View {
     }
 
     func Pfp(is_anon: Bool) -> some View {
-        return MaybeAnonPfpView(state: state, is_anon: is_anon, pubkey: pubkey, size: options.contains(.small_pfp) ? eventview_pfp_size(.small) : PFP_SIZE )
+        // Prevent navigation from pfp if on profile
+        var preventNavLink = false
+        
+        // Look at nav stack to determine if last (current) view is a profile, via its route,
+        // then compare pubKeys
+        if let route = state.nav.path.last {
+            switch route {
+            case .ProfileByKey(let profilePubKey):
+                if profilePubKey == pubkey {
+                    preventNavLink = true
+                }
+            case .Profile(let profileModel, _):
+                if profileModel.pubkey == pubkey {
+                    preventNavLink = true
+                }
+            default:
+                break
+            }
+        }
+
+        return MaybeAnonPfpView(
+            state: state,
+            is_anon: is_anon,
+            pubkey: pubkey,
+            size: options.contains(.small_pfp) ? eventview_pfp_size(.small) : PFP_SIZE,
+            preventNavLink: preventNavLink
+        )
     }
 
     var Threaded: some View {

--- a/damus/Views/Profile/MaybeAnonPfpView.swift
+++ b/damus/Views/Profile/MaybeAnonPfpView.swift
@@ -12,12 +12,15 @@ struct MaybeAnonPfpView: View {
     let is_anon: Bool
     let pubkey: String
     let size: CGFloat
+    /// Disallows navigation upon pfp tap
+    let preventNavLink: Bool
     
-    init(state: DamusState, is_anon: Bool, pubkey: String, size: CGFloat) {
+    init(state: DamusState, is_anon: Bool, pubkey: String, size: CGFloat, preventNavLink: Bool = false) {
         self.state = state
         self.is_anon = is_anon
         self.pubkey = pubkey
         self.size = size
+        self.preventNavLink = preventNavLink
     }
     
     var body: some View {
@@ -28,8 +31,12 @@ struct MaybeAnonPfpView: View {
                     .font(.largeTitle)
                     .frame(width: size, height: size)
             } else {
-                NavigationLink(value: Route.ProfileByKey(pubkey: pubkey)) {
+                if preventNavLink {
                     ProfilePicView(pubkey: pubkey, size: size, highlight: .none, profiles: state.profiles, disable_animation: state.settings.disable_animation)
+                } else {
+                    NavigationLink(value: Route.ProfileByKey(pubkey: pubkey)) {
+                        ProfilePicView(pubkey: pubkey, size: size, highlight: .none, profiles: state.profiles, disable_animation: state.settings.disable_animation)
+                    }
                 }
             }
         }


### PR DESCRIPTION
This fix adds a check, when creating `EventShell`s, to look at the last path of the NavigationCoordinator, in order to determine if the last view (current view) is a profile view, via its `Route`. If it is, and the public key of the `EventShell` is the same as the profile, then the pfp will not be wrapped in a nav link, preventing the ability to push the same profile infinitely.