### PR TITLE
ndb prep: switch to Pubkey/Privkey/Id aliases

### DIFF
--- a/damus.xcodeproj/xcshareddata/xcschemes/damus.xcscheme
+++ b/damus.xcodeproj/xcshareddata/xcschemes/damus.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/damus/Components/ImageCarousel.swift
+++ b/damus/Components/ImageCarousel.swift
@@ -57,7 +57,7 @@ enum ImageShape {
 struct ImageCarousel: View {
     var urls: [MediaUrl]
     
-    let evid: String
+    let evid: NoteId
     
     let state: DamusState
     
@@ -72,7 +72,7 @@ struct ImageCarousel: View {
     @State private var selectedIndex = 0
     @State private var video_size: CGSize? = nil
     
-    init(state: DamusState, evid: String, urls: [MediaUrl]) {
+    init(state: DamusState, evid: NoteId, urls: [MediaUrl]) {
         _open_sheet = State(initialValue: false)
         _current_url = State(initialValue: nil)
         let media_model = state.events.get_cache_data(evid).media_metadata_model

--- a/damus/Components/ImageCarousel.swift
+++ b/damus/Components/ImageCarousel.swift
@@ -289,7 +289,7 @@ public struct ImageFill {
 struct ImageCarousel_Previews: PreviewProvider {
     static var previews: some View {
         let url: MediaUrl = .image(URL(string: "https://jb55.com/red-me.jpg")!)
-        ImageCarousel(state: test_damus_state(), evid: "evid", urls: [url, url])
+        ImageCarousel(state: test_damus_state(), evid: test_note.id, urls: [url, url])
     }
 }
 

--- a/damus/Components/InvoiceView.swift
+++ b/damus/Components/InvoiceView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct InvoiceView: View {
     @Environment(\.colorScheme) var colorScheme
-    let our_pubkey: String
+    let our_pubkey: Pubkey
     let invoice: Invoice
     @State var showing_select_wallet: Bool = false
     @State var copied = false
@@ -108,7 +108,7 @@ let test_invoice = Invoice(description: .description("this is a description"), a
 
 struct InvoiceView_Previews: PreviewProvider {
     static var previews: some View {
-        InvoiceView(our_pubkey: "", invoice: test_invoice, settings: test_damus_state().settings)
+        InvoiceView(our_pubkey: .empty, invoice: test_invoice, settings: test_damus_state().settings)
             .frame(width: 300, height: 200)
     }
 }

--- a/damus/Components/InvoicesView.swift
+++ b/damus/Components/InvoicesView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct InvoicesView: View {
-    let our_pubkey: String
+    let our_pubkey: Pubkey
     var invoices: [Invoice]
     let settings: UserSettingsStore
     
@@ -29,7 +29,7 @@ struct InvoicesView: View {
 
 struct InvoicesView_Previews: PreviewProvider {
     static var previews: some View {
-        InvoicesView(our_pubkey: "", invoices: [Invoice.init(description: .description("description"), amount: .specific(10000), string: "invstr", expiry: 100000, payment_hash: Data(), created_at: 1000000)], settings: test_damus_state().settings)
+        InvoicesView(our_pubkey: test_note.pubkey, invoices: [Invoice.init(description: .description("description"), amount: .specific(10000), string: "invstr", expiry: 100000, payment_hash: Data(), created_at: 1000000)], settings: test_damus_state().settings)
             .frame(width: 300)
     }
 }

--- a/damus/Components/NIP05Badge.swift
+++ b/damus/Components/NIP05Badge.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 struct NIP05Badge: View {
     let nip05: NIP05
-    let pubkey: String
+    let pubkey: Pubkey
     let contacts: Contacts
     let show_domain: Bool
     let profiles: Profiles
 
     @Environment(\.openURL) var openURL
     
-    init(nip05: NIP05, pubkey: String, contacts: Contacts, show_domain: Bool, profiles: Profiles) {
+    init(nip05: NIP05, pubkey: Pubkey, contacts: Contacts, show_domain: Bool, profiles: Profiles) {
         self.nip05 = nip05
         self.pubkey = pubkey
         self.contacts = contacts
@@ -91,7 +91,7 @@ extension View {
     }
 }
 
-func use_nip05_color(pubkey: String, contacts: Contacts) -> Bool {
+func use_nip05_color(pubkey: Pubkey, contacts: Contacts) -> Bool {
     return contacts.is_friend_or_self(pubkey) ? true : false
 }
 
@@ -105,7 +105,7 @@ struct NIP05Badge_Previews: PreviewProvider {
 
             NIP05Badge(nip05: NIP05(username: "jb55", host: "jb55.com"), pubkey: test_state.pubkey, contacts: test_state.contacts, show_domain: true, profiles: test_state.profiles)
 
-            NIP05Badge(nip05: NIP05(username: "jb55", host: "jb55.com"), pubkey: test_state.pubkey, contacts: Contacts(our_pubkey: "sdkfjsdf"), show_domain: true, profiles: test_state.profiles)
+            NIP05Badge(nip05: NIP05(username: "jb55", host: "jb55.com"), pubkey: test_state.pubkey, contacts: Contacts(our_pubkey: test_pubkey), show_domain: true, profiles: test_state.profiles)
         }
     }
 }

--- a/damus/Components/Reposted.swift
+++ b/damus/Components/Reposted.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct Reposted: View {
     let damus: DamusState
-    let pubkey: String
+    let pubkey: Pubkey
     let profile: Profile?
     
     var body: some View {

--- a/damus/Components/TranslateView.swift
+++ b/damus/Components/TranslateView.swift
@@ -121,7 +121,7 @@ extension View {
 struct TranslateView_Previews: PreviewProvider {
     static var previews: some View {
         let ds = test_damus_state()
-        TranslateView(damus_state: ds, event: test_event, size: .normal)
+        TranslateView(damus_state: ds, event: test_note, size: .normal)
     }
 }
 

--- a/damus/Components/TranslateView.swift
+++ b/damus/Components/TranslateView.swift
@@ -125,7 +125,7 @@ struct TranslateView_Previews: PreviewProvider {
     }
 }
 
-func translate_note(profiles: Profiles, privkey: String?, event: NostrEvent, settings: UserSettingsStore, note_lang: String) async -> TranslateStatus {
+func translate_note(profiles: Profiles, privkey: Privkey?, event: NostrEvent, settings: UserSettingsStore, note_lang: String) async -> TranslateStatus {
     
     // If the note language is different from our preferred languages, send a translation request.
     let translator = Translator(settings)

--- a/damus/Components/UserView.swift
+++ b/damus/Components/UserView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct UserViewRow: View {
     let damus_state: DamusState
-    let pubkey: String
-    
+    let pubkey: Pubkey
+
     var body: some View {
         UserView(damus_state: damus_state, pubkey: pubkey)
             .contentShape(Rectangle())
@@ -20,12 +20,12 @@ struct UserViewRow: View {
 
 struct UserView: View {
     let damus_state: DamusState
-    let pubkey: String
+    let pubkey: Pubkey
     let spacer: Bool
     
     @State var about_text: Text? = nil
     
-    init(damus_state: DamusState, pubkey: String, spacer: Bool = true) {
+    init(damus_state: DamusState, pubkey: Pubkey, spacer: Bool = true) {
         self.damus_state = damus_state
         self.pubkey = pubkey
         self.spacer = spacer

--- a/damus/Components/UserView.swift
+++ b/damus/Components/UserView.swift
@@ -56,6 +56,6 @@ struct UserView: View {
 
 struct UserView_Previews: PreviewProvider {
     static var previews: some View {
-        UserView(damus_state: test_damus_state(), pubkey: "pk")
+        UserView(damus_state: test_damus_state(), pubkey: test_note.pubkey)
     }
 }

--- a/damus/Components/ZapButton.swift
+++ b/damus/Components/ZapButton.swift
@@ -141,10 +141,10 @@ struct ZapButton: View {
 
 struct ZapButton_Previews: PreviewProvider {
     static var previews: some View {
-        let pending_zap = PendingZap(amount_msat: 1000, target: ZapTarget.note(id: "noteid", author: "author"), request: .normal(test_zap_request), type: .pub, state: .external(.init(state: .fetching_invoice)))
+        let pending_zap = PendingZap(amount_msat: 1000, target: ZapTarget.note(id: test_note.id, author: test_note.pubkey), request: .normal(test_zap_request), type: .pub, state: .external(.init(state: .fetching_invoice)))
         let zaps = ZapsDataModel([.pending(pending_zap)])
         
-        ZapButton(damus_state: test_damus_state(), target: ZapTarget.note(id: test_event.id, author: test_event.pubkey), lnurl: "lnurl", zaps: zaps)
+        ZapButton(damus_state: test_damus_state(), target: ZapTarget.note(id: test_note.id, author: test_note.pubkey), lnurl: "lnurl", zaps: zaps)
     }
 }
 

--- a/damus/Models/ActionBarModel.swift
+++ b/damus/Models/ActionBarModel.swift
@@ -40,7 +40,7 @@ class ActionBarModel: ObservableObject {
         self.our_reply = our_reply
     }
     
-    func update(damus: DamusState, evid: String) {
+    func update(damus: DamusState, evid: NoteId) {
         self.likes = damus.likes.counts[evid] ?? 0
         self.boosts = damus.boosts.counts[evid] ?? 0
         self.zaps = damus.zaps.event_counts[evid] ?? 0

--- a/damus/Models/BookmarksManager.swift
+++ b/damus/Models/BookmarksManager.swift
@@ -7,18 +7,18 @@
 
 import Foundation
 
-fileprivate func get_bookmarks_key(pubkey: String) -> String {
+fileprivate func get_bookmarks_key(pubkey: Pubkey) -> String {
     pk_setting_key(pubkey, key: "bookmarks")
 }
 
-func load_bookmarks(pubkey: String) -> [NostrEvent] {
+func load_bookmarks(pubkey: Pubkey) -> [NostrEvent] {
     let key = get_bookmarks_key(pubkey: pubkey)
     return (UserDefaults.standard.stringArray(forKey: key) ?? []).compactMap {
         event_from_json(dat: $0)
     }
 }
 
-func save_bookmarks(pubkey: String, current_value: [NostrEvent], value: [NostrEvent]) -> Bool {
+func save_bookmarks(pubkey: Pubkey, current_value: [NostrEvent], value: [NostrEvent]) -> Bool {
     let uniq_bookmarks = uniq(value)
     
     if uniq_bookmarks != current_value {
@@ -32,8 +32,8 @@ func save_bookmarks(pubkey: String, current_value: [NostrEvent], value: [NostrEv
 
 class BookmarksManager: ObservableObject {
     
-    private let pubkey: String
-    
+    private let pubkey: Pubkey
+
     private var _bookmarks: [NostrEvent]
     var bookmarks: [NostrEvent] {
         get {
@@ -47,7 +47,7 @@ class BookmarksManager: ObservableObject {
         }
     }
     
-    init(pubkey: String) {
+    init(pubkey: Pubkey) {
         self._bookmarks = load_bookmarks(pubkey: pubkey)
         self.pubkey = pubkey
     }

--- a/damus/Models/Contacts.swift
+++ b/damus/Models/Contacts.swift
@@ -9,21 +9,21 @@ import Foundation
 
 
 class Contacts {
-    private var friends: Set<String> = Set()
-    private var friend_of_friends: Set<String> = Set()
+    private var friends: Set<Pubkey> = Set()
+    private var friend_of_friends: Set<Pubkey> = Set()
     /// Tracks which friends are friends of a given pubkey.
-    private var pubkey_to_our_friends = [String : Set<String>]()
-    private var muted: Set<String> = Set()
-    
-    let our_pubkey: String
+    private var pubkey_to_our_friends = [Pubkey : Set<Pubkey>]()
+    private var muted: Set<Pubkey> = Set()
+
+    let our_pubkey: Pubkey
     var event: NostrEvent?
     var mutelist: NostrEvent?
     
-    init(our_pubkey: String) {
+    init(our_pubkey: Pubkey) {
         self.our_pubkey = our_pubkey
     }
     
-    func is_muted(_ pk: String) -> Bool {
+    func is_muted(_ pk: Pubkey) -> Bool {
         return muted.contains(pk)
     }
     
@@ -58,7 +58,7 @@ class Contacts {
         }
     }
     
-    func remove_friend(_ pubkey: String) {
+    func remove_friend(_ pubkey: Pubkey) {
         friends.remove(pubkey)
 
         pubkey_to_our_friends.forEach {
@@ -66,7 +66,7 @@ class Contacts {
         }
     }
     
-    func get_friend_list() -> Set<String> {
+    func get_friend_list() -> Set<Pubkey> {
         return friends
     }
 
@@ -75,7 +75,7 @@ class Contacts {
         return Set(ev.referenced_hashtags.map({ $0.ref_id.string() }))
     }
 
-    func add_friend_pubkey(_ pubkey: String) {
+    func add_friend_pubkey(_ pubkey: Pubkey) {
         friends.insert(pubkey)
     }
     
@@ -88,7 +88,7 @@ class Contacts {
             // Exclude themself and us.
             if contact.pubkey != our_pubkey && contact.pubkey != pk {
                 if pubkey_to_our_friends[pk] == nil {
-                    pubkey_to_our_friends[pk] = Set<String>()
+                    pubkey_to_our_friends[pk] = Set<Pubkey>()
                 }
 
                 pubkey_to_our_friends[pk]?.insert(contact.pubkey)
@@ -96,28 +96,28 @@ class Contacts {
         }
     }
     
-    func is_friend_of_friend(_ pubkey: String) -> Bool {
+    func is_friend_of_friend(_ pubkey: Pubkey) -> Bool {
         return friend_of_friends.contains(pubkey)
     }
     
-    func is_in_friendosphere(_ pubkey: String) -> Bool {
+    func is_in_friendosphere(_ pubkey: Pubkey) -> Bool {
         return friends.contains(pubkey) || friend_of_friends.contains(pubkey)
     }
 
-    func is_friend(_ pubkey: String) -> Bool {
+    func is_friend(_ pubkey: Pubkey) -> Bool {
         return friends.contains(pubkey)
     }
     
-    func is_friend_or_self(_ pubkey: String) -> Bool {
+    func is_friend_or_self(_ pubkey: Pubkey) -> Bool {
         return pubkey == our_pubkey || is_friend(pubkey)
     }
     
-    func follow_state(_ pubkey: String) -> FollowState {
+    func follow_state(_ pubkey: Pubkey) -> FollowState {
         return is_friend(pubkey) ? .follows : .unfollows
     }
 
     /// Gets the list of pubkeys of our friends who follow the given pubkey.
-    func get_friended_followers(_ pubkey: String) -> [String] {
+    func get_friended_followers(_ pubkey: Pubkey) -> [Pubkey] {
         return Array((pubkey_to_our_friends[pubkey] ?? Set()))
     }
 }

--- a/damus/Models/CreateAccountModel.swift
+++ b/damus/Models/CreateAccountModel.swift
@@ -12,8 +12,8 @@ class CreateAccountModel: ObservableObject {
     @Published var real_name: String = ""
     @Published var nick_name: String = ""
     @Published var about: String = ""
-    @Published var pubkey: String = ""
-    @Published var privkey: String = ""
+    @Published var pubkey: Pubkey = .empty
+    @Published var privkey: Privkey = .empty
     @Published var profile_image: URL? = nil
 
     var pubkey_bech32: String {

--- a/damus/Models/DamusState.swift
+++ b/damus/Models/DamusState.swift
@@ -50,7 +50,7 @@ struct DamusState {
         return stored
     }
     
-    var pubkey: String {
+    var pubkey: Pubkey {
         return keypair.pubkey
     }
     

--- a/damus/Models/DirectMessageModel.swift
+++ b/damus/Models/DirectMessageModel.swift
@@ -16,11 +16,11 @@ class DirectMessageModel: ObservableObject {
 
     @Published var draft: String = ""
     
-    let pubkey: String
-    
+    let pubkey: Pubkey
+
     var is_request = false
-    var our_pubkey: String
-    
+    var our_pubkey: Pubkey
+
     func determine_is_request() -> Bool {
         for event in events {
             if event.pubkey == our_pubkey {
@@ -31,7 +31,7 @@ class DirectMessageModel: ObservableObject {
         return true
     }
     
-    init(events: [NostrEvent] = [], our_pubkey: String, pubkey: String) {
+    init(events: [NostrEvent] = [], our_pubkey: Pubkey, pubkey: Pubkey) {
         self.events = events
         self.our_pubkey = our_pubkey
         self.pubkey = pubkey

--- a/damus/Models/DirectMessagesModel.swift
+++ b/damus/Models/DirectMessagesModel.swift
@@ -11,10 +11,10 @@ class DirectMessagesModel: ObservableObject {
     @Published var dms: [DirectMessageModel] = []
     @Published var loading: Bool = false
     @Published var open_dm: Bool = false
-    @Published private(set) var active_model: DirectMessageModel = DirectMessageModel(our_pubkey: "", pubkey: "")
-    let our_pubkey: String
-    
-    init(our_pubkey: String) {
+    @Published private(set) var active_model: DirectMessageModel = DirectMessageModel(our_pubkey: .empty, pubkey: .empty)
+    let our_pubkey: Pubkey
+
+    init(our_pubkey: Pubkey) {
         self.our_pubkey = our_pubkey
     }
     
@@ -30,14 +30,14 @@ class DirectMessagesModel: ObservableObject {
         self.active_model = model
     }
     
-    func set_active_dm(_ pubkey: String) {
+    func set_active_dm(_ pubkey: Pubkey) {
         for model in self.dms where model.pubkey == pubkey {
             self.set_active_dm_model(model)
             break
         }
     }
     
-    func lookup_or_create(_ pubkey: String) -> DirectMessageModel {
+    func lookup_or_create(_ pubkey: Pubkey) -> DirectMessageModel {
         if let dm = lookup(pubkey) {
             return dm
         }
@@ -47,7 +47,7 @@ class DirectMessagesModel: ObservableObject {
         return new
     }
     
-    func lookup(_ pubkey: String) -> DirectMessageModel? {
+    func lookup(_ pubkey: Pubkey) -> DirectMessageModel? {
         for dm in dms {
             if pubkey == dm.pubkey {
                 return dm

--- a/damus/Models/EventsModel.swift
+++ b/damus/Models/EventsModel.swift
@@ -10,14 +10,14 @@ import Foundation
 
 class EventsModel: ObservableObject {
     let state: DamusState
-    let target: String
+    let target: NoteId
     let kind: NostrKind
     let sub_id = UUID().uuidString
     let profiles_id = UUID().uuidString
     
     @Published var events: [NostrEvent] = []
     
-    init(state: DamusState, target: String, kind: NostrKind) {
+    init(state: DamusState, target: NoteId, kind: NostrKind) {
         self.state = state
         self.target = target
         self.kind = kind

--- a/damus/Models/FollowersModel.swift
+++ b/damus/Models/FollowersModel.swift
@@ -9,11 +9,11 @@ import Foundation
 
 class FollowersModel: ObservableObject {
     let damus_state: DamusState
-    let target: String
-    
-    @Published var contacts: [String]? = nil
-    var has_contact: Set<String> = Set()
-    
+    let target: Pubkey
+
+    @Published var contacts: [Pubkey]? = nil
+    var has_contact: Set<Pubkey> = Set()
+
     let sub_id: String = UUID().description
     let profiles_id: String = UUID().description
     
@@ -24,14 +24,13 @@ class FollowersModel: ObservableObject {
         return contacts.count
     }
     
-    init(damus_state: DamusState, target: String) {
+    init(damus_state: DamusState, target: Pubkey) {
         self.damus_state = damus_state
         self.target = target
     }
     
     func get_filter() -> NostrFilter {
-        NostrFilter(kinds: [.contacts],
-                    pubkeys: [target])
+        NostrFilter(kinds: [.contacts], pubkeys: [target])
     }
     
     func subscribe() {

--- a/damus/Models/FollowingModel.swift
+++ b/damus/Models/FollowingModel.swift
@@ -11,18 +11,18 @@ class FollowingModel {
     let damus_state: DamusState
     var needs_sub: Bool = true
     
-    let contacts: [String]
-    
+    let contacts: [Pubkey]
+
     let sub_id: String = UUID().description
     
-    init(damus_state: DamusState, contacts: [String]) {
+    init(damus_state: DamusState, contacts: [Pubkey]) {
         self.damus_state = damus_state
         self.contacts = contacts
     }
     
     func get_filter() -> NostrFilter {
         var f = NostrFilter(kinds: [.metadata])
-        f.authors = self.contacts.reduce(into: Array<String>()) { acc, pk in
+        f.authors = self.contacts.reduce(into: Array<Pubkey>()) { acc, pk in
             // don't fetch profiles we already have
             if damus_state.profiles.has_fresh_profile(id: pk) {
                 return

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -72,6 +72,7 @@ class HomeModel {
     var incoming_dms: [NostrEvent] = []
     let dm_debouncer = Debouncer(interval: 0.5)
     let resub_debouncer = Debouncer(interval: 3.0)
+    let save_last_event_debouncer = Debouncer(interval: 3.0)
     var should_debounce_dms = true
 
     let home_subid = UUID().description
@@ -237,7 +238,7 @@ class HomeModel {
                 return
             }
 
-            guard let new_bits = handle_last_events(new_events: self.notification_status.new_events, ev: ev, timeline: .notifications, shouldNotify: true) else {
+            guard let new_bits = handle_last_events(debouncer: self.save_last_event_debouncer, new_events: self.notification_status.new_events, ev: ev, timeline: .notifications, shouldNotify: true) else {
                 return
             }
             
@@ -608,7 +609,7 @@ class HomeModel {
 
     @discardableResult
     func handle_last_event(ev: NostrEvent, timeline: Timeline, shouldNotify: Bool = true) -> Bool {
-        if let new_bits = handle_last_events(new_events: self.notification_status.new_events, ev: ev, timeline: timeline, shouldNotify: shouldNotify) {
+        if let new_bits = handle_last_events(debouncer: save_last_event_debouncer, new_events: self.notification_status.new_events, ev: ev, timeline: timeline, shouldNotify: shouldNotify) {
             self.notification_status.new_events = new_bits
             return true
         } else {
@@ -659,7 +660,7 @@ class HomeModel {
         
         if !should_debounce_dms {
             self.incoming_dms.append(ev)
-            if let notifs = handle_incoming_dms(prev_events: notification_status.new_events, dms: self.dms, our_pubkey: self.damus_state.pubkey, evs: self.incoming_dms) {
+            if let notifs = handle_incoming_dms(debouncer: save_last_event_debouncer, prev_events: notification_status.new_events, dms: self.dms, our_pubkey: self.damus_state.pubkey, evs: self.incoming_dms) {
                 got_new_dm(notifs: notifs, ev: ev)
             }
             self.incoming_dms = []
@@ -669,7 +670,7 @@ class HomeModel {
         incoming_dms.append(ev)
         
         dm_debouncer.debounce { [self] in
-            if let notifs = handle_incoming_dms(prev_events: notification_status.new_events, dms: self.dms, our_pubkey: self.damus_state.pubkey, evs: self.incoming_dms) {
+            if let notifs = handle_incoming_dms(debouncer: save_last_event_debouncer, prev_events: notification_status.new_events, dms: self.dms, our_pubkey: self.damus_state.pubkey, evs: self.incoming_dms) {
                 got_new_dm(notifs: notifs, ev: ev)
             }
             self.incoming_dms = []
@@ -992,7 +993,7 @@ func fetch_relay_metadata(relay_id: String) async throws -> RelayMetadata? {
 }
 
 @discardableResult
-func handle_incoming_dm(ev: NostrEvent, our_pubkey: String, dms: DirectMessagesModel, prev_events: NewEventsBits) -> (Bool, NewEventsBits?) {
+func handle_incoming_dm(debouncer: Debouncer?, ev: NostrEvent, our_pubkey: Pubkey, dms: DirectMessagesModel, prev_events: NewEventsBits) -> (Bool, NewEventsBits?) {
     var inserted = false
     var found = false
     
@@ -1029,20 +1030,20 @@ func handle_incoming_dm(ev: NostrEvent, our_pubkey: String, dms: DirectMessagesM
     
     var new_bits: NewEventsBits? = nil
     if inserted {
-        new_bits = handle_last_events(new_events: prev_events, ev: ev, timeline: .dms, shouldNotify: !ours)
+        new_bits = handle_last_events(debouncer: debouncer, new_events: prev_events, ev: ev, timeline: .dms, shouldNotify: !ours)
     }
     
     return (inserted, new_bits)
 }
 
 @discardableResult
-func handle_incoming_dms(prev_events: NewEventsBits, dms: DirectMessagesModel, our_pubkey: String, evs: [NostrEvent]) -> NewEventsBits? {
+func handle_incoming_dms(debouncer: Debouncer, prev_events: NewEventsBits, dms: DirectMessagesModel, our_pubkey: Pubkey, evs: [NostrEvent]) -> NewEventsBits? {
     var inserted = false
 
     var new_events: NewEventsBits? = nil
     
     for ev in evs {
-        let res = handle_incoming_dm(ev: ev, our_pubkey: our_pubkey, dms: dms, prev_events: prev_events)
+        let res = handle_incoming_dm(debouncer: debouncer, ev: ev, our_pubkey: our_pubkey, dms: dms, prev_events: prev_events)
         inserted = res.0 || inserted
         if let new = res.1 {
             new_events = new
@@ -1101,11 +1102,17 @@ func timeline_to_notification_bits(_ timeline: Timeline, ev: NostrEvent?) -> New
 }
 
 /// A helper to determine if we need to notify the user of new events
-func handle_last_events(new_events: NewEventsBits, ev: NostrEvent, timeline: Timeline, shouldNotify: Bool = true) -> NewEventsBits? {
+func handle_last_events(debouncer: Debouncer?, new_events: NewEventsBits, ev: NostrEvent, timeline: Timeline, shouldNotify: Bool = true) -> NewEventsBits? {
     let last_ev = get_last_event(timeline)
 
     if last_ev == nil || last_ev!.created_at < ev.created_at {
-        save_last_event(ev, timeline: timeline)
+        if let debouncer {
+            debouncer.debounce {
+                save_last_event(ev, timeline: timeline)
+            }
+        } else {
+            save_last_event(ev, timeline: timeline)
+        }
         if shouldNotify {
             return new_events.union(timeline_to_notification_bits(timeline, ev: ev))
         }

--- a/damus/Models/LikeCounter.swift
+++ b/damus/Models/LikeCounter.swift
@@ -13,16 +13,16 @@ enum CountResult {
 }
 
 class EventCounter {
-    var counts: [String: Int] = [:]
-    var user_events: [String: Set<String>] = [:]
-    var our_events: [String: NostrEvent] = [:]
-    var our_pubkey: String
-    
-    init(our_pubkey: String) {
+    var counts: [NoteId: Int] = [:]
+    var user_events: [Pubkey: Set<NoteId>] = [:]
+    var our_events: [NoteId: NostrEvent] = [:]
+    var our_pubkey: Pubkey
+
+    init(our_pubkey: Pubkey) {
         self.our_pubkey = our_pubkey
     }
     
-    func add_event(_ ev: NostrEvent, target: String) -> CountResult {
+    func add_event(_ ev: NostrEvent, target: NoteId) -> CountResult {
         let pubkey = ev.pubkey
         
         if self.user_events[pubkey] == nil {

--- a/damus/Models/Liked.swift
+++ b/damus/Models/Liked.swift
@@ -9,6 +9,6 @@ import Foundation
 
 struct Counted {
     let event: NostrEvent
-    let id: String
+    let id: NoteId
     let total: Int
 }

--- a/damus/Models/MutedThreadsManager.swift
+++ b/damus/Models/MutedThreadsManager.swift
@@ -7,16 +7,16 @@
 
 import Foundation
 
-fileprivate func getMutedThreadsKey(pubkey: String) -> String {
+fileprivate func getMutedThreadsKey(pubkey: Pubkey) -> String {
     pk_setting_key(pubkey, key: "muted_threads")
 }
 
-func loadMutedThreads(pubkey: String) -> [String] {
+func loadMutedThreads(pubkey: Pubkey) -> [NoteId] {
     let key = getMutedThreadsKey(pubkey: pubkey)
     return UserDefaults.standard.stringArray(forKey: key) ?? []
 }
 
-func saveMutedThreads(pubkey: String, currentValue: [String], value: [String]) -> Bool {
+func saveMutedThreads(pubkey: Pubkey, currentValue: [NoteId], value: [NoteId]) -> Bool {
     let uniqueMutedThreads = Array(Set(value))
 
     if uniqueMutedThreads != currentValue {
@@ -31,9 +31,9 @@ class MutedThreadsManager: ObservableObject {
 
     private let keypair: Keypair
 
-    private var _mutedThreadsSet: Set<String>
-    private var _mutedThreads: [String]
-    var mutedThreads: [String] {
+    private var _mutedThreadsSet: Set<NoteId>
+    private var _mutedThreads: [NoteId]
+    var mutedThreads: [NoteId] {
         get {
             return _mutedThreads
         }
@@ -51,7 +51,7 @@ class MutedThreadsManager: ObservableObject {
         self.keypair = keypair
     }
 
-    func isMutedThread(_ ev: NostrEvent, privkey: String?) -> Bool {
+    func isMutedThread(_ ev: NostrEvent, privkey: Privkey?) -> Bool {
         return _mutedThreadsSet.contains(ev.thread_id(privkey: privkey))
     }
 

--- a/damus/Models/Notifications/ZapGroup.swift
+++ b/damus/Models/Notifications/ZapGroup.swift
@@ -10,8 +10,8 @@ import Foundation
 class ZapGroup {
     var zaps: [Zapping] = []
     var msat_total: Int64 = 0
-    var zappers = Set<String>()
-    
+    var zappers = Set<Pubkey>()
+
     var last_event_at: UInt32 {
         guard let first = zaps.first else {
             return 0

--- a/damus/Models/NotificationsModel.swift
+++ b/damus/Models/NotificationsModel.swift
@@ -35,22 +35,7 @@ enum NotificationItem {
             return nil
         }
     }
-    
-    var id: String {
-        switch self {
-        case .repost(let evid, _):
-            return "repost_" + evid
-        case .reaction(let evid, _):
-            return "reaction_" + evid
-        case .profile_zap:
-            return "profile_zap"
-        case .event_zap(let evid, _):
-            return "event_zap_" + evid
-        case .reply(let ev):
-            return "reply_" + ev.id
-        }
-    }
-    
+
     var last_event_at: UInt32 {
         switch self {
         case .reaction(_, let evgrp):

--- a/damus/Models/NotificationsModel.swift
+++ b/damus/Models/NotificationsModel.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 enum NotificationItem {
-    case repost(String, EventGroup)
-    case reaction(String, EventGroup)
+    case repost(NoteId, EventGroup)
+    case reaction(NoteId, EventGroup)
     case profile_zap(ZapGroup)
-    case event_zap(String, ZapGroup)
+    case event_zap(NoteId, ZapGroup)
     case reply(NostrEvent)
     
     var is_reply: NostrEvent? {
@@ -104,23 +104,23 @@ class NotificationsModel: ObservableObject, ScrollQueue {
     var should_queue: Bool = true
     
     // mappings from events to
-    var zaps: [String: ZapGroup] = [:]
+    var zaps: [NoteId: ZapGroup] = [:]
     var profile_zaps = ZapGroup()
-    var reactions: [String: EventGroup] = [:]
-    var reposts: [String: EventGroup] = [:]
+    var reactions: [NoteId: EventGroup] = [:]
+    var reposts: [NoteId: EventGroup] = [:]
     var replies: [NostrEvent] = []
-    var has_reply = Set<String>()
-    var has_ev = Set<String>()
-    
+    var has_reply = Set<NoteId>()
+    var has_ev = Set<NoteId>()
+
     @Published var notifications: [NotificationItem] = []
     
     func set_should_queue(_ val: Bool) {
         self.should_queue = val
     }
     
-    func uniq_pubkeys() -> [String] {
-        var pks = Set<String>()
-        
+    func uniq_pubkeys() -> [Pubkey] {
+        var pks = Set<Pubkey>()
+
         for ev in incoming_events {
             pks.insert(ev.pubkey)
         }

--- a/damus/Models/ProfileModel.swift
+++ b/damus/Models/ProfileModel.swift
@@ -14,14 +14,14 @@ class ProfileModel: ObservableObject, Equatable {
     @Published var progress: Int = 0
     
     var events: EventHolder
-    let pubkey: String
+    let pubkey: Pubkey
     let damus: DamusState
     
-    var seen_event: Set<String> = Set()
+    var seen_event: Set<NoteId> = Set()
     var sub_id = UUID().description
     var prof_subid = UUID().description
     
-    init(pubkey: String, damus: DamusState) {
+    init(pubkey: Pubkey, damus: DamusState) {
         self.pubkey = pubkey
         self.damus = damus
         self.events = EventHolder(on_queue: { ev in
@@ -29,7 +29,7 @@ class ProfileModel: ObservableObject, Equatable {
         })
     }
     
-    func follows(pubkey: String) -> Bool {
+    func follows(pubkey: Pubkey) -> Bool {
         guard let contacts = self.contacts else {
             return false
         }

--- a/damus/Models/ProfileUpdate.swift
+++ b/damus/Models/ProfileUpdate.swift
@@ -9,6 +9,6 @@ import Foundation
 
 
 struct ProfileUpdate {
-    let pubkey: String
+    let pubkey: Pubkey
     let profile: Profile
 }

--- a/damus/Models/ReactionsModel.swift
+++ b/damus/Models/ReactionsModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final class ReactionsModel: EventsModel {
     
-    init(state: DamusState, target: String) {
+    init(state: DamusState, target: NoteId) {
         super.init(state: state, target: target, kind: .like)
     }
 }

--- a/damus/Models/Reply.swift
+++ b/damus/Models/Reply.swift
@@ -8,13 +8,13 @@
 import Foundation
 
 struct ReplyDesc {
-    let pubkeys: [String]
+    let pubkeys: [Pubkey]
     let others: Int
 }
 
 func make_reply_description(_ tags: [[String]]) -> ReplyDesc {
     var c = 0
-    var ns: [String] = []
+    var ns: [Pubkey] = []
     var i = tags.count - 1
         
     while i >= 0 {

--- a/damus/Models/ReplyMap.swift
+++ b/damus/Models/ReplyMap.swift
@@ -8,20 +8,20 @@
 import Foundation
 
 class ReplyMap {
-    var replies: [String: Set<String>] = [:]
-    
-    func lookup(_ id: String) -> Set<String>? {
+    var replies: [NoteId: Set<NoteId>] = [:]
+
+    func lookup(_ id: NoteId) -> Set<NoteId>? {
         return replies[id]
     }
     
-    private func ensure_set(id: String) {
+    private func ensure_set(id: NoteId) {
         if replies[id] == nil {
             replies[id] = Set()
         }
     }
     
     @discardableResult
-    func add(id: String, reply_id: String) -> Bool {
+    func add(id: NoteId, reply_id: NoteId) -> Bool {
         ensure_set(id: id)
         if (replies[id]!).contains(reply_id) {
             return false

--- a/damus/Models/Report.swift
+++ b/damus/Models/Report.swift
@@ -31,12 +31,12 @@ enum ReportType: String, CustomStringConvertible, CaseIterable {
 }
 
 struct ReportNoteTarget {
-    let pubkey: String
-    let note_id: String
+    let pubkey: Pubkey
+    let note_id: NoteId
 }
 
 enum ReportTarget {
-    case user(String)
+    case user(Pubkey)
     case note(ReportNoteTarget)
 
     static func note(pubkey: Pubkey, note_id: NoteId) -> ReportTarget {
@@ -54,9 +54,10 @@ struct Report {
 func create_report_tags(target: ReportTarget, type: ReportType) -> [[String]] {
     switch target {
     case .user(let pubkey):
-        return [["p", pubkey, type.rawValue]]
+        return [["p", pubkey.hex(), type.rawValue]]
     case .note(let notet):
-        return [["e", notet.note_id, type.rawValue], ["p", notet.pubkey]]
+        return [["e", notet.note_id.hex(), type.rawValue],
+                ["p", notet.pubkey.hex()]]
     }
 }
 

--- a/damus/Models/RepostsModel.swift
+++ b/damus/Models/RepostsModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 final class RepostsModel: EventsModel {
     
-    init(state: DamusState, target: String) {
+    init(state: DamusState, target: NoteId) {
         super.init(state: state, target: target, kind: .boost)
     }
 }

--- a/damus/Models/SearchHomeModel.swift
+++ b/damus/Models/SearchHomeModel.swift
@@ -13,7 +13,7 @@ class SearchHomeModel: ObservableObject {
     var events: EventHolder
     @Published var loading: Bool = false
 
-    var seen_pubkey: Set<String> = Set()
+    var seen_pubkey: Set<Pubkey> = Set()
     let damus_state: DamusState
     let base_subid = UUID().description
     let profiles_subid = UUID().description
@@ -91,7 +91,7 @@ class SearchHomeModel: ObservableObject {
     }
 }
 
-func find_profiles_to_fetch(profiles: Profiles, load: PubkeysToLoad, cache: EventCache) -> [String] {
+func find_profiles_to_fetch(profiles: Profiles, load: PubkeysToLoad, cache: EventCache) -> [Pubkey] {
     switch load {
     case .from_events(let events):
         return find_profiles_to_fetch_from_events(profiles: profiles, events: events, cache: cache)
@@ -100,13 +100,13 @@ func find_profiles_to_fetch(profiles: Profiles, load: PubkeysToLoad, cache: Even
     }
 }
 
-func find_profiles_to_fetch_from_keys(profiles: Profiles, pks: [String]) -> [String] {
+func find_profiles_to_fetch_from_keys(profiles: Profiles, pks: [Pubkey]) -> [Pubkey] {
     Array(Set(pks.filter { pk in !profiles.has_fresh_profile(id: pk) }))
 }
 
-func find_profiles_to_fetch_from_events(profiles: Profiles, events: [NostrEvent], cache: EventCache) -> [String] {
-    var pubkeys = Set<String>()
-    
+func find_profiles_to_fetch_from_events(profiles: Profiles, events: [NostrEvent], cache: EventCache) -> [Pubkey] {
+    var pubkeys = Set<Pubkey>()
+
     for ev in events {
         // lookup profiles from boosted events
         if ev.known_kind == .boost, let bev = ev.get_inner_event(cache: cache), !profiles.has_fresh_profile(id: bev.pubkey) {
@@ -123,7 +123,7 @@ func find_profiles_to_fetch_from_events(profiles: Profiles, events: [NostrEvent]
 
 enum PubkeysToLoad {
     case from_events([NostrEvent])
-    case from_keys([String])
+    case from_keys([Pubkey])
 }
 
 func load_profiles(profiles_subid: String, relay_id: String, load: PubkeysToLoad, damus_state: DamusState) {

--- a/damus/Models/ThreadModel.swift
+++ b/damus/Models/ThreadModel.swift
@@ -128,7 +128,7 @@ class ThreadModel: ObservableObject {
 }
 
 
-func get_top_zap(events: EventCache, evid: String) -> Zapping? {
+func get_top_zap(events: EventCache, evid: NoteId) -> Zapping? {
     return events.get_cache_data(evid).zaps_model.zaps.first(where: { zap in
         !zap.request.marked_hidden
     })

--- a/damus/Models/UserSearchCache.swift
+++ b/damus/Models/UserSearchCache.swift
@@ -11,15 +11,15 @@ import Foundation
 /// Optimized for fast searches of substrings by using a Trie.
 /// Optimal for performing user searches that could be initiated by typing quickly on a keyboard into a text input field.
 class UserSearchCache {
-    private let trie = Trie<String>()
+    private let trie = Trie<Pubkey>()
 
-    func search(key: String) -> [String] {
+    func search(key: String) -> [Pubkey] {
         let results = trie.find(key: key)
         return results
     }
 
     /// Computes the differences between an old profile, if it exists, and a new profile, and updates the user search cache accordingly.
-    func updateProfile(id: String, profiles: Profiles, oldProfile: Profile?, newProfile: Profile) {
+    func updateProfile(id: Pubkey, profiles: Profiles, oldProfile: Profile?, newProfile: Profile) {
         // Remove searchable keys tied to the old profile if they differ from the new profile
         // to keep the trie clean without empty nodes while avoiding excessive graph searching.
         if let oldProfile {
@@ -38,7 +38,7 @@ class UserSearchCache {
     }
 
     /// Adds a profile to the user search cache.
-    private func addProfile(id: String, profiles: Profiles, profile: Profile) {
+    private func addProfile(id: Pubkey, profiles: Profiles, profile: Profile) {
         // Searchable by name.
         if let name = profile.name {
             trie.insert(key: name.lowercased(), value: id)
@@ -56,7 +56,7 @@ class UserSearchCache {
     }
 
     /// Computes the diffences between an old contacts event and a new contacts event for our own user, and updates the search cache accordingly.
-    func updateOwnContactsPetnames(id: String, oldEvent: NostrEvent?, newEvent: NostrEvent) {
+    func updateOwnContactsPetnames(id: Pubkey, oldEvent: NostrEvent?, newEvent: NostrEvent) {
         guard newEvent.known_kind == .contacts && newEvent.pubkey == id else {
             return
         }

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -11,7 +11,7 @@ import UIKit
 let fallback_zap_amount = 1000
 
 func setting_property_key(key: String) -> String {
-    return pk_setting_key(UserSettingsStore.pubkey ?? "", key: key)
+    return pk_setting_key(UserSettingsStore.pubkey ?? .empty, key: key)
 }
 
 func setting_get_property_value<T>(key: String, scoped_key: String, default_value: T) -> T {
@@ -63,7 +63,7 @@ func setting_set_property_value<T: Equatable>(scoped_key: String, old_value: T, 
     private var value: T
     
     init(key: String, default_value: T) {
-        self.key = pk_setting_key(UserSettingsStore.pubkey ?? "", key: key)
+        self.key = pk_setting_key(UserSettingsStore.pubkey ?? .empty, key: key)
         if let loaded = UserDefaults.standard.string(forKey: self.key), let val = T.init(from: loaded) {
             self.value = val
         } else if let loaded = UserDefaults.standard.string(forKey: key), let val = T.init(from: loaded) {
@@ -91,7 +91,7 @@ func setting_set_property_value<T: Equatable>(scoped_key: String, old_value: T, 
 }
 
 class UserSettingsStore: ObservableObject {
-    static var pubkey: String? = nil
+    static var pubkey: Pubkey? = nil
     static var shared: UserSettingsStore? = nil
     static var bool_options = Set<String>()
     
@@ -261,6 +261,6 @@ class UserSettingsStore: ObservableObject {
     }
 }
 
-func pk_setting_key(_ pubkey: String, key: String) -> String {
-    return "\(pubkey)_\(key)"
+func pk_setting_key(_ pubkey: Pubkey, key: String) -> String {
+    return "\(pubkey.hex())_\(key)"
 }

--- a/damus/Nostr/Nostr.swift
+++ b/damus/Nostr/Nostr.swift
@@ -201,7 +201,7 @@ class Profile: Codable {
         try container.encode(value)
     }
     
-    static func displayName(profile: Profile?, pubkey: String) -> DisplayName {
+    static func displayName(profile: Profile?, pubkey: Pubkey) -> DisplayName {
         return parse_display_name(profile: profile, pubkey: pubkey)
     }
 }

--- a/damus/Nostr/NostrFilter.swift
+++ b/damus/Nostr/NostrFilter.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 struct NostrFilter: Codable, Equatable {
-    var ids: [String]?
+    var ids: [NoteId]?
     var kinds: [NostrKind]?
-    var referenced_ids: [String]?
-    var pubkeys: [String]?
+    var referenced_ids: [NoteId]?
+    var pubkeys: [Pubkey]?
     var since: UInt32?
     var until: UInt32?
     var limit: UInt32?
-    var authors: [String]?
+    var authors: [Pubkey]?
     var hashtag: [String]?
     var parameter: [String]?
 
@@ -32,7 +32,7 @@ struct NostrFilter: Codable, Equatable {
         case limit
     }
     
-    init(ids: [String]? = nil, kinds: [NostrKind]? = nil, referenced_ids: [String]? = nil, pubkeys: [String]? = nil, since: UInt32? = nil, until: UInt32? = nil, limit: UInt32? = nil, authors: [String]? = nil, hashtag: [String]? = nil) {
+    init(ids: [NoteId]? = nil, kinds: [NostrKind]? = nil, referenced_ids: [NoteId]? = nil, pubkeys: [Pubkey]? = nil, since: UInt32? = nil, until: UInt32? = nil, limit: UInt32? = nil, authors: [Pubkey]? = nil, hashtag: [String]? = nil) {
         self.ids = ids
         self.kinds = kinds
         self.referenced_ids = referenced_ids

--- a/damus/Nostr/NostrResponse.swift
+++ b/damus/Nostr/NostrResponse.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct CommandResult {
-    let event_id: String
+    let event_id: NoteId
     let ok: Bool
     let msg: String
 }

--- a/damus/Nostr/Profiles.swift
+++ b/damus/Nostr/Profiles.swift
@@ -100,7 +100,9 @@ class Profiles {
         if profile != nil {
             return true
         }
-        
+        // check memory first
+        return false
+
         // then disk
         guard let pull_date = database.get_network_pull_date(id: id) else {
             return false

--- a/damus/Nostr/Pubkey.swift
+++ b/damus/Nostr/Pubkey.swift
@@ -12,3 +12,18 @@ typealias FollowRef = ReferencedId
 typealias Pubkey = String
 typealias NoteId = String
 typealias Privkey = String
+
+extension String {
+    // Id constructors
+    init?(hex: String) {
+        self = hex
+    }
+
+    static var empty: String {
+        return ""
+    }
+
+    func hex() -> String {
+        return self
+    }
+}

--- a/damus/Nostr/Relay.swift
+++ b/damus/Nostr/Relay.swift
@@ -68,7 +68,7 @@ struct Limitations: Codable {
 struct RelayMetadata: Codable {
     let name: String?
     let description: String?
-    let pubkey: String?
+    let pubkey: Pubkey?
     let contact: String?
     let supported_nips: [Int]?
     let software: String?

--- a/damus/Nostr/RelayPool.swift
+++ b/damus/Nostr/RelayPool.swift
@@ -21,7 +21,7 @@ struct QueuedRequest {
 
 struct SeenEvent: Hashable {
     let relay_id: String
-    let evid: String
+    let evid: NoteId
 }
 
 class RelayPool {

--- a/damus/TestData.swift
+++ b/damus/TestData.swift
@@ -12,9 +12,9 @@ let test_pubkey = "a9952fe066ced622167acb8069a0dfd1d44d9493ef2a4c28cf93e2877248b
 let test_keypair = Keypair(pubkey: test_pubkey, privkey: test_seckey)
 let test_keypair_full = test_keypair.to_full()!
 
-let test_event_holder = EventHolder(events: [], incoming: [test_event])
+let test_event_holder = EventHolder(events: [], incoming: [test_note])
 
-let test_event =
+let test_note =
         NostrEvent(
             content: "hello there https://jb55.com/s/Oct12-150217.png https://jb55.com/red-me.jpg cool",
             keypair: test_keypair,
@@ -32,18 +32,18 @@ let test_event_group = EventGroup(events: test_reposts)
 let test_zap_invoice = ZapInvoice(description: .description("description"), amount: 10000, string: "lnbc1", expiry: 1000000, payment_hash: Data(), created_at: 1000000)
 let test_zap_request_ev = NostrEvent(content: "hi", keypair: test_keypair, kind: 9734)!
 let test_zap_request = ZapRequest(ev: test_zap_request_ev)
-let test_zap = Zap(event: test_event, invoice: test_zap_invoice, zapper: "zapper", target: .profile("pk"), raw_request: test_zap_request, is_anon: false, private_request: nil)
+let test_zap = Zap(event: test_note, invoice: test_zap_invoice, zapper: test_note.pubkey, target: .profile(test_pubkey), raw_request: test_zap_request, is_anon: false, private_request: nil)
 
-let test_private_zap = Zap(event: test_event, invoice: test_zap_invoice, zapper: "zapper", target: .profile("pk"), raw_request: test_zap_request, is_anon: false, private_request: .init(ev: test_event))
+let test_private_zap = Zap(event: test_note, invoice: test_zap_invoice, zapper: test_note.pubkey, target: .profile(test_pubkey), raw_request: test_zap_request, is_anon: false, private_request: .init(ev: test_note))
 
-let test_pending_zap = PendingZap(amount_msat: 10000, target: .note(id: "id", author: "pk"), request: .normal(test_zap_request), type: .pub, state: .external(.init(state: .fetching_invoice)))
+let test_pending_zap = PendingZap(amount_msat: 10000, target: .note(id: test_note.id, author: test_note.pubkey), request: .normal(test_zap_request), type: .pub, state: .external(.init(state: .fetching_invoice)))
 
 
 func test_damus_state() -> DamusState {
     let damus = DamusState.empty
 
     let prof = Profile(name: "damus", display_name: "damus", about: "iOS app!", picture: "https://damus.io/img/logo.png", banner: "", website: "https://damus.io", lud06: nil, lud16: "jb55@sendsats.lol", nip05: "damus.io", damus_donation: nil)
-    let tsprof = TimestampedProfile(profile: prof, timestamp: 0, event: test_event)
+    let tsprof = TimestampedProfile(profile: prof, timestamp: 0, event: test_note)
     damus.profiles.add(id: test_pubkey, profile: tsprof)
     return damus
 }

--- a/damus/Util/Bech32Object.swift
+++ b/damus/Util/Bech32Object.swift
@@ -9,9 +9,9 @@ import Foundation
 
 
 enum Bech32Object {
-    case nsec(String)
-    case npub(String)
-    case note(String)
+    case nsec(Privkey)
+    case npub(Pubkey)
+    case note(NoteId)
     case nscript([UInt8])
     
     static func parse(_ str: String) -> Bech32Object? {

--- a/damus/Util/DisplayName.swift
+++ b/damus/Util/DisplayName.swift
@@ -37,7 +37,7 @@ enum DisplayName {
 }
 
 
-func parse_display_name(profile: Profile?, pubkey: String) -> DisplayName {
+func parse_display_name(profile: Profile?, pubkey: Pubkey) -> DisplayName {
     if pubkey == ANON_PUBKEY {
         return .one(NSLocalizedString("Anonymous", comment: "Placeholder display name of anonymous user."))
     }

--- a/damus/Util/EventCache.swift
+++ b/damus/Util/EventCache.swift
@@ -61,7 +61,7 @@ class ZapsDataModel: ObservableObject {
         self.zaps = zaps
     }
     
-    func confirm_nwc(reqid: String) {
+    func confirm_nwc(reqid: NoteId) {
         guard let zap = zaps.first(where: { z in z.request.ev.id == reqid }),
               case .pending(let pzap) = zap
         else {
@@ -82,7 +82,7 @@ class ZapsDataModel: ObservableObject {
         zaps.reduce(0) { total, zap in total + zap.amount }
     }
    
-    func from(_ pubkey: String) -> [Zapping] {
+    func from(_ pubkey: Pubkey) -> [Zapping] {
         return self.zaps.filter { z in z.request.ev.pubkey == pubkey }
     }
     
@@ -137,7 +137,7 @@ class EventData {
 }
 
 class EventCache {
-    private var events: [String: NostrEvent] = [:]
+    private var events: [NoteId: NostrEvent] = [:]
     private var replies = ReplyMap()
     private var cancellable: AnyCancellable?
     private var image_metadata: [String: ImageMetadataState] = [:]
@@ -154,7 +154,7 @@ class EventCache {
         }
     }
     
-    func get_cache_data(_ evid: String) -> EventData {
+    func get_cache_data(_ evid: NoteId) -> EventData {
         guard let data = event_data[evid] else {
             let data = EventData()
             event_data[evid] = data
@@ -164,11 +164,11 @@ class EventCache {
         return data
     }
     
-    func is_event_valid(_ evid: String) -> ValidationResult {
+    func is_event_valid(_ evid: NoteId) -> ValidationResult {
         return get_cache_data(evid).validated
     }
     
-    func store_event_validation(evid: String, validated: ValidationResult) {
+    func store_event_validation(evid: NoteId, validated: ValidationResult) {
         get_cache_data(evid).validated = validated
     }
     
@@ -278,7 +278,7 @@ class EventCache {
         return ev
     }
     
-    func lookup(_ evid: String) -> NostrEvent? {
+    func lookup(_ evid: NoteId) -> NostrEvent? {
         return events[evid]
     }
     

--- a/damus/Util/LNUrls.swift
+++ b/damus/Util/LNUrls.swift
@@ -15,14 +15,14 @@ enum LNUrlState {
 }
 
 class LNUrls {
-    var endpoints: [String: LNUrlState]
+    var endpoints: [Pubkey: LNUrlState]
 
     init() {
         self.endpoints = [:]
     }
 
     @MainActor
-    func lookup_or_fetch(pubkey: String, lnurl: String) async -> LNUrlPayRequest? {
+    func lookup_or_fetch(pubkey: Pubkey, lnurl: String) async -> LNUrlPayRequest? {
         switch lookup(pubkey: pubkey) {
         case .failed(let tries):
             print("lnurls.lookup_or_fetch failed \(tries) \(lnurl)")
@@ -57,7 +57,7 @@ class LNUrls {
         return v
     }
 
-    func lookup(pubkey: String) -> LNUrlState {
+    func lookup(pubkey: Pubkey) -> LNUrlState {
         return self.endpoints[pubkey] ?? .not_fetched
     }
 }

--- a/damus/Util/NIP05.swift
+++ b/damus/Util/NIP05.swift
@@ -30,7 +30,7 @@ struct NIP05 {
 
 
 struct NIP05Response: Decodable {
-    let names: [String: String]
+    let names: [String: Pubkey]
 }
 
 func fetch_nip05(nip05: NIP05) async -> NIP05Response? {
@@ -51,7 +51,7 @@ func fetch_nip05(nip05: NIP05) async -> NIP05Response? {
     return decoded
 }
 
-func validate_nip05(pubkey: String, nip05_str: String) async -> NIP05? {
+func validate_nip05(pubkey: Pubkey, nip05_str: String) async -> NIP05? {
     guard let nip05 = NIP05.parse(nip05_str) else {
         return nil
     }

--- a/damus/Util/PostBox.swift
+++ b/damus/Util/PostBox.swift
@@ -55,8 +55,8 @@ enum CancelSendErr {
 
 class PostBox {
     let pool: RelayPool
-    var events: [String: PostedEvent]
-    
+    var events: [NoteId: PostedEvent]
+
     init(pool: RelayPool) {
         self.pool = pool
         self.events = [:]
@@ -64,7 +64,7 @@ class PostBox {
     }
     
     // only works reliably on delay-sent events
-    func cancel_send(evid: String) -> CancelSendErr? {
+    func cancel_send(evid: NoteId) -> CancelSendErr? {
         guard let ev = events[evid] else {
             return .nothing_to_cancel
         }
@@ -114,7 +114,7 @@ class PostBox {
     }
     
     @discardableResult
-    func remove_relayer(relay_id: String, event_id: String) -> Bool {
+    func remove_relayer(relay_id: String, event_id: NoteId) -> Bool {
         guard let ev = self.events[event_id] else {
             return false
         }

--- a/damus/Util/PreviewCache.swift
+++ b/damus/Util/PreviewCache.swift
@@ -65,9 +65,9 @@ enum PreviewState {
 }
 
 class PreviewCache {
-    private var previews: [String: Preview] = [:]
+    private var previews: [NoteId: Preview] = [:]
     
-    func lookup(_ evid: String) -> Preview? {
+    func lookup(_ evid: NoteId) -> Preview? {
         return previews[evid]
     }
 }

--- a/damus/Util/Relays/RelayBootstrap.swift
+++ b/damus/Util/Relays/RelayBootstrap.swift
@@ -14,17 +14,17 @@ let BOOTSTRAP_RELAYS = [
     "wss://nos.lol",
 ]
 
-func bootstrap_relays_setting_key(pubkey: String) -> String {
+func bootstrap_relays_setting_key(pubkey: Pubkey) -> String {
     return pk_setting_key(pubkey, key: "bootstrap_relays")
 }
 
-func save_bootstrap_relays(pubkey: String, relays: [String])  {
+func save_bootstrap_relays(pubkey: Pubkey, relays: [String])  {
     let key = bootstrap_relays_setting_key(pubkey: pubkey)
     
     UserDefaults.standard.set(relays, forKey: key)
 }
 
-func load_bootstrap_relays(pubkey: String) -> [String] {
+func load_bootstrap_relays(pubkey: Pubkey) -> [String] {
     let key = bootstrap_relays_setting_key(pubkey: pubkey)
     
     guard let relays = UserDefaults.standard.stringArray(forKey: key) else {

--- a/damus/Util/Relays/RelayFilters.swift
+++ b/damus/Util/Relays/RelayFilters.swift
@@ -18,7 +18,7 @@ struct RelayFilter: Hashable {
 }
 
 class RelayFilters {
-    private let our_pubkey: String
+    private let our_pubkey: Pubkey
     private var disabled: Set<RelayFilter>
     
     func is_filtered(timeline: Timeline, relay_id: String) -> Bool {
@@ -47,23 +47,23 @@ class RelayFilters {
         save_relay_filters(our_pubkey, filters: disabled)
     }
     
-    init(our_pubkey: String) {
+    init(our_pubkey: Pubkey) {
         self.our_pubkey = our_pubkey
         disabled = load_relay_filters(our_pubkey) ?? Set()
     }
 }
 
-func save_relay_filters(_ pubkey: String, filters: Set<RelayFilter>) {
+func save_relay_filters(_ pubkey: Pubkey, filters: Set<RelayFilter>) {
     let key = pk_setting_key(pubkey, key: "relay_filters")
     let arr = Array(filters.map { filter in "\(filter.timeline)\t\(filter.relay_id)" })
     UserDefaults.standard.set(arr, forKey: key)
 }
 
-func relay_filter_setting_key(_ pubkey: String) -> String {
+func relay_filter_setting_key(_ pubkey: Pubkey) -> String {
     return pk_setting_key(pubkey, key: "relay_filters")
 }
 
-func load_relay_filters(_ pubkey: String) -> Set<RelayFilter>? {
+func load_relay_filters(_ pubkey: Pubkey) -> Set<RelayFilter>? {
     let key = relay_filter_setting_key(pubkey)
     guard let filters = UserDefaults.standard.stringArray(forKey: key) else {
         return nil

--- a/damus/Util/ReplyCounter.swift
+++ b/damus/Util/ReplyCounter.swift
@@ -8,23 +8,23 @@
 import Foundation
 
 class ReplyCounter {
-    private var replies: [String: Int]
-    private var counted: Set<String>
-    private var our_replies: [String: NostrEvent]
-    private let our_pubkey: String
-    
-    init(our_pubkey: String) {
+    private var replies: [NoteId: Int]
+    private var counted: Set<NoteId>
+    private var our_replies: [NoteId: NostrEvent]
+    private let our_pubkey: Pubkey
+
+    init(our_pubkey: Pubkey) {
         self.our_pubkey = our_pubkey
         replies = [:]
         counted = Set()
         our_replies = [:]
     }
     
-    func our_reply(_ evid: String) -> NostrEvent? {
+    func our_reply(_ evid: NoteId) -> NostrEvent? {
         return our_replies[evid]
     }
     
-    func get_replies(_ evid: String) -> Int {
+    func get_replies(_ evid: NoteId) -> Int {
         return replies[evid] ?? 0
     }
     

--- a/damus/Util/Router.swift
+++ b/damus/Util/Router.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 enum Route: Hashable {
-    case ProfileByKey(pubkey: String)
+    case ProfileByKey(pubkey: Pubkey)
     case Profile(profile: ProfileModel, followers: FollowersModel)
     case Followers(followers: FollowersModel)
     case Relay(relay: String, showActionButtons: Binding<Bool>)
     case RelayDetail(relay: String, metadata: RelayMetadata?)
     case Following(following: FollowingModel)
-    case MuteList(users: [String])
+    case MuteList(users: [Pubkey])
     case RelayConfig
     case Script(script: ScriptModel)
     case Bookmarks
@@ -41,7 +41,7 @@ enum Route: Hashable {
     case SaveKeys(account: CreateAccountModel)
     case Wallet(wallet: WalletModel)
     case WalletScanner(result: Binding<WalletScanResult>)
-    case FollowersYouKnow(friendedFollowers: [String], followers: FollowersModel)
+    case FollowersYouKnow(friendedFollowers: [Pubkey], followers: FollowersModel)
 
     @ViewBuilder
     func view(navigationCoordinator: NavigationCoordinator, damusState: DamusState) -> some View {

--- a/damus/Util/WalletConnect.swift
+++ b/damus/Util/WalletConnect.swift
@@ -16,16 +16,16 @@ struct WalletConnectURL: Equatable {
     
     let relay: RelayURL
     let keypair: FullKeypair
-    let pubkey: String
+    let pubkey: Pubkey
     let lud16: String?
     
     func to_url() -> URL {
         var urlComponents = URLComponents()
         urlComponents.scheme = "nostrwalletconnect"
-        urlComponents.host = pubkey
+        urlComponents.host = pubkey.hex()
         urlComponents.queryItems = [
             URLQueryItem(name: "relay", value: relay.id),
-            URLQueryItem(name: "secret", value: keypair.privkey)
+            URLQueryItem(name: "secret", value: keypair.privkey.hex())
         ]
 
         if let lud16 {
@@ -55,7 +55,7 @@ struct WalletConnectURL: Equatable {
         self = WalletConnectURL(pubkey: pk, relay: relay_url, keypair: keypair, lud16: lud16)
     }
     
-    init(pubkey: String, relay: RelayURL, keypair: FullKeypair, lud16: String?) {
+    init(pubkey: Pubkey, relay: RelayURL, keypair: FullKeypair, lud16: String?) {
         self.pubkey = pubkey
         self.relay = relay
         self.keypair = keypair
@@ -86,7 +86,7 @@ enum WalletResponseResult {
 }
 
 struct FullWalletResponse {
-    let req_id: String
+    let req_id: NoteId
     let response: WalletResponse
     
     init?(from: NostrEvent, nwc: WalletConnectURL) async {
@@ -165,7 +165,7 @@ struct PayInvoiceRequest: Codable {
     let invoice: String
 }
 
-func make_wallet_connect_request<T>(req: WalletRequest<T>, to_pk: String, keypair: FullKeypair) -> NostrEvent? {
+func make_wallet_connect_request<T>(req: WalletRequest<T>, to_pk: Pubkey, keypair: FullKeypair) -> NostrEvent? {
     let tags = [["p", to_pk]]
     let created_at = UInt32(Date().timeIntervalSince1970)
     guard let content = encode_json(req) else {

--- a/damus/Util/Zap.swift
+++ b/damus/Util/Zap.swift
@@ -7,20 +7,20 @@
 
 import Foundation
 
-public struct NoteZapTarget: Equatable, Hashable {
-    public let note_id: String
-    public let author: String
+struct NoteZapTarget: Equatable, Hashable {
+    public let note_id: NoteId
+    public let author: Pubkey
 }
 
-public enum ZapTarget: Equatable {
-    case profile(String)
+enum ZapTarget: Equatable, Hashable {
+    case profile(Pubkey)
     case note(NoteZapTarget)
     
-    public static func note(id: String, author: String) -> ZapTarget {
+    static func note(id: NoteId, author: Pubkey) -> ZapTarget {
         return .note(NoteZapTarget(note_id: id, author: author))
     }
-    
-    var pubkey: String {
+
+    var pubkey: Pubkey {
         switch self {
         case .profile(let pk):
             return pk
@@ -258,7 +258,7 @@ enum Zapping {
 struct Zap {
     public let event: NostrEvent
     public let invoice: ZapInvoice
-    public let zapper: String /// zap authorizer
+    public let zapper: Pubkey /// zap authorizer
     public let target: ZapTarget
     public let raw_request: ZapRequest
     public let is_anon: Bool
@@ -268,7 +268,7 @@ struct Zap {
         return private_request ?? self.raw_request
     }
     
-    public static func from_zap_event(zap_ev: NostrEvent, zapper: String, our_privkey: String?) -> Zap? {
+    public static func from_zap_event(zap_ev: NostrEvent, zapper: Pubkey, our_privkey: Privkey?) -> Zap? {
         /// Make sure that we only create a zap event if it is authorized by the profile or event
         guard zapper == zap_ev.pubkey else {
             return nil

--- a/damus/Util/Zaps.swift
+++ b/damus/Util/Zaps.swift
@@ -8,14 +8,14 @@
 import Foundation
 
 class Zaps {
-    private(set) var zaps: [String: Zapping]
-    let our_pubkey: String
-    var our_zaps: [String: [Zapping]]
+    private(set) var zaps: [NoteId: Zapping]
+    let our_pubkey: Pubkey
+    var our_zaps: [NoteId: [Zapping]]
 
-    private(set) var event_counts: [String: Int]
-    private(set) var event_totals: [String: Int64]
-    
-    init(our_pubkey: String) {
+    private(set) var event_counts: [NoteId: Int]
+    private(set) var event_totals: [NoteId: Int64]
+
+    init(our_pubkey: Pubkey) {
         self.zaps = [:]
         self.our_pubkey = our_pubkey
         self.our_zaps = [:]
@@ -23,7 +23,7 @@ class Zaps {
         self.event_totals = [:]
     }
     
-    func remove_zap(reqid: String) -> Zapping? {
+    func remove_zap(reqid: NoteId) -> Zapping? {
         var res: Zapping? = nil
         for kv in our_zaps {
             let ours = kv.value

--- a/damus/Views/ActionBar/EventActionBar.swift
+++ b/damus/Views/ActionBar/EventActionBar.swift
@@ -349,11 +349,11 @@ struct EventActionBar_Previews: PreviewProvider {
 
         let bar = ActionBarModel.empty()
         let likedbar = ActionBarModel(likes: 10, boosts: 0, zaps: 0, zap_total: 0, replies: 0, our_like: nil, our_boost: nil, our_zap: nil, our_reply: nil)
-        let likedbar_ours = ActionBarModel(likes: 10, boosts: 0, zaps: 0, zap_total: 0, replies: 0, our_like: test_event, our_boost: nil, our_zap: nil, our_reply: nil)
-        let maxed_bar = ActionBarModel(likes: 999, boosts: 999, zaps: 999, zap_total: 99999999, replies: 999, our_like: test_event, our_boost: test_event, our_zap: nil, our_reply: nil)
-        let extra_max_bar = ActionBarModel(likes: 9999, boosts: 9999, zaps: 9999, zap_total: 99999999, replies: 9999, our_like: test_event, our_boost: test_event, our_zap: nil, our_reply: test_event)
-        let mega_max_bar = ActionBarModel(likes: 9999999, boosts: 99999, zaps: 9999, zap_total: 99999999, replies: 9999999,  our_like: test_event, our_boost: test_event, our_zap: .zap(test_zap), our_reply: test_event)
-        
+        let likedbar_ours = ActionBarModel(likes: 10, boosts: 0, zaps: 0, zap_total: 0, replies: 0, our_like: test_note, our_boost: nil, our_zap: nil, our_reply: nil)
+        let maxed_bar = ActionBarModel(likes: 999, boosts: 999, zaps: 999, zap_total: 99999999, replies: 999, our_like: test_note, our_boost: test_note, our_zap: nil, our_reply: nil)
+        let extra_max_bar = ActionBarModel(likes: 9999, boosts: 9999, zaps: 9999, zap_total: 99999999, replies: 9999, our_like: test_note, our_boost: test_note, our_zap: nil, our_reply: test_note)
+        let mega_max_bar = ActionBarModel(likes: 9999999, boosts: 99999, zaps: 9999, zap_total: 99999999, replies: 9999999,  our_like: test_note, our_boost: test_note, our_zap: .zap(test_zap), our_reply: test_note)
+
         VStack(spacing: 50) {
             EventActionBar(damus_state: ds, event: ev, bar: bar)
             

--- a/damus/Views/ActionBar/EventDetailBar.swift
+++ b/damus/Views/ActionBar/EventDetailBar.swift
@@ -9,12 +9,12 @@ import SwiftUI
 
 struct EventDetailBar: View {
     let state: DamusState
-    let target: String
-    let target_pk: String
-    
+    let target: NoteId
+    let target_pk: Pubkey
+
     @ObservedObject var bar: ActionBarModel
     
-    init(state: DamusState, target: String, target_pk: String) {
+    init(state: DamusState, target: NoteId, target_pk: Pubkey) {
         self.state = state
         self.target = target
         self.target_pk = target_pk
@@ -56,6 +56,6 @@ struct EventDetailBar: View {
 
 struct EventDetailBar_Previews: PreviewProvider {
     static var previews: some View {
-        EventDetailBar(state: test_damus_state(), target: "", target_pk: "")
+        EventDetailBar(state: test_damus_state(), target: .empty, target_pk: .empty)
     }
 }

--- a/damus/Views/ActionBar/RepostAction.swift
+++ b/damus/Views/ActionBar/RepostAction.swift
@@ -61,6 +61,6 @@ struct RepostAction: View {
 
 struct RepostAction_Previews: PreviewProvider {
     static var previews: some View {
-        RepostAction(damus_state: test_damus_state(), event: test_event)
+        RepostAction(damus_state: test_damus_state(), event: test_note)
     }
 }

--- a/damus/Views/BannerImageView.swift
+++ b/damus/Views/BannerImageView.swift
@@ -63,12 +63,12 @@ struct InnerBannerImageView: View {
 
 struct BannerImageView: View {
     let disable_animation: Bool
-    let pubkey: String
+    let pubkey: Pubkey
     let profiles: Profiles
     
     @State var banner: String?
     
-    init(pubkey: String, profiles: Profiles, disable_animation: Bool, banner: String? = nil) {
+    init(pubkey: Pubkey, profiles: Profiles, disable_animation: Bool, banner: String? = nil) {
         self.pubkey = pubkey
         self.profiles = profiles
         self._banner = State(initialValue: banner)
@@ -89,7 +89,7 @@ struct BannerImageView: View {
     }
 }
 
-func get_banner_url(banner: String?, pubkey: String, profiles: Profiles) -> URL? {
+func get_banner_url(banner: String?, pubkey: Pubkey, profiles: Profiles) -> URL? {
     let bannerUrlString = banner ?? profiles.lookup(id: pubkey)?.banner ?? ""
     if let url = URL(string: bannerUrlString) {
         return url
@@ -98,12 +98,10 @@ func get_banner_url(banner: String?, pubkey: String, profiles: Profiles) -> URL?
 }
 
 struct BannerImageView_Previews: PreviewProvider {
-    static let pubkey = "ca48854ac6555fed8e439ebb4fa2d928410e0eef13fa41164ec45aaaa132d846"
-    
     static var previews: some View {
         BannerImageView(
-            pubkey: pubkey,
-            profiles: make_preview_profiles(pubkey),
+            pubkey: test_pubkey,
+            profiles: make_preview_profiles(test_pubkey),
             disable_animation: false
         )
     }

--- a/damus/Views/CreateAccountView.swift
+++ b/damus/Views/CreateAccountView.swift
@@ -134,8 +134,8 @@ struct CreateAccountView_Previews: PreviewProvider {
     }
 }
 
-func KeyText(_ text: Binding<String>) -> some View {
-    let decoded = hex_decode(text.wrappedValue)!
+func KeyText(_ pubkey: Binding<Pubkey>) -> some View {
+    let decoded = hex_decode(pubkey.wrappedValue)!
     let bechkey = bech32_encode(hrp: PUBKEY_HRP, decoded)
     return Text(bechkey)
         .textSelection(.enabled)

--- a/damus/Views/DMChatView.swift
+++ b/damus/Views/DMChatView.swift
@@ -141,7 +141,7 @@ struct DMChatView: View, KeyboardReadable {
 
         damus_state.postbox.send(dm)
         
-        handle_incoming_dm(ev: dm, our_pubkey: damus_state.pubkey, dms: damus_state.dms, prev_events: NewEventsBits())
+        handle_incoming_dm(debouncer: nil, ev: dm, our_pubkey: damus_state.pubkey, dms: damus_state.dms, prev_events: NewEventsBits())
 
         end_editing()
     }

--- a/damus/Views/DMChatView.swift
+++ b/damus/Views/DMChatView.swift
@@ -13,7 +13,7 @@ struct DMChatView: View, KeyboardReadable {
     @ObservedObject var dms: DirectMessageModel
     @State var showPrivateKeyWarning: Bool = false
     
-    var pubkey: String {
+    var pubkey: Pubkey {
         dms.pubkey
     }
     
@@ -128,7 +128,7 @@ struct DMChatView: View, KeyboardReadable {
     }
 
     func send_message() {
-        let tags = [["p", pubkey]]
+        let tags = [["p", pubkey.hex()]]
         let post_blocks = parse_post_blocks(content: dms.draft)
         let content = render_blocks(blocks: post_blocks)
 
@@ -190,7 +190,7 @@ enum EncEncoding {
     case bech32
 }
 
-func encrypt_message(message: String, privkey: String, to_pk: String, encoding: EncEncoding = .base64) -> String? {
+func encrypt_message(message: String, privkey: Privkey, to_pk: Pubkey, encoding: EncEncoding = .base64) -> String? {
     let iv = random_bytes(count: 16).bytes
     guard let shared_sec = get_shared_secret(privkey: privkey, pubkey: to_pk) else {
         return nil
@@ -209,7 +209,7 @@ func encrypt_message(message: String, privkey: String, to_pk: String, encoding: 
     
 }
 
-func create_encrypted_event(_ message: String, to_pk: String, tags: [[String]], keypair: FullKeypair, created_at: UInt32, kind: UInt32) -> NostrEvent? {
+func create_encrypted_event(_ message: String, to_pk: Pubkey, tags: [[String]], keypair: FullKeypair, created_at: UInt32, kind: UInt32) -> NostrEvent? {
     let privkey = keypair.privkey
     
     guard let enc_content = encrypt_message(message: message, privkey: privkey, to_pk: to_pk) else {
@@ -219,7 +219,7 @@ func create_encrypted_event(_ message: String, to_pk: String, tags: [[String]], 
     return NostrEvent(content: enc_content, keypair: keypair.to_keypair(), kind: kind, tags: tags, createdAt: created_at)
 }
 
-func create_dm(_ message: String, to_pk: String, tags: [[String]], keypair: Keypair, created_at: UInt32? = nil) -> NostrEvent?
+func create_dm(_ message: String, to_pk: Pubkey, tags: [[String]], keypair: Keypair, created_at: UInt32? = nil) -> NostrEvent?
 {
     let created = created_at ?? UInt32(Date().timeIntervalSince1970)
 

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -20,9 +20,9 @@ struct EventView: View {
     let event: NostrEvent
     let options: EventViewOptions
     let damus: DamusState
-    let pubkey: String
+    let pubkey: Pubkey
 
-    init(damus: DamusState, event: NostrEvent, pubkey: String? = nil, options: EventViewOptions = []) {
+    init(damus: DamusState, event: NostrEvent, pubkey: Pubkey? = nil, options: EventViewOptions = []) {
         self.event = event
         self.options = options
         self.damus = damus
@@ -54,7 +54,7 @@ struct EventView: View {
 }
 
 // blame the porn bots for this code
-func should_show_images(settings: UserSettingsStore, contacts: Contacts, ev: NostrEvent, our_pubkey: String, booster_pubkey: String? = nil) -> Bool {
+func should_show_images(settings: UserSettingsStore, contacts: Contacts, ev: NostrEvent, our_pubkey: Pubkey, booster_pubkey: Pubkey? = nil) -> Bool {
     if settings.always_show_images {
         return true
     }
@@ -72,7 +72,7 @@ func should_show_images(settings: UserSettingsStore, contacts: Contacts, ev: Nos
 }
 
 extension View {
-    func pubkey_context_menu(bech32_pubkey: String) -> some View {
+    func pubkey_context_menu(bech32_pubkey: Pubkey) -> some View {
         return self.contextMenu {
             Button {
                     UIPasteboard.general.string = bech32_pubkey
@@ -96,7 +96,7 @@ func format_date(_ created_at: UInt32) -> String {
     return dateFormatter.string(from: date)
 }
 
-func make_actionbar_model(ev: String, damus: DamusState) -> ActionBarModel {
+func make_actionbar_model(ev: NoteId, damus: DamusState) -> ActionBarModel {
     let model = ActionBarModel.empty()
     model.update(damus: damus, evid: ev)
     return model

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -143,7 +143,7 @@ struct EventView_Previews: PreviewProvider {
             
              */
 
-            EventView( damus: test_damus_state(), event: test_event )
+            EventView( damus: test_damus_state(), event: test_note )
 
             EventView( damus: test_damus_state(), event: test_longform_event.event, options: [.wide] )
         }

--- a/damus/Views/Events/BuilderEventView.swift
+++ b/damus/Views/Events/BuilderEventView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct BuilderEventView: View {
     let damus: DamusState
-    let event_id: String
+    let event_id: NoteId
     @State var event: NostrEvent?
     @State var subscription_uuid: String = UUID().description
     
@@ -19,7 +19,7 @@ struct BuilderEventView: View {
         self.event_id = event.id
     }
     
-    init(damus: DamusState, event_id: String) {
+    init(damus: DamusState, event_id: NoteId) {
         let event = damus.events.lookup(event_id)
         self.event_id = event_id
         self.damus = damus

--- a/damus/Views/Events/BuilderEventView.swift
+++ b/damus/Views/Events/BuilderEventView.swift
@@ -93,7 +93,7 @@ struct BuilderEventView: View {
 
 struct BuilderEventView_Previews: PreviewProvider {
     static var previews: some View {
-        BuilderEventView(damus: test_damus_state(), event_id: "536bee9e83c818e3b82c101935128ae27a0d4290039aaf253efe5f09232c1962")
+        BuilderEventView(damus: test_damus_state(), event_id: test_note.id)
     }
 }
 

--- a/damus/Views/Events/Components/EventTop.swift
+++ b/damus/Views/Events/Components/EventTop.swift
@@ -10,10 +10,10 @@ import SwiftUI
 struct EventTop: View {
     let state: DamusState
     let event: NostrEvent
-    let pubkey: String
+    let pubkey: Pubkey
     let is_anon: Bool
     
-    init(state: DamusState, event: NostrEvent, pubkey: String, is_anon: Bool) {
+    init(state: DamusState, event: NostrEvent, pubkey: Pubkey, is_anon: Bool) {
         self.state = state
         self.event = event
         self.pubkey = pubkey

--- a/damus/Views/Events/Components/EventTop.swift
+++ b/damus/Views/Events/Components/EventTop.swift
@@ -41,6 +41,6 @@ struct EventTop: View {
 
 struct EventTop_Previews: PreviewProvider {
     static var previews: some View {
-        EventTop(state: test_damus_state(), event: test_event, pubkey: test_event.pubkey, is_anon: false)
+        EventTop(state: test_damus_state(), event: test_note, pubkey: test_note.pubkey, is_anon: false)
     }
 }

--- a/damus/Views/Events/Components/ReplyDescription.swift
+++ b/damus/Views/Events/Components/ReplyDescription.swift
@@ -22,7 +22,7 @@ struct ReplyDescription: View {
 
 struct ReplyDescription_Previews: PreviewProvider {
     static var previews: some View {
-        ReplyDescription(event: test_event, profiles: test_damus_state().profiles)
+        ReplyDescription(event: test_note, profiles: test_damus_state().profiles)
     }
 }
 

--- a/damus/Views/Events/Components/ReplyPart.swift
+++ b/damus/Views/Events/Components/ReplyPart.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ReplyPart: View {
     let event: NostrEvent
-    let privkey: String?
+    let privkey: Privkey?
     let profiles: Profiles
     
     var body: some View {

--- a/damus/Views/Events/Components/ReplyPart.swift
+++ b/damus/Views/Events/Components/ReplyPart.swift
@@ -25,6 +25,6 @@ struct ReplyPart: View {
 
 struct ReplyPart_Previews: PreviewProvider {
     static var previews: some View {
-        ReplyPart(event: test_event, privkey: nil, profiles: test_damus_state().profiles)
+        ReplyPart(event: test_note, privkey: nil, profiles: test_damus_state().profiles)
     }
 }

--- a/damus/Views/Events/EventBody.swift
+++ b/damus/Views/Events/EventBody.swift
@@ -43,6 +43,6 @@ struct EventBody: View {
 
 struct EventBody_Previews: PreviewProvider {
     static var previews: some View {
-        EventBody(damus_state: test_damus_state(), event: test_event, size: .normal, options: [])
+        EventBody(damus_state: test_damus_state(), event: test_note, size: .normal, options: [])
     }
 }

--- a/damus/Views/Events/EventMenu.swift
+++ b/damus/Views/Events/EventMenu.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct EventMenuContext: View {
     let event: NostrEvent
     let keypair: Keypair
-    let target_pubkey: String
+    let target_pubkey: Pubkey
     let bookmarks: BookmarksManager
     let muted_threads: MutedThreadsManager
     @ObservedObject var settings: UserSettingsStore
@@ -44,7 +44,7 @@ struct EventMenuContext: View {
 struct MenuItems: View {
     let event: NostrEvent
     let keypair: Keypair
-    let target_pubkey: String
+    let target_pubkey: Pubkey
     let bookmarks: BookmarksManager
     let muted_threads: MutedThreadsManager
     @ObservedObject var settings: UserSettingsStore
@@ -52,7 +52,7 @@ struct MenuItems: View {
     @State private var isBookmarked: Bool = false
     @State private var isMutedThread: Bool = false
     
-    init(event: NostrEvent, keypair: Keypair, target_pubkey: String, bookmarks: BookmarksManager, muted_threads: MutedThreadsManager, settings: UserSettingsStore) {
+    init(event: NostrEvent, keypair: Keypair, target_pubkey: Pubkey, bookmarks: BookmarksManager, muted_threads: MutedThreadsManager, settings: UserSettingsStore) {
         let bookmarked = bookmarks.isBookmarked(event)
         self._isBookmarked = State(initialValue: bookmarked)
 

--- a/damus/Views/Events/EventProfile.swift
+++ b/damus/Views/Events/EventProfile.swift
@@ -51,6 +51,6 @@ struct EventProfile: View {
 
 struct EventProfile_Previews: PreviewProvider {
     static var previews: some View {
-        EventProfile(damus_state: test_damus_state(), pubkey: "pk", profile: nil, size: .normal)
+        EventProfile(damus_state: test_damus_state(), pubkey: test_note.pubkey, profile: nil, size: .normal)
     }
 }

--- a/damus/Views/Events/EventProfile.swift
+++ b/damus/Views/Events/EventProfile.swift
@@ -24,7 +24,7 @@ func eventview_pfp_size(_ size: EventViewKind) -> CGFloat {
 
 struct EventProfile: View {
     let damus_state: DamusState
-    let pubkey: String
+    let pubkey: Pubkey
     let profile: Profile?
     let size: EventViewKind
     

--- a/damus/Views/Events/EventShell.swift
+++ b/damus/Views/Events/EventShell.swift
@@ -10,11 +10,11 @@ import SwiftUI
 struct EventShell<Content: View>: View {
     let state: DamusState
     let event: NostrEvent
-    let pubkey: String
+    let pubkey: Pubkey
     let options: EventViewOptions
     let content: Content
     
-    init(state: DamusState, event: NostrEvent, pubkey: String, options: EventViewOptions, @ViewBuilder content: () -> Content) {
+    init(state: DamusState, event: NostrEvent, pubkey: Pubkey, options: EventViewOptions, @ViewBuilder content: () -> Content) {
         self.state = state
         self.event = event
         self.options = options

--- a/damus/Views/Events/EventShell.swift
+++ b/damus/Views/Events/EventShell.swift
@@ -133,11 +133,11 @@ struct EventShell_Previews: PreviewProvider {
 
     static var previews: some View {
         VStack {
-            EventShell(state: test_damus_state(), event: test_event, options: [.no_action_bar]) {
+            EventShell(state: test_damus_state(), event: test_note, options: [.no_action_bar]) {
                 Text(verbatim: "Hello")
             }
 
-            EventShell(state: test_damus_state(), event: test_event, options: [.no_action_bar, .wide]) {
+            EventShell(state: test_damus_state(), event: test_note, options: [.no_action_bar, .wide]) {
                 Text(verbatim: "Hello")
             }
         }

--- a/damus/Views/Events/MutedEventView.swift
+++ b/damus/Views/Events/MutedEventView.swift
@@ -77,7 +77,7 @@ struct MutedEventView_Previews: PreviewProvider {
     
     static var previews: some View {
         
-        MutedEventView(damus_state: test_damus_state(), event: test_event, selected: false)
+        MutedEventView(damus_state: test_damus_state(), event: test_note, selected: false)
             .frame(width: .infinity, height: 50)
     }
 }

--- a/damus/Views/Events/SelectedEventView.swift
+++ b/damus/Views/Events/SelectedEventView.swift
@@ -12,7 +12,7 @@ struct SelectedEventView: View {
     let event: NostrEvent
     let size: EventViewKind
     
-    var pubkey: String {
+    var pubkey: Pubkey {
         event.pubkey
     }
     

--- a/damus/Views/Events/SelectedEventView.swift
+++ b/damus/Views/Events/SelectedEventView.swift
@@ -86,6 +86,6 @@ struct SelectedEventView: View {
 
 struct SelectedEventView_Previews: PreviewProvider {
     static var previews: some View {
-        SelectedEventView(damus: test_damus_state(), event: test_event, size: .selected)
+        SelectedEventView(damus: test_damus_state(), event: test_note, size: .selected)
     }
 }

--- a/damus/Views/Events/TextEvent.swift
+++ b/damus/Views/Events/TextEvent.swift
@@ -75,10 +75,10 @@ func event_is_anonymous(ev: NostrEvent) -> Bool {
 struct TextEvent_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 20) {
-            TextEvent(damus: test_damus_state(), event: test_event, pubkey: "pk", options: [])
+            TextEvent(damus: test_damus_state(), event: test_note, pubkey: test_pubkey, options: [])
                 .frame(height: 400)
             
-            TextEvent(damus: test_damus_state(), event: test_event, pubkey: "pk", options: [.wide])
+            TextEvent(damus: test_damus_state(), event: test_note, pubkey: test_pubkey, options: [.wide])
                 .frame(height: 400)
         }
     }

--- a/damus/Views/Events/TextEvent.swift
+++ b/damus/Views/Events/TextEvent.swift
@@ -26,11 +26,11 @@ struct EventViewOptions: OptionSet {
 struct TextEvent: View {
     let damus: DamusState
     let event: NostrEvent
-    let pubkey: String
+    let pubkey: Pubkey
     let options: EventViewOptions
     let evdata: EventData
     
-    init(damus: DamusState, event: NostrEvent, pubkey: String, options: EventViewOptions) {
+    init(damus: DamusState, event: NostrEvent, pubkey: Pubkey, options: EventViewOptions) {
         self.damus = damus
         self.event = event
         self.pubkey = pubkey

--- a/damus/Views/Events/WideEventView.swift
+++ b/damus/Views/Events/WideEventView.swift
@@ -17,6 +17,6 @@ struct WideEventView: View {
 
 struct WideEventView_Previews: PreviewProvider {
     static var previews: some View {
-        WideEventView(event: test_event)
+        WideEventView(event: test_note)
     }
 }

--- a/damus/Views/FollowingView.swift
+++ b/damus/Views/FollowingView.swift
@@ -26,7 +26,7 @@ struct FollowUserView: View {
 
 struct FollowersYouKnowView: View {
     let damus_state: DamusState
-    let friended_followers: [String]
+    let friended_followers: [Pubkey]
     @ObservedObject var followers: FollowersModel
 
     var body: some View {

--- a/damus/Views/ImagePicker.swift
+++ b/damus/Views/ImagePicker.swift
@@ -15,7 +15,7 @@ struct ImagePicker: UIViewControllerRepresentable {
 
     let uploader: MediaUploader
     let sourceType: UIImagePickerController.SourceType
-    let pubkey: String
+    let pubkey: Pubkey
     @Binding var image_upload_confirm: Bool
     var imagesOnly: Bool = false
     let onImagePicked: (URL) -> Void

--- a/damus/Views/Images/ProfilePicImageView.swift
+++ b/damus/Views/Images/ProfilePicImageView.swift
@@ -62,7 +62,7 @@ struct NavDismissBarView: View {
 }
 
 struct ProfilePicImageView: View {
-    let pubkey: String
+    let pubkey: Pubkey
     let profiles: Profiles
     let disable_animation: Bool
     
@@ -90,12 +90,10 @@ struct ProfilePicImageView: View {
 }
 
 struct ProfileZoomView_Previews: PreviewProvider {
-    static let pubkey = "ca48854ac6555fed8e439ebb4fa2d928410e0eef13fa41164ec45aaaa132d846"
-    
     static var previews: some View {
         ProfilePicImageView(
-            pubkey: pubkey,
-            profiles: make_preview_profiles(pubkey),
+            pubkey: test_pubkey,
+            profiles: make_preview_profiles(test_pubkey),
             disable_animation: false
         )
     }

--- a/damus/Views/LoginView.swift
+++ b/damus/Views/LoginView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 enum ParsedKey {
-    case pub(String)
-    case priv(String)
+    case pub(Pubkey)
+    case priv(Privkey)
     case hex(String)
     case nip05(String)
 
@@ -203,7 +203,7 @@ func process_login(_ key: ParsedKey, is_pubkey: Bool) async throws {
         }
     }
     
-    func handle_privkey(_ privkey: String) throws {
+    func handle_privkey(_ privkey: Privkey) throws {
         try save_privkey(privkey: privkey)
         
         guard let pk = privkey_to_pubkey(privkey: privkey) else {
@@ -231,7 +231,7 @@ struct NIP05Result: Decodable {
 }
 
 struct NIP05User {
-    let pubkey: String
+    let pubkey: Pubkey
     let relays: [String]
 }
 

--- a/damus/Views/Muting/MutelistView.swift
+++ b/damus/Views/Muting/MutelistView.swift
@@ -68,6 +68,6 @@ func get_mutelist_users(_ mlist: NostrEvent?) -> [String] {
 
 struct MutelistView_Previews: PreviewProvider {
     static var previews: some View {
-        MutelistView(damus_state: test_damus_state(), users: [test_event.pubkey, test_event.pubkey+"hi"])
+        MutelistView(damus_state: test_damus_state(), users: [test_note.pubkey, test_note.pubkey])
     }
 }

--- a/damus/Views/Muting/MutelistView.swift
+++ b/damus/Views/Muting/MutelistView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 struct MutelistView: View {
     let damus_state: DamusState
-    @State var users: [String]
+    @State var users: [Pubkey]
     
-    func RemoveAction(pubkey: String) -> some View {
+    func RemoveAction(pubkey: Pubkey) -> some View {
         Button {
             guard let mutelist = damus_state.contacts.mutelist else {
                 return

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -601,7 +601,7 @@ struct NoteContentView_Previews: PreviewProvider {
         let state = test_damus_state()
 
         VStack {
-            NoteContentView(damus_state: state, event: test_event, show_images: true, size: .normal, options: [])
+            NoteContentView(damus_state: state, event: test_note, show_images: true, size: .normal, options: [])
 
             NoteContentView(damus_state: state, event: test_longform_event.event, show_images: true, size: .normal, options: [.wide])
                 .border(Color.red)

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -392,7 +392,7 @@ func note_artifact_is_separated(kind: NostrKind?) -> Bool {
     return kind != .longform
 }
 
-func render_note_content(ev: NostrEvent, profiles: Profiles, privkey: String?) -> NoteArtifacts {
+func render_note_content(ev: NostrEvent, profiles: Profiles, privkey: Privkey?) -> NoteArtifacts {
     let blocks = ev.blocks(privkey)
     
     if ev.known_kind == .longform {
@@ -574,7 +574,7 @@ func classify_url(_ url: URL) -> UrlType {
     return .link(url)
 }
 
-func lookup_cached_preview_size(previews: PreviewCache, evid: String) -> CGFloat? {
+func lookup_cached_preview_size(previews: PreviewCache, evid: NoteId) -> CGFloat? {
     guard case .value(let cached) = previews.lookup(evid) else {
         return nil
     }

--- a/damus/Views/Notifications/EventGroupView.swift
+++ b/damus/Views/Notifications/EventGroupView.swift
@@ -261,11 +261,11 @@ struct EventGroupView: View {
 struct EventGroupView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            EventGroupView(state: test_damus_state(), event: test_event, group: .repost(test_event_group))
+            EventGroupView(state: test_damus_state(), event: test_note, group: .repost(test_event_group))
                 .frame(height: 200)
                 .padding()
             
-            EventGroupView(state: test_damus_state(), event: test_event, group: .reaction(test_event_group))
+            EventGroupView(state: test_damus_state(), event: test_note, group: .reaction(test_event_group))
                 .frame(height: 200)
                 .padding()
         }

--- a/damus/Views/Notifications/EventGroupView.swift
+++ b/damus/Views/Notifications/EventGroupView.swift
@@ -56,7 +56,7 @@ enum ReactingTo {
     case your_profile
 }
 
-func determine_reacting_to(our_pubkey: String, ev: NostrEvent?) -> ReactingTo {
+func determine_reacting_to(our_pubkey: Pubkey, ev: NostrEvent?) -> ReactingTo {
     guard let ev else {
         return .your_profile
     }
@@ -68,21 +68,21 @@ func determine_reacting_to(our_pubkey: String, ev: NostrEvent?) -> ReactingTo {
     return .tagged_in
 }
 
-func event_author_name(profiles: Profiles, pubkey: String) -> String {
+func event_author_name(profiles: Profiles, pubkey: Pubkey) -> String {
     let alice_prof = profiles.lookup(id: pubkey)
     return Profile.displayName(profile: alice_prof, pubkey: pubkey).username.truncate(maxLength: 50)
 }
 
-func event_group_unique_pubkeys(profiles: Profiles, group: EventGroupType) -> [String] {
-    var seen = Set<String>()
-    var sorted = [String]()
+func event_group_unique_pubkeys(profiles: Profiles, group: EventGroupType) -> [Pubkey] {
+    var seen = Set<Pubkey>()
+    var sorted = [Pubkey]()
 
     if let zapgrp = group.zap_group {
         let zaps = zapgrp.zaps
 
         for i in 0..<zaps.count {
             let zap = zapgrp.zaps[i]
-            let pubkey: String
+            let pubkey: Pubkey
 
             if zap.is_anon {
                 pubkey = ANON_PUBKEY
@@ -148,7 +148,7 @@ func event_group_unique_pubkeys(profiles: Profiles, group: EventGroupType) -> [S
  "zapped_your_profile_2" - returned when 2 zaps occurred to the current user's profile
  "zapped_your_profile_3" - returned when 3 or more zaps occurred to the current user's profile
  */
-func reacting_to_text(profiles: Profiles, our_pubkey: String, group: EventGroupType, ev: NostrEvent?, pubkeys: [String], locale: Locale? = nil) -> String {
+func reacting_to_text(profiles: Profiles, our_pubkey: Pubkey, group: EventGroupType, ev: NostrEvent?, pubkeys: [Pubkey], locale: Locale? = nil) -> String {
     if group.events.count == 0 {
         return "??"
     }
@@ -192,7 +192,7 @@ struct EventGroupView: View {
     let event: NostrEvent?
     let group: EventGroupType
 
-    func GroupDescription(_ pubkeys: [String]) -> some View {
+    func GroupDescription(_ pubkeys: [Pubkey]) -> some View {
         Text(verbatim: "\(reacting_to_text(profiles: state.profiles, our_pubkey: state.pubkey, group: group, ev: event, pubkeys: pubkeys))")
     }
     

--- a/damus/Views/Notifications/NotificationItemView.swift
+++ b/damus/Views/Notifications/NotificationItemView.swift
@@ -84,7 +84,7 @@ struct NotificationItemView: View {
     }
 }
 
-let test_notification_item: NotificationItem = .repost("evid", test_event_group)
+let test_notification_item: NotificationItem = .repost(test_note.id, test_event_group)
 
 struct NotificationItemView_Previews: PreviewProvider {
     static var previews: some View {

--- a/damus/Views/Notifications/NotificationsView.swift
+++ b/damus/Views/Notifications/NotificationsView.swift
@@ -23,7 +23,7 @@ enum FriendFilter: String, StringCodable {
         self.rawValue
     }
     
-    func filter(contacts: Contacts, pubkey: String) -> Bool {
+    func filter(contacts: Contacts, pubkey: Pubkey) -> Bool {
         switch self {
         case .all:
             return true

--- a/damus/Views/Notifications/NotificationsView.swift
+++ b/damus/Views/Notifications/NotificationsView.swift
@@ -166,8 +166,9 @@ struct NotificationsView: View {
                     Color.white.opacity(0)
                         .id("startblock")
                         .frame(height: 5)
-                    ForEach(filter.filter(contacts: state.contacts, items: notifications.notifications), id: \.id) { item in
-                        NotificationItemView(state: state, item: item)
+                    let notifs = Array(zip(1..., filter.filter(contacts: state.contacts, items: notifications.notifications)))
+                    ForEach(notifs, id: \.0) { zip in
+                        NotificationItemView(state: state, item: zip.1)
                     }
                 }
                 .background(GeometryReader { proxy -> Color in

--- a/damus/Views/Notifications/ProfilePicturesView.swift
+++ b/damus/Views/Notifications/ProfilePicturesView.swift
@@ -25,6 +25,7 @@ struct ProfilePicturesView: View {
 
 struct ProfilePicturesView_Previews: PreviewProvider {
     static var previews: some View {
-        ProfilePicturesView(state: test_damus_state(), pubkeys: ["a", "b"])
+        let pubkey = test_note.pubkey
+        ProfilePicturesView(state: test_damus_state(), pubkeys: [pubkey, pubkey])
     }
 }

--- a/damus/Views/Notifications/ProfilePicturesView.swift
+++ b/damus/Views/Notifications/ProfilePicturesView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct ProfilePicturesView: View {
     let state: DamusState
-    let pubkeys: [String]
-    
+    let pubkeys: [Pubkey]
+
     var body: some View {
         HStack {
             ForEach(pubkeys.prefix(8), id: \.self) { pubkey in

--- a/damus/Views/Onboarding/SuggestedUserView.swift
+++ b/damus/Views/Onboarding/SuggestedUserView.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct SuggestedUser: Codable {
-    let pubkey: String
+    let pubkey: Pubkey
     let name: String
     let about: String
     let pfp: URL
     let profile: Profile
 
-    init?(profile: Profile, pubkey: String) {
+    init?(profile: Profile, pubkey: Pubkey) {
 
         guard let name = profile.name,
                 let about = profile.about,
@@ -64,7 +64,7 @@ struct SuggestedUserView_Previews: PreviewProvider {
     static var previews: some View {
         let profile = Profile(name: "klabo", about: "A person who likes nostr a lot and I like to tell people about myself in very long-winded ways that push the limits of UI and almost break things", picture: "https://primal.b-cdn.net/media-cache?s=m&a=1&u=https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2F1599994711430742017%2F33zLk9Wi_400x400.jpg")
 
-        let user = SuggestedUser(profile: profile, pubkey: "abcd")!
+        let user = SuggestedUser(profile: profile, pubkey: test_pubkey)!
         List {
             SuggestedUserView(user: user, damus_state: test_damus_state())
         }

--- a/damus/Views/Onboarding/SuggestedUsersViewModel.swift
+++ b/damus/Views/Onboarding/SuggestedUsersViewModel.swift
@@ -11,7 +11,7 @@ import Combine
 struct SuggestedUserGroup: Identifiable, Codable {
     let id = UUID()
     let title: String
-    let users: [String]
+    let users: [Pubkey]
 
     enum CodingKeys: String, CodingKey {
         case title, users
@@ -34,7 +34,7 @@ class SuggestedUsersViewModel: ObservableObject {
         subscribeToSuggestedProfiles(pubkeys: pubkeys)
     }
 
-    func suggestedUser(pubkey: String) -> SuggestedUser? {
+    func suggestedUser(pubkey: Pubkey) -> SuggestedUser? {
         if let profile = damus_state.profiles.lookup(id: pubkey),
            let user = SuggestedUser(profile: profile, pubkey: pubkey) {
             return user
@@ -42,7 +42,7 @@ class SuggestedUsersViewModel: ObservableObject {
         return nil
     }
 
-    func follow(pubkeys: [String]) {
+    func follow(pubkeys: [Pubkey]) {
         for pubkey in pubkeys {
             notify(.follow(.pubkey(pubkey)))
         }
@@ -66,17 +66,16 @@ class SuggestedUsersViewModel: ObservableObject {
         }
     }
 
-    private func getPubkeys(groups: [SuggestedUserGroup]) -> [String] {
-        var pubkeys: [String] = []
+    private func getPubkeys(groups: [SuggestedUserGroup]) -> [Pubkey] {
+        var pubkeys: [Pubkey] = []
         for group in groups {
             pubkeys.append(contentsOf: group.users)
         }
         return pubkeys
     }
 
-    private func subscribeToSuggestedProfiles(pubkeys: [String]) {
-        let filter = NostrFilter(kinds: [.metadata],
-                                 authors: pubkeys)
+    private func subscribeToSuggestedProfiles(pubkeys: [Pubkey]) {
+        let filter = NostrFilter(kinds: [.metadata], authors: pubkeys)
         damus_state.pool.subscribe(sub_id: sub_id, filters: [filter], handler: handle_event)
     }
 

--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -21,7 +21,7 @@ class TagModel: ObservableObject {
 
 enum PostTarget {
     case none
-    case user(String)
+    case user(Pubkey)
 }
 
 enum PostAction {

--- a/damus/Views/Posting/UserSearch.swift
+++ b/damus/Views/Posting/UserSearch.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 struct SearchedUser: Identifiable {
     let profile: Profile?
-    let pubkey: String
-    
-    var id: String {
+    let pubkey: Pubkey
+
+    var id: Pubkey {
         return pubkey
     }
 }
@@ -151,7 +151,7 @@ func append_user_tag(tag: NSAttributedString, post: NSMutableAttributedString, w
 }
 
 /// Generate a mention attributed string, including the internal damus:nostr: link
-func user_tag_attr_string(profile: Profile?, pubkey: String) -> NSMutableAttributedString {
+func user_tag_attr_string(profile: Profile?, pubkey: Pubkey) -> NSMutableAttributedString {
     let display_name = Profile.displayName(profile: profile, pubkey: pubkey)
     let name = display_name.username.truncate(maxLength: 50)
     let tagString = "@\(name)"

--- a/damus/Views/Profile/CondensedProfilePicturesView.swift
+++ b/damus/Views/Profile/CondensedProfilePicturesView.swift
@@ -9,10 +9,10 @@ import SwiftUI
 
 struct CondensedProfilePicturesView: View {
     let state: DamusState
-    let pubkeys: [String]
+    let pubkeys: [Pubkey]
     let maxPictures: Int
 
-    init(state: DamusState, pubkeys: [String], maxPictures: Int) {
+    init(state: DamusState, pubkeys: [Pubkey], maxPictures: Int) {
         self.state = state
         self.pubkeys = pubkeys
         self.maxPictures = min(maxPictures, pubkeys.count)
@@ -33,6 +33,6 @@ struct CondensedProfilePicturesView: View {
 
 struct CondensedProfilePicturesView_Previews: PreviewProvider {
     static var previews: some View {
-        CondensedProfilePicturesView(state: test_damus_state(), pubkeys: ["a", "b", "c", "d"], maxPictures: 3)
+        CondensedProfilePicturesView(state: test_damus_state(), pubkeys: [test_pubkey, test_pubkey, test_pubkey, test_pubkey], maxPictures: 3)
     }
 }

--- a/damus/Views/Profile/EditPictureControl.swift
+++ b/damus/Views/Profile/EditPictureControl.swift
@@ -13,7 +13,7 @@ class ImageUploadingObserver: ObservableObject {
 
 struct EditPictureControl: View {
     let uploader: MediaUploader
-    let pubkey: String
+    let pubkey: Pubkey
     @Binding var image_url: URL?
     @ObservedObject var uploadObserver: ImageUploadingObserver
     let callback: (URL?) -> Void
@@ -120,12 +120,11 @@ struct EditPictureControl: View {
 
 struct EditPictureControl_Previews: PreviewProvider {
     static var previews: some View {
-        let pubkey = "123"
         let url = Binding<URL?>.constant(URL(string: "https://damus.io")!)
         let observer = ImageUploadingObserver()
         ZStack {
             Color.gray
-            EditPictureControl(uploader: .nostrBuild, pubkey: pubkey, image_url: url, uploadObserver: observer) { _ in
+            EditPictureControl(uploader: .nostrBuild, pubkey: test_pubkey, image_url: url, uploadObserver: observer) { _ in
                 //
             }
         }

--- a/damus/Views/Profile/EventProfileName.swift
+++ b/damus/Views/Profile/EventProfileName.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /// Profile Name used when displaying an event in the timeline
 struct EventProfileName: View {
     let damus_state: DamusState
-    let pubkey: String
+    let pubkey: Pubkey
     let profile: Profile?
     
     @State var display_name: DisplayName?
@@ -19,7 +19,7 @@ struct EventProfileName: View {
     
     let size: EventViewKind
     
-    init(pubkey: String, profile: Profile?, damus: DamusState, size: EventViewKind = .normal) {
+    init(pubkey: Pubkey, profile: Profile?, damus: DamusState, size: EventViewKind = .normal) {
         self.damus_state = damus
         self.pubkey = pubkey
         self.profile = profile

--- a/damus/Views/Profile/EventProfileName.swift
+++ b/damus/Views/Profile/EventProfileName.swift
@@ -106,6 +106,6 @@ struct EventProfileName: View {
 
 struct EventProfileName_Previews: PreviewProvider {
     static var previews: some View {
-        EventProfileName(pubkey: "pk", profile: nil, damus: test_damus_state())
+        EventProfileName(pubkey: test_note.pubkey, profile: nil, damus: test_damus_state())
     }
 }

--- a/damus/Views/Profile/MaybeAnonPfpView.swift
+++ b/damus/Views/Profile/MaybeAnonPfpView.swift
@@ -10,10 +10,10 @@ import SwiftUI
 struct MaybeAnonPfpView: View {
     let state: DamusState
     let is_anon: Bool
-    let pubkey: String
+    let pubkey: Pubkey
     let size: CGFloat
     
-    init(state: DamusState, is_anon: Bool, pubkey: String, size: CGFloat) {
+    init(state: DamusState, is_anon: Bool, pubkey: Pubkey, size: CGFloat) {
         self.state = state
         self.is_anon = is_anon
         self.pubkey = pubkey

--- a/damus/Views/Profile/ProfileName.swift
+++ b/damus/Views/Profile/ProfileName.swift
@@ -12,7 +12,7 @@ enum FriendType {
     case fof
 }
 
-func get_friend_type(contacts: Contacts, pubkey: String) -> FriendType? {
+func get_friend_type(contacts: Contacts, pubkey: Pubkey) -> FriendType? {
     if contacts.is_friend_or_self(pubkey) {
         return .friend
     }
@@ -26,7 +26,7 @@ func get_friend_type(contacts: Contacts, pubkey: String) -> FriendType? {
 
 struct ProfileName: View {
     let damus_state: DamusState
-    let pubkey: String
+    let pubkey: Pubkey
     let profile: Profile?
     let prefix: String
     
@@ -36,7 +36,7 @@ struct ProfileName: View {
     @State var nip05: NIP05?
     @State var donation: Int?
     
-    init(pubkey: String, profile: Profile?, prefix: String = "", damus: DamusState, show_nip5_domain: Bool = true) {
+    init(pubkey: Pubkey, profile: Profile?, prefix: String = "", damus: DamusState, show_nip5_domain: Bool = true) {
         self.pubkey = pubkey
         self.profile = profile
         self.prefix = prefix

--- a/damus/Views/Profile/ProfileNameView.swift
+++ b/damus/Views/Profile/ProfileNameView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ProfileNameView: View {
-    let pubkey: String
+    let pubkey: Pubkey
     let profile: Profile?
     let follows_you: Bool
     let damus: DamusState

--- a/damus/Views/Profile/ProfileNameView.swift
+++ b/damus/Views/Profile/ProfileNameView.swift
@@ -54,9 +54,9 @@ struct ProfileNameView: View {
 struct ProfileNameView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            ProfileNameView(pubkey: test_event.pubkey, profile: nil, follows_you: true, damus: test_damus_state())
-            
-            ProfileNameView(pubkey: test_event.pubkey, profile: nil, follows_you: false, damus: test_damus_state())
+            ProfileNameView(pubkey: test_note.pubkey, profile: nil, follows_you: true, damus: test_damus_state())
+
+            ProfileNameView(pubkey: test_note.pubkey, profile: nil, follows_you: false, damus: test_damus_state())
         }
     }
 }

--- a/damus/Views/Profile/ProfilePicView.swift
+++ b/damus/Views/Profile/ProfilePicView.swift
@@ -106,19 +106,19 @@ func get_profile_url(picture: String?, pubkey: String, profiles: Profiles) -> UR
     return URL(string: robohash(pubkey))!
 }
 
-func make_preview_profiles(_ pubkey: String) -> Profiles {
+func make_preview_profiles(_ pubkey: Pubkey) -> Profiles {
     let user_search_cache = UserSearchCache()
     let profiles = Profiles(user_search_cache: user_search_cache)
     let picture = "http://cdn.jb55.com/img/red-me.jpg"
     let profile = Profile(name: "jb55", display_name: "William Casarin", about: "It's me", picture: picture, banner: "", website: "https://jb55.com", lud06: nil, lud16: nil, nip05: "jb55.com", damus_donation: nil)
-    let ts_profile = TimestampedProfile(profile: profile, timestamp: 0, event: test_event)
+    let ts_profile = TimestampedProfile(profile: profile, timestamp: 0, event: test_note)
     profiles.add(id: pubkey, profile: ts_profile)
     return profiles
 }
 
 struct ProfilePicView_Previews: PreviewProvider {
-    static let pubkey = "ca48854ac6555fed8e439ebb4fa2d928410e0eef13fa41164ec45aaaa132d846"
-    
+    static let pubkey = test_note.pubkey
+
     static var previews: some View {
         ProfilePicView(
             pubkey: pubkey,

--- a/damus/Views/Profile/ProfilePicView.swift
+++ b/damus/Views/Profile/ProfilePicView.swift
@@ -31,7 +31,7 @@ func pfp_line_width(_ h: Highlight) -> CGFloat {
 struct InnerProfilePicView: View {
     let url: URL?
     let fallbackUrl: URL?
-    let pubkey: String
+    let pubkey: Pubkey
     let size: CGFloat
     let highlight: Highlight
     let disable_animation: Bool
@@ -67,7 +67,7 @@ struct InnerProfilePicView: View {
 }
 
 struct ProfilePicView: View {
-    let pubkey: String
+    let pubkey: Pubkey
     let size: CGFloat
     let highlight: Highlight
     let profiles: Profiles
@@ -75,7 +75,7 @@ struct ProfilePicView: View {
     
     @State var picture: String?
     
-    init(pubkey: String, size: CGFloat, highlight: Highlight, profiles: Profiles, disable_animation: Bool, picture: String? = nil) {
+    init(pubkey: Pubkey, size: CGFloat, highlight: Highlight, profiles: Profiles, disable_animation: Bool, picture: String? = nil) {
         self.pubkey = pubkey
         self.profiles = profiles
         self.size = size
@@ -98,7 +98,7 @@ struct ProfilePicView: View {
     }
 }
 
-func get_profile_url(picture: String?, pubkey: String, profiles: Profiles) -> URL {
+func get_profile_url(picture: String?, pubkey: Pubkey, profiles: Profiles) -> URL {
     let pic = picture ?? profiles.lookup(id: pubkey)?.picture ?? robohash(pubkey)
     if let url = URL(string: pic) {
         return url

--- a/damus/Views/Profile/ProfilePictureSelector.swift
+++ b/damus/Views/Profile/ProfilePictureSelector.swift
@@ -13,7 +13,7 @@ struct EditProfilePictureView: View {
     
     @State var profile_url: URL?
     
-    let pubkey: String
+    let pubkey: Pubkey
     var damus_state: DamusState?
     var size: CGFloat = 80.0
     let highlight: Highlight = .custom(Color.white, 2.0)
@@ -52,7 +52,6 @@ struct EditProfilePictureView: View {
 
 struct ProfilePictureSelector_Previews: PreviewProvider {
     static var previews: some View {
-        let test_pubkey = "ff48854ac6555fed8e439ebb4fa2d928410e0eef13fa41164ec45aaaa132d846"
         EditProfilePictureView(pubkey: test_pubkey, uploadObserver: ImageUploadingObserver()) { _ in
             //
         }

--- a/damus/Views/Profile/ProfileView.swift
+++ b/damus/Views/Profile/ProfileView.swift
@@ -31,7 +31,7 @@ func follow_btn_txt(_ fs: FollowState, follows_you: Bool) -> String {
     }
 }
 
-func followedByString(_ friend_intersection: [String], profiles: Profiles, locale: Locale = Locale.current) -> String {
+func followedByString(_ friend_intersection: [Pubkey], profiles: Profiles, locale: Locale = Locale.current) -> String {
     let bundle = bundleForLocale(locale: locale)
     let names: [String] = friend_intersection.prefix(3).map {
         let profile = profiles.lookup(id: $0)
@@ -90,7 +90,7 @@ struct ProfileView: View {
         self._followers = StateObject(wrappedValue: followers)
     }
 
-    init(damus_state: DamusState, pubkey: String) {
+    init(damus_state: DamusState, pubkey: Pubkey) {
         self.damus_state = damus_state
         self._profile = StateObject(wrappedValue: ProfileModel(pubkey: pubkey, damus: damus_state))
         self._followers = StateObject(wrappedValue: FollowersModel(damus_state: damus_state, target: pubkey))
@@ -493,7 +493,7 @@ struct ProfileView_Previews: PreviewProvider {
 }
 
 struct KeyView: View {
-    let pubkey: String
+    let pubkey: Pubkey
 
     @Environment(\.colorScheme) var colorScheme
 
@@ -566,7 +566,7 @@ extension View {
     }
 }
 
-func check_nip05_validity(pubkey: String, profiles: Profiles) {
+func check_nip05_validity(pubkey: Pubkey, profiles: Profiles) {
     guard let profile = profiles.lookup(id: pubkey),
           let nip05 = profile.nip05,
           profiles.is_validated(pubkey) == nil

--- a/damus/Views/QRCodeView.swift
+++ b/damus/Views/QRCodeView.swift
@@ -297,7 +297,7 @@ struct QRCodeView: View {
 
 struct QRCodeView_Previews: PreviewProvider {
     static var previews: some View {
-        QRCodeView(damus_state: test_damus_state(), pubkey: test_event.pubkey)
+        QRCodeView(damus_state: test_damus_state(), pubkey: test_note.pubkey)
     }
 }
 

--- a/damus/Views/QRCodeView.swift
+++ b/damus/Views/QRCodeView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import CoreImage.CIFilterBuiltins
 
 struct ProfileScanResult: Equatable {
-    let pubkey: String
+    let pubkey: Pubkey
     
     init(hex: String) {
         self.pubkey = hex
@@ -42,7 +42,7 @@ struct ProfileScanResult: Equatable {
 
 struct QRCodeView: View {
     let damus_state: DamusState
-    @State var pubkey: String
+    @State var pubkey: Pubkey
     
     @Environment(\.presentationMode) var presentationMode
     

--- a/damus/Views/ReactionsView.swift
+++ b/damus/Views/ReactionsView.swift
@@ -38,6 +38,6 @@ struct ReactionsView: View {
 struct ReactionsView_Previews: PreviewProvider {
     static var previews: some View {
         let state = test_damus_state()
-        ReactionsView(damus_state: state, model: ReactionsModel(state: state, target: "pubkey"))
+        ReactionsView(damus_state: state, model: ReactionsModel(state: state, target: test_note.id))
     }
 }

--- a/damus/Views/ReplyView.swift
+++ b/damus/Views/ReplyView.swift
@@ -81,7 +81,7 @@ struct ReplyView: View {
 struct ReplyView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
-            ReplyView(replying_to: test_event, damus: test_damus_state(), originalReferences: .constant([]), references: .constant([]))
+            ReplyView(replying_to: test_note, damus: test_damus_state(), originalReferences: .constant([]), references: .constant([]))
                 .frame(height: 300)
 
             ReplyView(replying_to: test_longform_event.event, damus: test_damus_state(), originalReferences: .constant([]), references: .constant([]))

--- a/damus/Views/Reposts/RepostedEvent.swift
+++ b/damus/Views/Reposts/RepostedEvent.swift
@@ -31,6 +31,6 @@ struct RepostedEvent: View {
 
 struct RepostedEvent_Previews: PreviewProvider {
     static var previews: some View {
-        RepostedEvent(damus: test_damus_state(), event: test_event, inner_ev: test_event, options: [])
+        RepostedEvent(damus: test_damus_state(), event: test_note, inner_ev: test_note, options: [])
     }
 }

--- a/damus/Views/RepostsView.swift
+++ b/damus/Views/RepostsView.swift
@@ -33,6 +33,6 @@ struct RepostsView: View {
 struct RepostsView_Previews: PreviewProvider {
     static var previews: some View {
         let state = test_damus_state()
-        RepostsView(damus_state: state, model: RepostsModel(state: state, target: "pubkey"))
+        RepostsView(damus_state: state, model: RepostsModel(state: state, target: test_note.id))
     }
 }

--- a/damus/Views/Search/SearchingEventView.swift
+++ b/damus/Views/Search/SearchingEventView.swift
@@ -125,6 +125,6 @@ struct SearchingEventView: View {
 struct SearchingEventView_Previews: PreviewProvider {
     static var previews: some View {
         let state = test_damus_state()
-        SearchingEventView(state: state, evid: test_event.id, search_type: .event)
+        SearchingEventView(state: state, evid: test_note.id, search_type: .event)
     }
 }

--- a/damus/Views/Search/SearchingEventView.swift
+++ b/damus/Views/Search/SearchingEventView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 enum SearchState {
     case searching
     case found(NostrEvent)
-    case found_profile(String)
+    case found_profile(Pubkey)
     case not_found
 }
 

--- a/damus/Views/SearchResultsView.swift
+++ b/damus/Views/SearchResultsView.swift
@@ -15,8 +15,8 @@ struct MultiSearch {
 enum Search: Identifiable {
     case profiles([SearchedUser])
     case hashtag(String)
-    case profile(String)
-    case note(String)
+    case profile(Pubkey)
+    case note(NoteId)
     case nip05(String)
     case hex(String)
     case multi(MultiSearch)
@@ -38,7 +38,7 @@ struct InnerSearchResults: View {
     let damus_state: DamusState
     let search: Search?
     
-    func ProfileSearchResult(pk: String) -> some View {
+    func ProfileSearchResult(pk: Pubkey) -> some View {
         FollowUserView(target: .pubkey(pk), damus_state: damus_state)
     }
     

--- a/damus/Views/SelectWalletView.swift
+++ b/damus/Views/SelectWalletView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct SelectWalletView: View {
     let default_wallet: Wallet
     @Binding var active_sheet: Sheets?
-    let our_pubkey: String
+    let our_pubkey: Pubkey
     let invoice: String
     @State var invoice_copied: Bool = false
     
@@ -71,6 +71,6 @@ struct SelectWalletView_Previews: PreviewProvider {
     @State static var active_sheet: Sheets? = nil
     
     static var previews: some View {
-        SelectWalletView(default_wallet: .lnlink, active_sheet: $active_sheet, our_pubkey: "", invoice: "")
+        SelectWalletView(default_wallet: .lnlink, active_sheet: $active_sheet, our_pubkey: test_pubkey, invoice: "")
     }
 }

--- a/damus/Views/ThreadView.swift
+++ b/damus/Views/ThreadView.swift
@@ -104,7 +104,7 @@ struct ThreadView: View {
 struct ThreadView_Previews: PreviewProvider {
     static var previews: some View {
         let state = test_damus_state()
-        let thread = ThreadModel(event: test_event, damus_state: state)
+        let thread = ThreadModel(event: test_note, damus_state: state)
         ThreadView(state: state, thread: thread)
     }
 }

--- a/damus/Views/Zaps/CustomizeZapView.swift
+++ b/damus/Views/Zaps/CustomizeZapView.swift
@@ -302,7 +302,7 @@ extension View {
 
 struct CustomizeZapView_Previews: PreviewProvider {
     static var previews: some View {
-        CustomizeZapView(state: test_damus_state(), target: ZapTarget.note(id: test_event.id, author: test_event.pubkey), lnurl: "")
+        CustomizeZapView(state: test_damus_state(), target: ZapTarget.note(id: test_note.id, author: test_note.pubkey), lnurl: "")
             .frame(width: 400, height: 600)
     }
 }

--- a/damus/Views/Zaps/ZapTypePicker.swift
+++ b/damus/Views/Zaps/ZapTypePicker.swift
@@ -31,7 +31,7 @@ struct ZapTypePicker: View {
     @Binding var zap_type: ZapType
     @ObservedObject var settings: UserSettingsStore
     let profiles: Profiles
-    let pubkey: String
+    let pubkey: Pubkey
     
     @Environment(\.colorScheme) var colorScheme
     
@@ -106,11 +106,11 @@ struct ZapTypePicker_Previews: PreviewProvider {
     @State static var zap_type: ZapType = .pub
     static var previews: some View {
         let ds = test_damus_state()
-        ZapTypePicker(zap_type: $zap_type, settings: ds.settings, profiles: ds.profiles, pubkey: "bob")
+        ZapTypePicker(zap_type: $zap_type, settings: ds.settings, profiles: ds.profiles, pubkey: test_pubkey)
     }
 }
 
-func zap_type_desc(type: ZapType, profiles: Profiles, pubkey: String) -> String {
+func zap_type_desc(type: ZapType, profiles: Profiles, pubkey: Pubkey) -> String {
     switch type {
     case .pub:
         return NSLocalizedString("Everyone will see that you zapped", comment: "Description of public zap type where the zap is sent publicly and identifies the user who sent it.")

--- a/damus/Views/Zaps/ZapUserView.swift
+++ b/damus/Views/Zaps/ZapUserView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct ZapUserView: View {
     let state: DamusState
-    let pubkey: String
-    
+    let pubkey: Pubkey
+
     var body: some View {
         HStack(alignment: .center) {
             Text("Zap")

--- a/damusTests/DMTests.swift
+++ b/damusTests/DMTests.swift
@@ -48,55 +48,56 @@ final class DMTests: XCTestCase {
         let now = UInt32(Date().timeIntervalSince1970)
 
         let alice_to_bob = create_dm("hi bob", to_pk: bob.pubkey, tags: [["p", bob.pubkey]], keypair: alice, created_at: now)!
-        handle_incoming_dms(prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [alice_to_bob])
-        
+        let debouncer = Debouncer(interval: 3.0)
+        handle_incoming_dms(debouncer: debouncer, prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [alice_to_bob])
+
         XCTAssertEqual(model.dms.count, 1)
         XCTAssertEqual(model.dms[0].pubkey, bob.pubkey)
 
         let bob_to_alice = create_dm("hi alice", to_pk: alice.pubkey, tags: [["p", alice.pubkey]], keypair: bob, created_at: now + 1)!
-        handle_incoming_dms(prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [bob_to_alice])
-        
+        handle_incoming_dms(debouncer: debouncer, prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [bob_to_alice])
+
         XCTAssertEqual(model.dms.count, 1)
         XCTAssertEqual(model.dms[0].pubkey, bob.pubkey)
         
         let alice_to_bob_2 = create_dm("hi bob", to_pk: bob.pubkey, tags: [["p", bob.pubkey]], keypair: alice, created_at: now + 2)!
-        handle_incoming_dms(prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [alice_to_bob_2])
-        
+        handle_incoming_dms(debouncer: debouncer, prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [alice_to_bob_2])
+
         XCTAssertEqual(model.dms.count, 1)
         XCTAssertEqual(model.dms[0].pubkey, bob.pubkey)
         
         let fiatjaf_to_alice = create_dm("hi alice", to_pk: alice.pubkey, tags: [["p", alice.pubkey]], keypair: fiatjaf, created_at: now+5)!
-        handle_incoming_dms(prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [fiatjaf_to_alice])
-        
+        handle_incoming_dms(debouncer: debouncer, prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [fiatjaf_to_alice])
+
         XCTAssertEqual(model.dms.count, 2)
         XCTAssertEqual(model.dms[0].pubkey, fiatjaf.pubkey)
         
         let dave_to_alice = create_dm("hi alice", to_pk: alice.pubkey, tags: [["p", alice.pubkey]], keypair: dave, created_at: now + 10)!
-        handle_incoming_dms(prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [dave_to_alice])
+        handle_incoming_dms(debouncer: debouncer, prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [dave_to_alice])
 
         XCTAssertEqual(model.dms.count, 3)
         XCTAssertEqual(model.dms[0].pubkey, dave.pubkey)
 
         let bob_to_alice_2 = create_dm("hi alice 2", to_pk: alice.pubkey, tags: [["p", alice.pubkey]], keypair: bob, created_at: now + 15)!
-        handle_incoming_dms(prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [bob_to_alice_2])
+        handle_incoming_dms(debouncer: debouncer, prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [bob_to_alice_2])
 
         XCTAssertEqual(model.dms.count, 3)
         XCTAssertEqual(model.dms[0].pubkey, bob.pubkey)
 
         let charlie_to_alice = create_dm("hi alice", to_pk: alice.pubkey, tags: [["p", alice.pubkey]], keypair: charlie, created_at: now + 20)!
-        handle_incoming_dms(prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [charlie_to_alice])
+        handle_incoming_dms(debouncer: debouncer, prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [charlie_to_alice])
 
         XCTAssertEqual(model.dms.count, 4)
         XCTAssertEqual(model.dms[0].pubkey, charlie.pubkey)
 
         let bob_to_alice_3 = create_dm("hi alice 3", to_pk: alice.pubkey, tags: [["p", alice.pubkey]], keypair: bob, created_at: now + 25)!
-        handle_incoming_dms(prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [bob_to_alice_3])
+        handle_incoming_dms(debouncer: debouncer, prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [bob_to_alice_3])
 
         XCTAssertEqual(model.dms.count, 4)
         XCTAssertEqual(model.dms[0].pubkey, bob.pubkey)
 
         let charlie_to_alice_2 = create_dm("hi alice 2", to_pk: alice.pubkey, tags: [["p", alice.pubkey]], keypair: charlie, created_at: now + 30)!
-        handle_incoming_dms(prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [charlie_to_alice_2])
+        handle_incoming_dms(debouncer: debouncer, prev_events: notif, dms: model, our_pubkey: alice.pubkey, evs: [charlie_to_alice_2])
 
         XCTAssertEqual(model.dms.count, 4)
         XCTAssertEqual(model.dms[0].pubkey, charlie.pubkey)

--- a/damusTests/EventGroupViewTests.swift
+++ b/damusTests/EventGroupViewTests.swift
@@ -56,16 +56,16 @@ final class EventGroupViewTests: XCTestCase {
         let repost2 = NostrEvent(content: encodedPost, keypair: pk2, kind: NostrKind.boost.rawValue, tags: [], createdAt: 1)!
         let repost3 = NostrEvent(content: encodedPost, keypair: pk3, kind: NostrKind.boost.rawValue, tags: [], createdAt: 1)!
 
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_event, pubkeys: [], locale: enUsLocale), "??")
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_event, pubkeys: [pk1.pubkey], locale: enUsLocale), "pk1:pk1 reposted a note you were tagged in")
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_event, pubkeys: [pk1.pubkey, pk2.pubkey], locale: enUsLocale), "pk1:pk1 and pk2:pk2 reposted a note you were tagged in")
-        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost2])), ev: test_event, pubkeys: [pk1.pubkey, pk2.pubkey, pk3.pubkey], locale: enUsLocale), "pk1:pk1 and 2 others reposted a note you were tagged in")
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_note, pubkeys: [], locale: enUsLocale), "??")
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_note, pubkeys: [pk1.pubkey], locale: enUsLocale), "pk1:pk1 reposted a note you were tagged in")
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_note, pubkeys: [pk1.pubkey, pk2.pubkey], locale: enUsLocale), "pk1:pk1 and pk2:pk2 reposted a note you were tagged in")
+        XCTAssertEqual(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost2])), ev: test_note, pubkeys: [pk1.pubkey, pk2.pubkey, pk3.pubkey], locale: enUsLocale), "pk1:pk1 and 2 others reposted a note you were tagged in")
 
         Bundle.main.localizations.map { Locale(identifier: $0) }.forEach {
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_event, pubkeys: [], locale: $0), "??")
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_event, pubkeys: [pk1.pubkey], locale: $0))
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_event, pubkeys: [pk1.pubkey, pk2.pubkey], locale: $0))
-            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost3])), ev: test_event, pubkeys: [pk1.pubkey, pk2.pubkey, pk3.pubkey], locale: $0))
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [])), ev: test_note, pubkeys: [], locale: $0), "??")
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1])), ev: test_note, pubkeys: [pk1.pubkey], locale: $0))
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2])), ev: test_note, pubkeys: [pk1.pubkey, pk2.pubkey], locale: $0))
+            XCTAssertNoThrow(reacting_to_text(profiles: damusState.profiles, our_pubkey: damusState.pubkey, group: .repost(EventGroup(events: [repost1, repost2, repost3])), ev: test_note, pubkeys: [pk1.pubkey, pk2.pubkey, pk3.pubkey], locale: $0))
         }
     }
 

--- a/damusTests/UserSearchCacheTests.swift
+++ b/damusTests/UserSearchCacheTests.swift
@@ -86,7 +86,7 @@ final class UserSearchCacheTests: XCTestCase {
         let damus = "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681"
         let jb55 = "32e1827635450ebb3c5a7d12c1f8e7b2b514439ac10a67eef3d9fd9c5c68e245"
 
-        var pubkeysToPetnames = [String: String]()
+        var pubkeysToPetnames = [Pubkey: String]()
         pubkeysToPetnames[damus] = "damus"
         pubkeysToPetnames[jb55] = "jb55"
 
@@ -114,7 +114,7 @@ final class UserSearchCacheTests: XCTestCase {
         XCTAssertEqual(damusState.user_search_cache.search(key: "l"), [jb55])
     }
 
-    private func createContactsEventWithPetnames(pubkeysToPetnames: [String: String]) throws -> NostrEvent {
+    private func createContactsEventWithPetnames(pubkeysToPetnames: [Pubkey: String]) throws -> NostrEvent {
         let keypair = try XCTUnwrap(keypair)
 
         let bootstrapRelays = load_bootstrap_relays(pubkey: keypair.pubkey)

--- a/damusTests/UserSearchCacheTests.swift
+++ b/damusTests/UserSearchCacheTests.swift
@@ -24,7 +24,7 @@ final class UserSearchCacheTests: XCTestCase {
             damusState.profiles.set_validated(pubkey, nip05: validatedNip05)
 
             let profile = Profile(name: "tyiu", display_name: "Terry Yiu", about: nil, picture: nil, banner: nil, website: nil, lud06: nil, lud16: nil, nip05: nip05, damus_donation: nil)
-            let timestampedProfile = TimestampedProfile(profile: profile, timestamp: 0, event: test_event)
+            let timestampedProfile = TimestampedProfile(profile: profile, timestamp: 0, event: test_note)
             damusState.profiles.add(id: pubkey, profile: timestampedProfile)
 
             // Lookup to synchronize access on profiles dictionary to avoid race conditions.
@@ -56,7 +56,7 @@ final class UserSearchCacheTests: XCTestCase {
         damusState.profiles.set_validated(keypair.pubkey, nip05: NIP05.parse(newNip05))
 
         let newProfile = Profile(name: "whoami", display_name: "T-DAWG", about: nil, picture: nil, banner: nil, website: nil, lud06: nil, lud16: nil, nip05: newNip05, damus_donation: nil)
-        let newTimestampedProfile = TimestampedProfile(profile: newProfile, timestamp: 1000, event: test_event)
+        let newTimestampedProfile = TimestampedProfile(profile: newProfile, timestamp: 1000, event: test_note)
         damusState.profiles.add(id: keypair.pubkey, profile: newTimestampedProfile)
 
         // Lookup to synchronize access on profiles dictionary to avoid race conditions.

--- a/nostrdb/NdbNote.swift
+++ b/nostrdb/NdbNote.swift
@@ -242,7 +242,7 @@ extension NdbNote {
         References.hashtags(tags: self.tags)
     }
 
-    func event_refs(_ privkey: String?) -> [EventRef] {
+    func event_refs(_ privkey: Privkey?) -> [EventRef] {
         if let rs = _event_refs {
             return rs
         }
@@ -251,7 +251,7 @@ extension NdbNote {
         return refs
     }
 
-    func get_content(_ privkey: String?) -> String {
+    func get_content(_ privkey: Privkey?) -> String {
         if known_kind == .dm {
             return decrypted(privkey: privkey) ?? "*failed to decrypt content*"
         }
@@ -259,7 +259,7 @@ extension NdbNote {
         return content
     }
 
-    func blocks(_ privkey: String?) -> Blocks {
+    func blocks(_ privkey: Privkey?) -> Blocks {
         if let bs = _blocks { return bs }
 
         let blocks = get_blocks(content: self.get_content(privkey))
@@ -268,8 +268,8 @@ extension NdbNote {
     }
 
     // NDBTODO: switch this to operating on bytes not strings
-    func decrypted(privkey: String?) -> String? {
-        if let decrypted_content = decrypted_content {
+    func decrypted(privkey: Privkey?) -> String? {
+        if let decrypted_content {
             return decrypted_content
         }
 
@@ -312,7 +312,7 @@ extension NdbNote {
     }
      */
 
-    public func direct_replies(_ privkey: String?) -> [ReferencedId] {
+    public func direct_replies(_ privkey: Privkey?) -> [ReferencedId] {
         return event_refs(privkey).reduce(into: []) { acc, evref in
             if let direct_reply = evref.is_direct_reply {
                 acc.append(direct_reply)
@@ -321,7 +321,7 @@ extension NdbNote {
     }
 
     // NDBTODO: just use Id
-    public func thread_id(privkey: String?) -> String {
+    public func thread_id(privkey: Privkey?) -> NoteId {
         for ref in event_refs(privkey) {
             if let thread_id = ref.is_thread_id {
                 return thread_id.ref_id
@@ -346,11 +346,11 @@ extension NdbNote {
         return false
     }
 
-    func is_reply(_ privkey: String?) -> Bool {
+    func is_reply(_ privkey: Privkey?) -> Bool {
         return event_is_reply(self.event_refs(privkey))
     }
 
-    func note_language(_ privkey: String?) async -> String? {
+    func note_language(_ privkey: Privkey?) async -> String? {
         let t = Task.detached {
             // Rely on Apple's NLLanguageRecognizer to tell us which language it thinks the note is in
             // and filter on only the text portions of the content as URLs and hashtags confuse the language recognizer.


### PR DESCRIPTION
The ndb branch (nostrdb) is quite large and has some weird bugs in it, so I've decided to start splitering off commits to make it easier to bisect and review. These are some commits that shouldn't change any logic.

This PR starts the switch over to the new Pubkey/Privkey/Id types. Right now they are just type aliases for strings but in the future these will be actual Data types.