### PR TITLE
Changelog-Fixed: Save Image Permissions

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		9CA876E229A00CEA0003B9A3 /* AttachMediaUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA876E129A00CE90003B9A3 /* AttachMediaUtility.swift */; };
 		BA693074295D649800ADDB87 /* UserSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA693073295D649800ADDB87 /* UserSettingsStore.swift */; };
 		BAB68BED29543FA3007BA466 /* SelectWalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */; };
+		BC4294742A7430FF00566E03 /* ImageSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC4294732A7430FF00566E03 /* ImageSaver.swift */; };
 		D2277EEA2A089BD5006C3807 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2277EE92A089BD5006C3807 /* Router.swift */; };
 		E4FA1C032A24BB7F00482697 /* SearchSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4FA1C022A24BB7F00482697 /* SearchSettingsView.swift */; };
 		E990020F2955F837003BBC5A /* EditMetadataView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E990020E2955F837003BBC5A /* EditMetadataView.swift */; };
@@ -845,6 +846,7 @@
 		9CA876E129A00CE90003B9A3 /* AttachMediaUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachMediaUtility.swift; sourceTree = "<group>"; };
 		BA693073295D649800ADDB87 /* UserSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingsStore.swift; sourceTree = "<group>"; };
 		BAB68BEC29543FA3007BA466 /* SelectWalletView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectWalletView.swift; sourceTree = "<group>"; };
+		BC4294732A7430FF00566E03 /* ImageSaver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSaver.swift; sourceTree = "<group>"; };
 		D2277EE92A089BD5006C3807 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		E4FA1C022A24BB7F00482697 /* SearchSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSettingsView.swift; sourceTree = "<group>"; };
 		E990020E2955F837003BBC5A /* EditMetadataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditMetadataView.swift; sourceTree = "<group>"; };
@@ -1066,6 +1068,7 @@
 			isa = PBXGroup;
 			children = (
 				4C198DF429F88D2E004C165C /* ImageMetadata.swift */,
+				BC4294732A7430FF00566E03 /* ImageSaver.swift */,
 			);
 			path = Images;
 			sourceTree = "<group>";
@@ -2032,6 +2035,7 @@
 				64FBD06F296255C400D9D3B2 /* Theme.swift in Sources */,
 				4C1A9A2329DDDB8100516EAC /* IconLabel.swift in Sources */,
 				4C3EA64928FF597700C48A62 /* bech32.c in Sources */,
+				BC4294742A7430FF00566E03 /* ImageSaver.swift in Sources */,
 				4CE879522996B68900F758CC /* RelayType.swift in Sources */,
 				4CE8795B2996C47A00F758CC /* ZapsModel.swift in Sources */,
 				4C3A1D3729637E0500558C0F /* PreviewCache.swift in Sources */,

--- a/damus/Util/Images/ImageSaver.swift
+++ b/damus/Util/Images/ImageSaver.swift
@@ -1,0 +1,27 @@
+// ImageSaver.swift
+
+import UIKit
+
+enum ImageSaverError {
+    case permissions
+    case unknown
+}
+
+class ImageSaver: NSObject, ObservableObject {
+    var errorTitle: String = "Failed to save"
+    var errorMessage: String = "Unable to save the photo."
+    var errorType: ImageSaverError = .unknown
+    @Published var error = false
+
+    func writeToPhotoAlbum(image: UIImage) {
+        UIImageWriteToSavedPhotosAlbum(image, self, #selector(saveCompleted), nil)
+    }
+
+    @objc func saveCompleted(
+        _ image: UIImage,
+        didFinishSavingWithError error: Error?,
+        contextInfo: UnsafeRawPointer
+    ) {
+        self.error = error != nil
+    }
+}

--- a/damus/Views/Images/ImageContainerView.swift
+++ b/damus/Views/Images/ImageContainerView.swift
@@ -15,7 +15,8 @@ struct ImageContainerView: View {
     
     @State private var image: UIImage?
     @State private var showShareSheet = false
-    
+    @ObservedObject var imageSaver = ImageSaver()
+
     let disable_animation: Bool
     
     private struct ImageHandler: ImageModifier {
@@ -35,10 +36,23 @@ struct ImageContainerView: View {
             }
             .imageModifier(ImageHandler(handler: $image))
             .clipped()
-            .modifier(ImageContextMenuModifier(url: url, image: image, showShareSheet: $showShareSheet))
+            .modifier(ImageContextMenuModifier(url: url, image: image, imageSaver: imageSaver, showShareSheet: $showShareSheet))
             .sheet(isPresented: $showShareSheet) {
                 ShareSheet(activityItems: [url])
             }
+            .alert(
+                imageSaver.errorTitle,
+                isPresented: $imageSaver.error,
+                actions: {
+                    if imageSaver.errorType == .permissions {
+                        Button("Settings") {
+                            UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                        }
+                        Button("Cancel", role: .cancel) {}
+                    }
+                },
+                message: { Text(imageSaver.errorMessage) }
+            )
     }
     
     var body: some View {

--- a/damus/Views/Images/ProfilePicImageView.swift
+++ b/damus/Views/Images/ProfilePicImageView.swift
@@ -12,6 +12,7 @@ struct ProfileImageContainerView: View {
     
     @State private var image: UIImage?
     @State private var showShareSheet = false
+    @ObservedObject var imageSaver = ImageSaver()
     
     let disable_animation: Bool
     
@@ -33,10 +34,23 @@ struct ProfileImageContainerView: View {
             }
             .imageModifier(ImageHandler(handler: $image))
             .clipShape(Circle())
-            .modifier(ImageContextMenuModifier(url: url, image: image, showShareSheet: $showShareSheet))
+            .modifier(ImageContextMenuModifier(url: url, image: image, imageSaver: imageSaver, showShareSheet: $showShareSheet))
             .sheet(isPresented: $showShareSheet) {
                 ShareSheet(activityItems: [url])
             }
+            .alert(
+                imageSaver.errorTitle,
+                isPresented: $imageSaver.error,
+                actions: {
+                    if imageSaver.errorType == .permissions {
+                        Button("Settings") {
+                            UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                        }
+                        Button("Cancel", role: .cancel) {}
+                    }
+                },
+                message: { Text(imageSaver.errorMessage) }
+            )
     }
 }
 


### PR DESCRIPTION
Currently, without permission, saving an image will fail silently and simply not save the image. This PR adds an `ImageSaver` class to handle permission failures when saving images, as well as display an alert upon failure.

[Fixes: #1150]