### PR TITLE
Fix for missing bottom half of a note

### DIFF
--- a/damus/Components/SelectableText.swift
+++ b/damus/Components/SelectableText.swift
@@ -29,6 +29,7 @@ struct SelectableText: View {
             .padding([.leading, .trailing], -1.0)
             .onAppear {
                 self.selectedTextWidth = geo.size.width
+                self.selectedTextHeight = 100000.0
             }
             .onChange(of: geo.size) { newSize in
                 self.selectedTextWidth = newSize.width


### PR DESCRIPTION
Strange fix, but by increasing the height of a UiTextView past the size of any legitimate content, then re-sizes back to the correct size displaying the full content.