### PR TITLE
Adding zap icon to Eurothon hashtag

### DIFF
--- a/damus/Util/Hashtags.swift
+++ b/damus/Util/Hashtags.swift
@@ -38,6 +38,7 @@ let custom_hashtags: [String: CustomHashtag] = [
     "zaps": CustomHashtag.zap,
     "zapathon": CustomHashtag.zap,
     "onlyzaps": CustomHashtag.zap,
+    "eurothon": CustomHashtag.zap,
 ]
 
 func hashtag_str(_ htag: String) -> CompatibleText {


### PR DESCRIPTION
Adding the Zap ⚡️ icon to the Eurothon hashtag.
I created a new property for Eurothon.
I'm using the same svg icon file, just like the Zapathon hashtag.

I couldn't test it because I don't have a macOS environment.

Issue: #1474 