### PR TITLE
Second attempt at fixing SelectableText

### DIFF
--- a/damus/Components/SelectableText.swift
+++ b/damus/Components/SelectableText.swift
@@ -29,7 +29,9 @@ struct SelectableText: View {
             .padding([.leading, .trailing], -1.0)
             .onAppear {
                 self.selectedTextWidth = geo.size.width
-                self.selectedTextHeight = 100000.0
+                if(self.selectedTextHeight == .zero) {
+                    self.selectedTextHeight = 1000.0
+                }
             }
             .onChange(of: geo.size) { newSize in
                 self.selectedTextWidth = newSize.width


### PR DESCRIPTION
In some edge cases, the inflated UiTextView didn't render properly causing a black screen which needed the user to scroll. Dropped the inflate size and now only set where selectedTextHeight is .zero, seems more reliable.