### PR TITLE
Avoid notification for zap from mute profile

### DIFF
--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -226,6 +226,10 @@ class HomeModel {
             guard zap.target.pubkey == self.damus_state.keypair.pubkey else {
                 return
             }
+            
+            if damus_state.contacts.is_muted(ev.pubkey){
+                return
+            }
         
             if !self.notifications.insert_zap(.zap(zap)) {
                 return

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -229,7 +229,7 @@ class HomeModel {
                 return
             }
             
-            guard should_show_event(privkey: damus_state.keypair.privkey, hellthreads: damus_state.muted_threads, contacts: damus_state.contacts, ev: ev) else {
+            guard should_show_event(privkey: damus_state.keypair.privkey, hellthreads: damus_state.muted_threads, contacts: damus_state.contacts, ev: zap.request.ev) else {
                 return
             }
         

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -227,7 +227,7 @@ class HomeModel {
                 return
             }
             
-            if damus_state.contacts.is_muted(ev.pubkey){
+            guard should_show_event(privkey: damus_state.keypair.privkey, hellthreads: damus_state.muted_threads, contacts: damus_state.contacts, ev: ev) else {
                 return
             }
         


### PR DESCRIPTION
Fixing issue #1382 
Checks if the event pkey is in the mute list
Could not test the code, but it is a simple straightforward solution