### PR TITLE
Add nip 98 support for nostr.build

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		3ACB685F297633BC00C46468 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3ACB685D297633BC00C46468 /* Localizable.strings */; };
 		3ACBCB78295FE5C70037388A /* TimeAgoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ACBCB77295FE5C70037388A /* TimeAgoTests.swift */; };
 		3AE45AF6297BB2E700C1D842 /* LibreTranslateServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE45AF5297BB2E700C1D842 /* LibreTranslateServer.swift */; };
+		3CCD1E6A2A874C4E0099A953 /* Nip98HTTPAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CCD1E692A874C4E0099A953 /* Nip98HTTPAuth.swift */; };
 		4C06670128FC7C5900038D2A /* RelayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C06670028FC7C5900038D2A /* RelayView.swift */; };
 		4C06670428FC7EC500038D2A /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 4C06670328FC7EC500038D2A /* Kingfisher */; };
 		4C06670628FCB08600038D2A /* ImageCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C06670528FCB08600038D2A /* ImageCarousel.swift */; };
@@ -534,6 +535,7 @@
 		3AF6336829884C6B0005672A /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		3AF6336929884C6B0005672A /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		3AF6336A29884C6B0005672A /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "pt-PT"; path = "pt-PT.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
+		3CCD1E692A874C4E0099A953 /* Nip98HTTPAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Nip98HTTPAuth.swift; sourceTree = "<group>"; };
 		4C06670028FC7C5900038D2A /* RelayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayView.swift; sourceTree = "<group>"; };
 		4C06670528FCB08600038D2A /* ImageCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCarousel.swift; sourceTree = "<group>"; };
 		4C06670828FDE64700038D2A /* damus-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "damus-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -1313,6 +1315,7 @@
 				4C75EFAE28049D340006080F /* NostrFilter.swift */,
 				4C75EFB028049D510006080F /* NostrResponse.swift */,
 				4C75EFB228049D640006080F /* NostrEvent.swift */,
+				3CCD1E692A874C4E0099A953 /* Nip98HTTPAuth.swift */,
 				4C75EFB428049D790006080F /* Relay.swift */,
 				4C75EFB628049D990006080F /* RelayPool.swift */,
 				4C75EFBA2804A34C0006080F /* ProofOfWork.swift */,
@@ -2331,6 +2334,7 @@
 				4C12536A2A76D3850004F4B8 /* RelaysChangedNotify.swift in Sources */,
 				4C30AC8029A6A53F00E2BD5A /* ProfilePicturesView.swift in Sources */,
 				5C6E1DAD2A193EC2008FC15A /* GradientButtonStyle.swift in Sources */,
+				3CCD1E6A2A874C4E0099A953 /* Nip98HTTPAuth.swift in Sources */,
 				4C8EC52529D1FA6C0085D9A8 /* DamusColors.swift in Sources */,
 				3A4647CF2A413ADC00386AD8 /* CondensedProfilePicturesView.swift in Sources */,
 				D2277EEA2A089BD5006C3807 /* Router.swift in Sources */,

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -188,6 +188,8 @@ class HomeModel {
             break
         case .nwc_response:
             handle_nwc_response(ev, relay: relay_id)
+        case .http_auth:
+            break
         }
     }
     

--- a/damus/Models/ImageUploadModel.swift
+++ b/damus/Models/ImageUploadModel.swift
@@ -47,8 +47,8 @@ enum MediaUpload {
 class ImageUploadModel: NSObject, URLSessionTaskDelegate, ObservableObject {
     @Published var progress: Double? = nil
     
-    func start(media: MediaUpload, uploader: MediaUploader) async -> ImageUploadResult {
-        let res = await create_upload_request(mediaToUpload: media, mediaUploader: uploader, progress: self)
+    func start(media: MediaUpload, uploader: MediaUploader, keypair: Keypair? = nil) async -> ImageUploadResult {
+        let res = await create_upload_request(mediaToUpload: media, mediaUploader: uploader, progress: self, keypair: keypair)
         DispatchQueue.main.async {
             self.progress = nil
         }

--- a/damus/Nostr/Nip98HTTPAuth.swift
+++ b/damus/Nostr/Nip98HTTPAuth.swift
@@ -1,0 +1,23 @@
+//
+//  Nip98HTTPAuth.swift
+//  damus
+//
+//  Created by Fishcake on 2023/08/12.
+//
+
+import Foundation
+
+func create_nip98_signature (keypair: Keypair, method: String, url: URL) -> String? {
+    let tags = [
+        ["u", url.standardized.absoluteString], // Ensure that we standardise the URL before extracting string value.
+        ["method", method]
+    ]
+    
+    guard let ev = NostrEvent(content: "", keypair: keypair, kind: NostrKind.http_auth.rawValue, tags: tags) else {
+         return nil
+    }
+
+    let json = event_to_json(ev: ev)
+    let base64Header = base64_encode(Array(json.utf8))
+    return "Nostr " + base64Header // The returned value should be used in Authorization HTTP header
+}

--- a/damus/Nostr/NostrKind.swift
+++ b/damus/Nostr/NostrKind.swift
@@ -23,4 +23,5 @@ enum NostrKind: UInt32, Codable {
     case zap_request = 9734
     case nwc_request = 23194
     case nwc_response = 23195
+    case http_auth = 27235
 }

--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -255,7 +255,7 @@ struct PostView: View {
             let img = getImage(media: media)
             print("img size w:\(img.size.width) h:\(img.size.height)")
             async let blurhash = calculate_blurhash(img: img)
-            let res = await image_upload.start(media: media, uploader: uploader)
+            let res = await image_upload.start(media: media, uploader: uploader, keypair: damus_state.keypair)
             
             switch res {
             case .success(let url):


### PR DESCRIPTION
This change implements support for NIP-98 and uses it for uploads to nostr.build. It is also changing the nostr.build API end-point to V2. Implements #823 