### PR TITLE
Simplify and inline Report event logic

### DIFF
--- a/damus/Models/Report.swift
+++ b/damus/Models/Report.swift
@@ -39,9 +39,4 @@ enum ReportTarget {
     case user(Pubkey)
     case note(ReportNoteTarget)
 }
-struct Report {
-    let type: ReportType
-    let target: ReportTarget
-    let message: String
-}
 

--- a/damus/Models/Report.swift
+++ b/damus/Models/Report.swift
@@ -38,31 +38,10 @@ struct ReportNoteTarget {
 enum ReportTarget {
     case user(Pubkey)
     case note(ReportNoteTarget)
-
-    static func note(pubkey: Pubkey, note_id: NoteId) -> ReportTarget {
-        return .note(ReportNoteTarget(pubkey: pubkey, note_id: note_id))
-    }
 }
-
 struct Report {
     let type: ReportType
     let target: ReportTarget
     let message: String
-
 }
 
-func create_report_tags(target: ReportTarget, type: ReportType) -> [[String]] {
-    switch target {
-    case .user(let pubkey):
-        return [["p", pubkey.hex(), type.rawValue]]
-    case .note(let notet):
-        return [["e", notet.note_id.hex(), type.rawValue],
-                ["p", notet.pubkey.hex()]]
-    }
-}
-
-func create_report_event(keypair: FullKeypair, report: Report) -> NostrEvent? {
-    let kind: UInt32 = 1984
-    let tags = create_report_tags(target: report.target, type: report.type)
-    return NostrEvent(content: report.message, keypair: keypair.to_keypair(), kind: kind, tags: tags)
-}

--- a/damus/Views/Events/EventMenu.swift
+++ b/damus/Views/Events/EventMenu.swift
@@ -66,7 +66,6 @@ struct MenuItems: View {
     }
     
     var body: some View {
-
         Group {
             Button {
                 UIPasteboard.general.string = event.get_content(keypair.privkey)
@@ -126,7 +125,7 @@ struct MenuItems: View {
             // Only allow reporting if logged in with private key and the currently viewed profile is not the logged in profile.
             if keypair.pubkey != target_pubkey && keypair.privkey != nil {
                 Button(role: .destructive) {
-                    notify(.report(.note(pubkey: target_pubkey, note_id: event.id)))
+                    notify(.report(.note(ReportNoteTarget(pubkey: target_pubkey, note_id: event.id))))
                 } label: {
                     Label(NSLocalizedString("Report", comment: "Context menu option for reporting content."), image: "raising-hand")
                 }


### PR DESCRIPTION
Simplify and inline Report event logic. Move the tag enum unpacking into a fileprivate extension, unpack the event-creation functions that used the `Report` model as a throw-away intermediate step to creating a NostrEvent object.