### PR TITLE
Fixing -1 others

### DIFF
--- a/damus/Views/Events/Components/ReplyDescription.swift
+++ b/damus/Views/Events/Components/ReplyDescription.swift
@@ -47,7 +47,7 @@ func reply_desc(profiles: Profiles, event: NostrEvent, replying_to: NostrEvent?,
 
     if uniqueNames.count > 1 {
         let othersCount = n - pubkeys.count
-        if othersCount == 0 {
+        if othersCount <= 0 {
             return String(format: NSLocalizedString("Replying to %@ & %@", bundle: bundle, comment: "Label to indicate that the user is replying to 2 users."), locale: locale, uniqueNames[0], uniqueNames[1])
         } else {
             return String(format: localizedStringFormat(key: "replying_to_two_and_others", locale: locale), locale: locale, othersCount, uniqueNames[0], uniqueNames[1])


### PR DESCRIPTION
Fix for issue #1467 
The 'others' count is higher than pubkeys count

Note json :

`{ "pubkey": "97c70a44366a6535c145b333f973ea86dfdc2d7a99da618c40c64705ad98e322", "content": "No, just so other people can hear and profit, that's the point of the podcast. But I see you're PNW too, coffee also works if we end up in the same vicinity!", "id": "2c271f78da9522a342f6178667e4dd30423cab65a559f1fd683071d130fc3477", "created_at": 1691611954, "sig": "de62016ad6260180f9f99b83773066c60db63790560e3bd6239995e26526d647a2776469f6de0855bd9deab8d2a42c1fcddd275b07f7b5924bb0d4a922f486e3", "kind": 1, "tags": [ [ "p", "61066504617ee79387021e18c89fb79d1ddbc3e7bff19cf2298f40466f8715e9", "wss:\\/\\/anon.computer", "atyh" ], [ "e", "b7f986c892a0f128c131ab90996fcb94fac2c80869cb88a5d021e0b2f3609045", "wss:\\/\\/offchain.pub", "root" ], [ "e", "ad8d909a66d848a6101d7482245f484c86e3d6597fcec19921e1cc0f5b6e94fb" ], [ "e", "18ebd3e8f86bf3f318ed0a71e3853855bde59f3be433e37a958b33be8273f8e6", "wss:\\/\\/offchain.pub", "reply" ], [ "client", "coracle" ] ] }`

