### PR TITLE
Move the Block helper type to its own file

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		643EA5C8296B764E005081BB /* RelayFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 643EA5C7296B764E005081BB /* RelayFilterView.swift */; };
 		647D9A8D2968520300A295DE /* SideMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647D9A8C2968520300A295DE /* SideMenuView.swift */; };
 		64FBD06F296255C400D9D3B2 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FBD06E296255C400D9D3B2 /* Theme.swift */; };
+		7527271E2A93FF0100214108 /* Block.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7527271D2A93FF0100214108 /* Block.swift */; };
 		7C60CAEF298471A1009C80D6 /* CoreSVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C60CAEE298471A1009C80D6 /* CoreSVG.swift */; };
 		7C902AE32981D55B002AB16E /* ZoomableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C902AE22981D55B002AB16E /* ZoomableScrollView.swift */; };
 		7C95CAEE299DCEF1009DCB67 /* KFOptionSetter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */; };
@@ -1078,6 +1079,7 @@
 		643EA5C7296B764E005081BB /* RelayFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayFilterView.swift; sourceTree = "<group>"; };
 		647D9A8C2968520300A295DE /* SideMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuView.swift; sourceTree = "<group>"; };
 		64FBD06E296255C400D9D3B2 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		7527271D2A93FF0100214108 /* Block.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Block.swift; sourceTree = "<group>"; };
 		7C60CAEE298471A1009C80D6 /* CoreSVG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSVG.swift; sourceTree = "<group>"; };
 		7C902AE22981D55B002AB16E /* ZoomableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableScrollView.swift; sourceTree = "<group>"; };
 		7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KFOptionSetter+.swift"; sourceTree = "<group>"; };
@@ -1953,6 +1955,7 @@
 			isa = PBXGroup;
 			children = (
 				4CC14FED2A73FCBB007AEB17 /* Ids */,
+				7527271D2A93FF0100214108 /* Block.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -2795,6 +2798,7 @@
 				7CFF6317299FEFE5005D382A /* SelectableText.swift in Sources */,
 				4CA352A82A76B37E003BB08B /* NewMutesNotify.swift in Sources */,
 				4CFF8F6929CC9ED1008DB934 /* ImageContainerView.swift in Sources */,
+				7527271E2A93FF0100214108 /* Block.swift in Sources */,
 				4C54AA0729A540BA003E4487 /* NotificationsModel.swift in Sources */,
 				4C12536C2A76D4B00004F4B8 /* RepostedNotify.swift in Sources */,
 				4CB55EF3295E5D59007FD187 /* RecommendedRelayView.swift in Sources */,

--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -405,6 +405,7 @@
 		647D9A8D2968520300A295DE /* SideMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647D9A8C2968520300A295DE /* SideMenuView.swift */; };
 		64FBD06F296255C400D9D3B2 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64FBD06E296255C400D9D3B2 /* Theme.swift */; };
 		7527271E2A93FF0100214108 /* Block.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7527271D2A93FF0100214108 /* Block.swift */; };
+		75AD872B2AA23A460085EF2C /* Block+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75AD872A2AA23A460085EF2C /* Block+Tests.swift */; };
 		7C60CAEF298471A1009C80D6 /* CoreSVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C60CAEE298471A1009C80D6 /* CoreSVG.swift */; };
 		7C902AE32981D55B002AB16E /* ZoomableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C902AE22981D55B002AB16E /* ZoomableScrollView.swift */; };
 		7C95CAEE299DCEF1009DCB67 /* KFOptionSetter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */; };
@@ -1080,6 +1081,7 @@
 		647D9A8C2968520300A295DE /* SideMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuView.swift; sourceTree = "<group>"; };
 		64FBD06E296255C400D9D3B2 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		7527271D2A93FF0100214108 /* Block.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Block.swift; sourceTree = "<group>"; };
+		75AD872A2AA23A460085EF2C /* Block+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Block+Tests.swift"; sourceTree = "<group>"; };
 		7C60CAEE298471A1009C80D6 /* CoreSVG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSVG.swift; sourceTree = "<group>"; };
 		7C902AE22981D55B002AB16E /* ZoomableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableScrollView.swift; sourceTree = "<group>"; };
 		7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KFOptionSetter+.swift"; sourceTree = "<group>"; };
@@ -2272,6 +2274,7 @@
 			isa = PBXGroup;
 			children = (
 				F944F56D29EA9CCC0067B3BF /* DamusParseContentTests.swift */,
+				75AD872A2AA23A460085EF2C /* Block+Tests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2889,6 +2892,7 @@
 				4CB883AA297612FF00DC99E7 /* ZapTests.swift in Sources */,
 				4CB8839A297322D200DC99E7 /* DMTests.swift in Sources */,
 				4C9054852A6AEAA000811EEC /* NdbTests.swift in Sources */,
+				75AD872B2AA23A460085EF2C /* Block+Tests.swift in Sources */,
 				F944F56E29EA9CCC0067B3BF /* DamusParseContentTests.swift in Sources */,
 				3A5E47C72A4A76C800C0D090 /* TrieTests.swift in Sources */,
 				4CB883AE2976FA9300DC99E7 /* FormatTests.swift in Sources */,

--- a/damus/ContentParsing.swift
+++ b/damus/ContentParsing.swift
@@ -27,7 +27,7 @@ func parsed_blocks_finish(bs: inout note_blocks, tags: TagsSequence?) -> Blocks 
     while (i < bs.num_blocks) {
         let block = bs.blocks[i]
 
-        if let converted = convert_block(block, tags: tags) {
+        if let converted = Block(block, tags: tags) {
             out.append(converted)
         }
 

--- a/damus/Types/Block.swift
+++ b/damus/Types/Block.swift
@@ -1,0 +1,214 @@
+//
+//  Block.swift
+//  damus
+//
+//  Created by Kyle Roucis on 2023-08-21.
+//
+
+import Foundation
+
+
+fileprivate extension String {
+    /// Failable initializer to build a Swift.String from a C-backed `str_block_t`.
+    init?(_ s: str_block_t) {
+        let len = s.end - s.start
+        let bytes = Data(bytes: s.start, count: len)
+        self.init(bytes: bytes, encoding: .utf8)
+    }
+}
+
+/// Represents a block of data stored by the NOSTR protocol. This can be
+/// simple text, a hashtag, a url, a relay reference, a mention ref and
+/// potentially more in the future.
+enum Block: Equatable {
+    static func == (lhs: Block, rhs: Block) -> Bool {
+        switch (lhs, rhs) {
+        case (.text(let a), .text(let b)):
+            return a == b
+        case (.mention(let a), .mention(let b)):
+            return a == b
+        case (.hashtag(let a), .hashtag(let b)):
+            return a == b
+        case (.url(let a), .url(let b)):
+            return a == b
+        case (.invoice(let a), .invoice(let b)):
+            return a.string == b.string
+        case (_, _):
+            return false
+        }
+    }
+    
+    case text(String)
+    case mention(Mention<MentionRef>)
+    case hashtag(String)
+    case url(URL)
+    case invoice(Invoice)
+    case relay(String)
+}
+extension Block {
+    /// Failable initializer for the C-backed type `block_t`. This initializer will inspect
+    /// the underlying block type and build the appropriate enum value as needed.
+    init?(_ block: block_t, tags: TagsSequence? = nil) {
+        switch block.type {
+        case BLOCK_HASHTAG:
+            guard let str = String(block.block.str) else {
+                return nil
+            }
+            self = .hashtag(str)
+        case BLOCK_TEXT:
+            guard let str = String(block.block.str) else {
+                return nil
+            }
+            self = .text(str)
+        case BLOCK_MENTION_INDEX:
+            guard let b = Block(index: Int(block.block.mention_index), tags: tags) else {
+                return nil
+            }
+            self = b
+        case BLOCK_URL:
+            guard let b = Block(block.block.str) else {
+                return nil
+            }
+            self = b
+        case BLOCK_INVOICE:
+            guard let b = Block(invoice: block.block.invoice) else {
+                return nil
+            }
+            self = b
+        case BLOCK_MENTION_BECH32:
+            guard let b = Block(bech32: block.block.mention_bech32) else {
+                return nil
+            }
+            self = b
+        default:
+            return nil
+        }
+    }
+}
+fileprivate extension Block {
+    /// Failable initializer for the C-backed type `str_block_t`.
+    init?(_ b: str_block_t) {
+        guard let str = String(b) else {
+            return nil
+        }
+        
+        if let url = URL(string: str) {
+            self = .url(url)
+        }
+        else {
+            self = .text(str)
+        }
+    }
+}
+fileprivate extension Block {
+    /// Failable initializer for a block index and a tag sequence.
+    init?(index: Int, tags: TagsSequence? = nil) {
+        guard let tags,
+              index >= 0,
+              index + 1 <= tags.count
+        else {
+            self = .text("#[\(index)]")
+            return
+        }
+        
+        let tag = tags[index]
+        
+        if let mention = MentionRef.from_tag(tag: tag) {
+            self = .mention(.any(mention, index: index))
+        }
+        else {
+            self = .text("#[\(index)]")
+        }
+    }
+}
+fileprivate extension Block {
+    /// Failable initializer for the C-backed type `invoice_block_t`.
+    init?(invoice: invoice_block_t) {
+        guard let invstr = String(invoice.invstr) else {
+            return nil
+        }
+        
+        guard var b11 = maybe_pointee(invoice.bolt11) else {
+            return nil
+        }
+        
+        guard let description = convert_invoice_description(b11: b11) else {
+            return nil
+        }
+        
+        let amount: Amount = maybe_pointee(b11.msat).map { .specific(Int64($0.millisatoshis)) } ?? .any
+        let payment_hash = Data(bytes: &b11.payment_hash, count: 32)
+        let created_at = b11.timestamp
+        
+        tal_free(invoice.bolt11)
+        self = .invoice(Invoice(description: description, amount: amount, string: invstr, expiry: b11.expiry, payment_hash: payment_hash, created_at: created_at))
+    }
+}
+fileprivate extension Block {
+    /// Failable initializer for the C-backed type `mention_bech32_block_t`. This initializer will inspect the
+    /// bech32 type code and build the appropriate enum type.
+    init?(bech32 b: mention_bech32_block_t) {
+        switch b.bech32.type {
+        case NOSTR_BECH32_NOTE:
+            let note = b.bech32.data.note;
+            let note_id = NoteId(Data(bytes: note.event_id, count: 32))
+            self = .mention(.any(.note(note_id)))
+        case NOSTR_BECH32_NEVENT:
+            let nevent = b.bech32.data.nevent;
+            let note_id = NoteId(Data(bytes: nevent.event_id, count: 32))
+            self = .mention(.any(.note(note_id)))
+        case NOSTR_BECH32_NPUB:
+            let npub = b.bech32.data.npub
+            let pubkey = Pubkey(Data(bytes: npub.pubkey, count: 32))
+            self = .mention(.any(.pubkey(pubkey)))
+        case NOSTR_BECH32_NSEC:
+            let nsec = b.bech32.data.nsec
+            let privkey = Privkey(Data(bytes: nsec.nsec, count: 32))
+            guard let pubkey = privkey_to_pubkey(privkey: privkey) else { return nil }
+            self = .mention(.any(.pubkey(pubkey)))
+        case NOSTR_BECH32_NPROFILE:
+            let nprofile = b.bech32.data.nprofile
+            let pubkey = Pubkey(Data(bytes: nprofile.pubkey, count: 32))
+            self = .mention(.any(.pubkey(pubkey)))
+        case NOSTR_BECH32_NRELAY:
+            let nrelay = b.bech32.data.nrelay
+            guard let relay_str = String(nrelay.relay) else {
+                return nil
+            }
+            self = .relay(relay_str)
+        case NOSTR_BECH32_NADDR:
+            // TODO: wtf do I do with this
+            guard let naddr = String(b.str) else {
+                return nil
+            }
+            self = .text("nostr:" + naddr)
+        default:
+            return nil
+        }
+    }
+}
+extension Block {
+    var asString: String {
+        switch self {
+        case .mention(let m):
+            if let idx = m.index {
+                return "#[\(idx)]"
+            }
+            
+            switch m.ref {
+            case .pubkey(let pk):    return "nostr:\(pk.npub)"
+            case .note(let note_id): return "nostr:\(note_id.bech32)"
+            }
+        case .relay(let relay):
+            return relay
+        case .text(let txt):
+            return txt
+        case .hashtag(let htag):
+            return "#" + htag
+        case .url(let url):
+            return url.absoluteString
+        case .invoice(let inv):
+            return inv.string
+        }
+    }
+}

--- a/damus/Util/Zap.swift
+++ b/damus/Util/Zap.swift
@@ -393,7 +393,7 @@ func decode_bolt11(_ s: String) -> Invoice? {
     
     let block = bs.blocks[0]
     
-    guard let converted = convert_block(block, tags: nil) else {
+    guard let converted = Block(block) else {
         blocks_free(&bs)
         return nil
     }

--- a/damus/Views/DMChatView.swift
+++ b/damus/Views/DMChatView.swift
@@ -130,7 +130,9 @@ struct DMChatView: View, KeyboardReadable {
     func send_message() {
         let tags = [["p", pubkey.hex()]]
         let post_blocks = parse_post_blocks(content: dms.draft)
-        let content = render_blocks(blocks: post_blocks)
+        let content = post_blocks
+            .map(\.asString)
+            .joined(separator: "")
 
         guard let dm = create_dm(content, to_pk: pubkey, tags: tags, keypair: damus_state.keypair) else {
             print("error creating dm")

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -445,7 +445,15 @@ func render_blocks(blocks bs: Blocks, profiles: Profiles) -> NoteArtifactsSepara
     let blocks = bs.blocks
     
     let one_note_ref = blocks
-        .filter({ $0.is_note_mention })
+        .filter({
+            if case .mention(let mention) = $0,
+               case .note = mention.ref {
+                return true
+            }
+            else {
+                return false
+            }
+        })
         .count == 1
     
     var ind: Int = -1

--- a/damusTests/HashtagTests.swift
+++ b/damusTests/HashtagTests.swift
@@ -8,15 +8,17 @@
 import XCTest
 @testable import damus
 
+
 final class HashtagTests: XCTestCase {
     func testParseHashtag() {
         let parsed = parse_note_content(content: .content("some hashtag #bitcoin derp",nil)).blocks
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
-        XCTAssertEqual(parsed[0].is_text, "some hashtag ")
-        XCTAssertEqual(parsed[1].is_hashtag, "bitcoin")
-        XCTAssertEqual(parsed[2].is_text, " derp")
+        
+        XCTAssertEqual(parsed[0].asText, "some hashtag ")
+        XCTAssertEqual(parsed[1].asHashtag, "bitcoin")
+        XCTAssertEqual(parsed[2].asText, " derp")
     }
     
     func testHashtagWithComma() {
@@ -24,9 +26,9 @@ final class HashtagTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
-        XCTAssertEqual(parsed[0].is_text, "some hashtag ")
-        XCTAssertEqual(parsed[1].is_hashtag, "bitcoin")
-        XCTAssertEqual(parsed[2].is_text, ", cool")
+        XCTAssertEqual(parsed[0].asText, "some hashtag ")
+        XCTAssertEqual(parsed[1].asHashtag, "bitcoin")
+        XCTAssertEqual(parsed[2].asText, ", cool")
     }
     
     func testHashtagWithEmoji() {
@@ -36,14 +38,14 @@ final class HashtagTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
-        XCTAssertEqual(parsed[0].is_text, "some hashtag ")
-        XCTAssertEqual(parsed[1].is_hashtag, "bitcoin☕️")
-        XCTAssertEqual(parsed[2].is_text, " cool")
+        XCTAssertEqual(parsed[0].asText, "some hashtag ")
+        XCTAssertEqual(parsed[1].asHashtag, "bitcoin☕️")
+        XCTAssertEqual(parsed[2].asText, " cool")
 
         XCTAssertEqual(post_blocks.count, 3)
-        XCTAssertEqual(post_blocks[0].is_text, "some hashtag ")
-        XCTAssertEqual(post_blocks[1].is_hashtag, "bitcoin☕️")
-        XCTAssertEqual(post_blocks[2].is_text, " cool")
+        XCTAssertEqual(post_blocks[0].asText, "some hashtag ")
+        XCTAssertEqual(post_blocks[1].asHashtag, "bitcoin☕️")
+        XCTAssertEqual(post_blocks[2].asText, " cool")
     }
 
     func testPowHashtag() {
@@ -53,12 +55,12 @@ final class HashtagTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 2)
-        XCTAssertEqual(parsed[0].is_text, "pow! ")
-        XCTAssertEqual(parsed[1].is_hashtag, "ぽわ〜")
+        XCTAssertEqual(parsed[0].asText, "pow! ")
+        XCTAssertEqual(parsed[1].asHashtag, "ぽわ〜")
 
         XCTAssertEqual(post_blocks.count, 2)
-        XCTAssertEqual(post_blocks[0].is_text, "pow! ")
-        XCTAssertEqual(post_blocks[1].is_hashtag, "ぽわ〜")
+        XCTAssertEqual(post_blocks[0].asText, "pow! ")
+        XCTAssertEqual(post_blocks[1].asHashtag, "ぽわ〜")
     }
 
     func testHashtagWithAccents() {
@@ -66,8 +68,8 @@ final class HashtagTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 2)
-        XCTAssertEqual(parsed[0].is_text, "hello from ")
-        XCTAssertEqual(parsed[1].is_hashtag, "türkiye")
+        XCTAssertEqual(parsed[0].asText, "hello from ")
+        XCTAssertEqual(parsed[1].asHashtag, "türkiye")
     }
 
     func testHashtagWithNonLatinCharacters() {
@@ -75,9 +77,9 @@ final class HashtagTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
-        XCTAssertEqual(parsed[0].is_text, "this is a ")
-        XCTAssertEqual(parsed[1].is_hashtag, "시험")
-        XCTAssertEqual(parsed[2].is_text, " hope it works")
+        XCTAssertEqual(parsed[0].asText, "this is a ")
+        XCTAssertEqual(parsed[1].asHashtag, "시험")
+        XCTAssertEqual(parsed[2].asText, " hope it works")
     }
     
     func testParseHashtagEnd() {
@@ -85,8 +87,8 @@ final class HashtagTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 2)
-        XCTAssertEqual(parsed[0].is_text, "some hashtag ")
-        XCTAssertEqual(parsed[1].is_hashtag, "bitcoin")
+        XCTAssertEqual(parsed[0].asText, "some hashtag ")
+        XCTAssertEqual(parsed[1].asHashtag, "bitcoin")
     }
     
 }

--- a/damusTests/InvoiceTests.swift
+++ b/damusTests/InvoiceTests.swift
@@ -8,6 +8,19 @@
 import XCTest
 @testable import damus
 
+
+extension Block {
+    var asInvoice: Invoice? {
+        switch self {
+        case .invoice(let invoice):
+            return invoice
+        default:
+            return nil
+        }
+    }
+}
+
+
 final class InvoiceTests: XCTestCase {
 
     override func setUpWithError() throws {
@@ -24,8 +37,9 @@ final class InvoiceTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 1)
-        XCTAssertNotNil(parsed[0].is_invoice)
-        guard let invoice = parsed[0].is_invoice else {
+        let invoiceOrNil = parsed[0].asInvoice
+        XCTAssertNotNil(invoiceOrNil)
+        guard let invoice = invoiceOrNil else {
             return
         }
         XCTAssertEqual(invoice.amount, .any)
@@ -42,9 +56,10 @@ LNBC1P3MR5UJSP5G7SA48YD4JWTTPCHWMY4QYN4UWZQCJQ8NMWKD6QE3HCRVYTDLH9SPP57YM9TSA9NN
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 2)
-        XCTAssertNotNil(parsed[0].is_invoice)
-        XCTAssertEqual(parsed[1].is_text, "  hi there")
-        guard let invoice = parsed[0].is_invoice else {
+        let invoiceOrNil = parsed[0].asInvoice
+        XCTAssertNotNil(invoiceOrNil)
+        XCTAssertEqual(parsed[1].asText, "  hi there")
+        guard let invoice = invoiceOrNil else {
             return
         }
         XCTAssertEqual(invoice.amount, .any)
@@ -58,8 +73,9 @@ LNBC1P3MR5UJSP5G7SA48YD4JWTTPCHWMY4QYN4UWZQCJQ8NMWKD6QE3HCRVYTDLH9SPP57YM9TSA9NN
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 1)
-        XCTAssertNotNil(parsed[0].is_invoice)
-        guard let invoice = parsed[0].is_invoice else {
+        let invoiceOrNil = parsed[0].asInvoice
+        XCTAssertNotNil(invoiceOrNil)
+        guard let invoice = invoiceOrNil else {
             return
         }
         XCTAssertEqual(invoice.amount, .specific(10000))
@@ -74,7 +90,7 @@ LNBC1P3MR5UJSP5G7SA48YD4JWTTPCHWMY4QYN4UWZQCJQ8NMWKD6QE3HCRVYTDLH9SPP57YM9TSA9NN
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 1)
-        XCTAssertNotNil(parsed[0].is_invoice)
+        XCTAssertNotNil(parsed[0].asInvoice)
     }
     
     func testParseInvoiceWithPrefixCapitalized() throws {
@@ -83,7 +99,7 @@ LNBC1P3MR5UJSP5G7SA48YD4JWTTPCHWMY4QYN4UWZQCJQ8NMWKD6QE3HCRVYTDLH9SPP57YM9TSA9NN
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 1)
-        XCTAssertNotNil(parsed[0].is_invoice)
+        XCTAssertNotNil(parsed[0].asInvoice)
     }
     
     func testParseInvoice() throws {
@@ -92,8 +108,9 @@ LNBC1P3MR5UJSP5G7SA48YD4JWTTPCHWMY4QYN4UWZQCJQ8NMWKD6QE3HCRVYTDLH9SPP57YM9TSA9NN
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 1)
-        XCTAssertNotNil(parsed[0].is_invoice)
-        guard let invoice = parsed[0].is_invoice else {
+        let invoiceOrNil = parsed[0].asInvoice
+        XCTAssertNotNil(invoiceOrNil)
+        guard let invoice = invoiceOrNil else {
             return
         }
         XCTAssertEqual(invoice.amount, .specific(10000))

--- a/damusTests/Models/Block+Tests.swift
+++ b/damusTests/Models/Block+Tests.swift
@@ -1,0 +1,56 @@
+//
+//  Block+Tests.swift
+//  damusTests
+//
+//  Created by Kyle Roucis on 9/1/23.
+//
+
+import Foundation
+@testable import damus
+
+
+extension Block {
+    var asText: String? {
+        switch self {
+        case .text(let text):
+            return text
+        default:
+            return nil
+        }
+    }
+    
+    var isText: Bool {
+        return self.asText != nil
+    }
+    
+    var asURL: URL? {
+        switch self {
+        case .url(let url):
+            return url
+        default:
+            return nil
+        }
+    }
+    
+    var isURL: Bool {
+        return self.asURL != nil
+    }
+    
+    var asMention: Mention<MentionRef>? {
+        switch self {
+        case .mention(let mention):
+            return mention
+        default:
+            return nil
+        }
+    }
+    
+    var asHashtag: String? {
+        switch self {
+        case .hashtag(let hashtag):
+            return hashtag
+        default:
+            return nil
+        }
+    }
+}

--- a/damusTests/NoteContentViewTests.swift
+++ b/damusTests/NoteContentViewTests.swift
@@ -33,7 +33,7 @@ class NoteContentViewTests: XCTestCase {
         let testNote = NostrEvent.owned_from_json(json: testJSONWithEscapedSlashes)!
         let parsed = parse_note_content(content: .init(note: testNote, keypair: test_keypair))
         
-        XCTAssertTrue((parsed.blocks[0].is_url != nil), "NoteContentView does not correctly parse an image block when url in JSON content contains optional escaped slashes.")
+        XCTAssertTrue((parsed.blocks[0].asURL != nil), "NoteContentView does not correctly parse an image block when url in JSON content contains optional escaped slashes.")
     }
 
 }

--- a/damusTests/ReplyTests.swift
+++ b/damusTests/ReplyTests.swift
@@ -41,7 +41,7 @@ class ReplyTests: XCTestCase {
         let blocks = parse_post_blocks(content: content)
         
         XCTAssertEqual(blocks.count, 1)
-        XCTAssertEqual(blocks[0].is_text, "what @")
+        XCTAssertEqual(blocks[0].asString, "what @")
     }
     
     func testHashtagsInQuote() {
@@ -49,25 +49,25 @@ class ReplyTests: XCTestCase {
         let blocks = parse_post_blocks(content: content)
         
         XCTAssertEqual(blocks.count, 3)
-        XCTAssertEqual(blocks[0].is_text, "This is my \"")
-        XCTAssertEqual(blocks[1].is_hashtag, "awesome")
-        XCTAssertEqual(blocks[2].is_text, " post\"")
+        XCTAssertEqual(blocks[0].asText, "This is my \"")
+        XCTAssertEqual(blocks[1].asHashtag, "awesome")
+        XCTAssertEqual(blocks[2].asText, " post\"")
     }
     
     func testHashtagAtStartWorks() {
         let content = "#hashtag"
         let blocks = parse_post_blocks(content: content)
         XCTAssertEqual(blocks.count, 1)
-        XCTAssertEqual(blocks[0].is_hashtag, "hashtag")
+        XCTAssertEqual(blocks[0].asHashtag, "hashtag")
     }
     
     func testGroupOfHashtags() {
         let content = "#hashtag#what#nope"
         let blocks = parse_post_blocks(content: content)
         XCTAssertEqual(blocks.count, 3)
-        XCTAssertEqual(blocks[0].is_hashtag, "hashtag")
-        XCTAssertEqual(blocks[1].is_hashtag, "what")
-        XCTAssertEqual(blocks[2].is_hashtag, "nope")
+        XCTAssertEqual(blocks[0].asHashtag, "hashtag")
+        XCTAssertEqual(blocks[1].asHashtag, "what")
+        XCTAssertEqual(blocks[2].asHashtag, "nope")
     }
     
     func testRootReplyWithMention() throws {
@@ -109,7 +109,7 @@ class ReplyTests: XCTestCase {
         let tags: [[String]] = [[],[],[],[],[],[],[],[],[],[],["p", "3e999f94e2cb34ef44a64b351141ac4e51b5121b2d31aed4a6c84602a1144692"]]
         let ev = NostrEvent(content: content, keypair: test_keypair, tags: tags)!
         let blocks = parse_note_content(content: .init(note: ev, keypair: test_keypair)).blocks
-        let mentions = blocks.filter { $0.is_mention != nil }
+        let mentions = blocks.filter { $0.asMention != nil }
         XCTAssertEqual(mentions.count, 1)
     }
 
@@ -129,14 +129,14 @@ class ReplyTests: XCTestCase {
         XCTAssertEqual(post_note.content, expected_render)
 
         let blocks = parse_note_content(content: .content(post_note.content,nil)).blocks
-        let rendered = render_blocks(blocks: blocks)
+        let rendered = blocks.map { $0.asString }.joined(separator: "")
 
         XCTAssertEqual(rendered, expected_render)
 
         XCTAssertEqual(blocks.count, 3)
-        XCTAssertEqual(blocks[0].is_mention, .any(.pubkey(pk)))
-        XCTAssertEqual(blocks[1].is_text, "\n")
-        XCTAssertEqual(blocks[2].is_mention, .any(.pubkey(pk)))
+        XCTAssertEqual(blocks[0].asMention, .any(.pubkey(pk)))
+        XCTAssertEqual(blocks[1].asText, "\n")
+        XCTAssertEqual(blocks[2].asMention, .any(.pubkey(pk)))
     }
     
     func testThreadedReply() throws {
@@ -279,9 +279,9 @@ class ReplyTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
-        XCTAssertEqual(parsed[0].is_text, "this is ")
-        XCTAssertNotNil(parsed[1].is_mention)
-        XCTAssertEqual(parsed[2].is_text, " a mention")
+        XCTAssertEqual(parsed[0].asText, "this is ")
+        XCTAssertNotNil(parsed[1].asMention)
+        XCTAssertEqual(parsed[2].asText, " a mention")
     }
     
     func testEmptyPostReference() throws {
@@ -295,8 +295,8 @@ class ReplyTests: XCTestCase {
         let blocks = parse_post_blocks(content: content)
         
         XCTAssertEqual(blocks.count, 2)
-        XCTAssertEqual(blocks[0].is_mention, .any(.pubkey(pk)))
-        XCTAssertEqual(blocks[1].is_text, " hello there")
+        XCTAssertEqual(blocks[0].asMention, .any(.pubkey(pk)))
+        XCTAssertEqual(blocks[1].asText, " hello there")
 
     }
     
@@ -306,8 +306,8 @@ class ReplyTests: XCTestCase {
         let blocks = parse_post_blocks(content: content)
         
         XCTAssertEqual(blocks.count, 2)
-        XCTAssertEqual(blocks[1].is_mention, .any(.pubkey(pk)))
-        XCTAssertEqual(blocks[0].is_text, "this is a ")
+        XCTAssertEqual(blocks[1].asMention, .any(.pubkey(pk)))
+        XCTAssertEqual(blocks[0].asText, "this is a ")
     }
     
     func testNpubMention() throws {
@@ -320,7 +320,7 @@ class ReplyTests: XCTestCase {
 
         XCTAssertEqual(ev.tags.count, 2)
         XCTAssertEqual(blocks.count, 3)
-        XCTAssertEqual(blocks[1].is_mention, .any(.pubkey(pk)))
+        XCTAssertEqual(blocks[1].asMention, .any(.pubkey(pk)))
         XCTAssertEqual(ev.content, "this is a nostr:npub1xtscya34g58tk0z605fvr788k263gsu6cy9x0mhnm87echrgufzsevkk5s mention")
     }
     
@@ -335,7 +335,7 @@ class ReplyTests: XCTestCase {
 
         XCTAssertEqual(ev.tags.count, 2)
         XCTAssertEqual(blocks.count, 3)
-        XCTAssertEqual(blocks[1].is_mention, .any(.pubkey(pk)))
+        XCTAssertEqual(blocks[1].asMention, .any(.pubkey(pk)))
         XCTAssertEqual(ev.content, "this is a nostr:npub1enu46e5x2qtcmm72ttzsx6fmve5wkauftassz78l3mvluh8efqhqejf3v4 mention")
     }
     
@@ -402,9 +402,9 @@ class ReplyTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
-        XCTAssertEqual(parsed[0].is_text, "this is a ")
-        XCTAssertEqual(parsed[1].is_mention, .any(.pubkey(id)))
-        XCTAssertEqual(parsed[2].is_text, " event mention")
+        XCTAssertEqual(parsed[0].asText, "this is a ")
+        XCTAssertEqual(parsed[1].asMention, .any(.pubkey(id)))
+        XCTAssertEqual(parsed[2].asText, " event mention")
         
         guard case .text(let t1) = parsed[0] else {
             XCTAssertTrue(false)
@@ -425,9 +425,9 @@ class ReplyTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
-        XCTAssertEqual(parsed[0].is_text, "this is a ")
-        XCTAssertEqual(parsed[1].is_mention, .any(.note(id)))
-        XCTAssertEqual(parsed[2].is_text, " event mention")
+        XCTAssertEqual(parsed[0].asText, "this is a ")
+        XCTAssertEqual(parsed[1].asMention, .any(.note(id)))
+        XCTAssertEqual(parsed[2].asText, " event mention")
 
         guard case .text(let t1) = parsed[0] else {
             XCTAssertTrue(false)
@@ -447,9 +447,9 @@ class ReplyTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
-        XCTAssertEqual(parsed[0].is_text, "this is ")
-        XCTAssertEqual(parsed[1].is_text, "#[0]")
-        XCTAssertEqual(parsed[2].is_text, " a mention")
+        XCTAssertEqual(parsed[0].asText, "this is ")
+        XCTAssertEqual(parsed[1].asText, "#[0]")
+        XCTAssertEqual(parsed[2].asText, " a mention")
     }
 
 }

--- a/damusTests/ReplyTests.swift
+++ b/damusTests/ReplyTests.swift
@@ -41,7 +41,7 @@ class ReplyTests: XCTestCase {
         let blocks = parse_post_blocks(content: content)
         
         XCTAssertEqual(blocks.count, 1)
-        XCTAssertEqual(blocks[0].asString, "what @")
+        XCTAssertEqual(blocks[0].asText, "what @")
     }
     
     func testHashtagsInQuote() {

--- a/damusTests/UrlTests.swift
+++ b/damusTests/UrlTests.swift
@@ -26,65 +26,86 @@ final class UrlTests: XCTestCase {
     }
 
     func testParseUrlTrailingParenthesis() {
+        let testURL = URL(string: "https://en.m.wikipedia.org/wiki/Delicious_(website)")
+        XCTAssertNotNil(testURL)
+        
         let testString = "https://en.m.wikipedia.org/wiki/Delicious_(website)"
+        
         let parsed = parse_note_content(content: .content(testString, nil)).blocks
 
         XCTAssertNotNil(parsed)
-        XCTAssertEqual(parsed[0].is_url?.absoluteString, testString)
+        XCTAssertEqual(parsed[0].asURL, testURL)
     }
 
     func testParseUrlTrailingParenthesisAndInitialParenthesis() {
+        let testURL = URL(string: "https://en.m.wikipedia.org/wiki/Delicious_(website)")
+        XCTAssertNotNil(testURL)
+        
         let testString = "( https://en.m.wikipedia.org/wiki/Delicious_(website)"
         let parsed = parse_note_content(content: .content(testString, nil)).blocks
-
+        
         XCTAssertNotNil(parsed)
-        XCTAssertEqual(parsed[1].is_url?.absoluteString, "https://en.m.wikipedia.org/wiki/Delicious_(website)")
+        XCTAssertEqual(parsed[1].asURL, testURL)
     }
 
     func testParseUrlTrailingParenthesisShouldntParse() {
+        let testURL = URL(string: "https://jb55.com")
+        XCTAssertNotNil(testURL)
+        
         let testString = "(https://jb55.com)"
         let parsed = parse_note_content(content: .content(testString, nil)).blocks
 
         XCTAssertNotNil(parsed)
-        XCTAssertEqual(parsed[1].is_url?.absoluteString, "https://jb55.com")
+        XCTAssertEqual(parsed[1].asURL, testURL)
     }
 
     func testParseSmartParens() {
+        let testURL = URL(string: "https://nostr-con.com/simplex")
+        XCTAssertNotNil(testURL)
+        
         let testString = "(https://nostr-con.com/simplex)"
         let parsed = parse_note_content(content: .content(testString, nil)).blocks
 
         XCTAssertNotNil(parsed)
-        XCTAssertEqual(parsed[1].is_url?.absoluteString, "https://nostr-con.com/simplex")
+        XCTAssertEqual(parsed[1].asURL, testURL)
     }
 
     func testLinkIsNotAHashtag() {
         let link = "https://github.com/damus-io/damus/blob/b7513f28fa1d31c2747865067256ad1d7cf43aac/damus/Nostr/NostrEvent.swift#L560"
+        let testURL = URL(string: link)
+        XCTAssertNotNil(testURL)
 
         let content = "my \(link) link"
         let blocks = parse_post_blocks(content: content)
 
         XCTAssertEqual(blocks.count, 3)
-        XCTAssertEqual(blocks[0].is_text, "my ")
-        XCTAssertEqual(blocks[1].is_url, URL(string: link)!)
-        XCTAssertEqual(blocks[2].is_text, " link")
+        XCTAssertEqual(blocks[0].asText, "my ")
+        XCTAssertEqual(blocks[1].asURL, testURL)
+        XCTAssertEqual(blocks[2].asText, " link")
     }
 
     func testParseUrlUpper() {
+        let testURL = URL(string: "HTTPS://jb55.COM")
+        XCTAssertNotNil(testURL)
+        
         let parsed = parse_note_content(content: .content("a HTTPS://jb55.COM b", nil)).blocks
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
-        XCTAssertEqual(parsed[1].is_url?.absoluteString, "HTTPS://jb55.COM")
+        XCTAssertEqual(parsed[1].asURL, testURL)
     }
     
     func testUrlAnchorsAreNotHashtags() {
+        let testURL = URL(string: "https://jb55.com/index.html#buybitcoin")
+        XCTAssertNotNil(testURL)
+        
         let content = "this is my link: https://jb55.com/index.html#buybitcoin this is not a hashtag!"
         let blocks = parse_post_blocks(content: content)
 
         XCTAssertEqual(blocks.count, 3)
-        XCTAssertEqual(blocks[0].is_text, "this is my link: ")
-        XCTAssertEqual(blocks[1].is_url, URL(string: "https://jb55.com/index.html#buybitcoin")!)
-        XCTAssertEqual(blocks[2].is_text, " this is not a hashtag!")
+        XCTAssertEqual(blocks[0].asText, "this is my link: ")
+        XCTAssertEqual(blocks[1].asURL, testURL)
+        XCTAssertEqual(blocks[2].asText, " this is not a hashtag!")
     }
 
 }

--- a/damusTests/damusTests.swift
+++ b/damusTests/damusTests.swift
@@ -159,8 +159,13 @@ class damusTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 2)
-//        XCTAssertEqual(parsed[0].is_url?.absoluteString, "https://jb55.com")
-//        XCTAssertEqual(parsed[1].is_text, " br")
+        
+        let testURL = URL(string: "https://jb55.com")
+        XCTAssertNotNil(testURL)
+        
+        XCTAssertEqual(parsed[0].asURL, testURL)
+        
+        XCTAssertEqual(parsed[1].asText, " br")
     }
     
     func testNoParseUrlWithOnlyWhitespace() {
@@ -168,15 +173,19 @@ class damusTests: XCTestCase {
         let parsed = parse_note_content(content: .content(testString,nil)).blocks
 
         XCTAssertNotNil(parsed)
-//        XCTAssertEqual(parsed[0].is_text, testString)
+        XCTAssertFalse(parsed[0].isURL)
+        XCTAssertEqual(parsed[0].asText, testString)
     }
     
     func testNoParseUrlTrailingCharacters() {
         let testString = "https://foo.bar, "
         let parsed = parse_note_content(content: .content(testString,nil)).blocks
 
+        let testURL = URL(string: "https://foo.bar")
+        XCTAssertNotNil(testURL)
+        
         XCTAssertNotNil(parsed)
-//        XCTAssertEqual(parsed[0].is_url?.absoluteString, "https://foo.bar")
+        XCTAssertEqual(parsed[0].asURL, testURL)
     }
 
 
@@ -210,7 +219,7 @@ class damusTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 1)
-//        XCTAssertEqual(parsed[0].is_text, "there is no mention here")
+        XCTAssertEqual(parsed[0].asText, "there is no mention here")
         
         guard case .text(let txt) = parsed[0] else {
             XCTAssertTrue(false)

--- a/damusTests/damusTests.swift
+++ b/damusTests/damusTests.swift
@@ -8,6 +8,7 @@
 import XCTest
 @testable import damus
 
+
 class damusTests: XCTestCase {
 
     override func setUpWithError() throws {
@@ -77,9 +78,15 @@ class damusTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
-        XCTAssertNotNil(parsed[0].is_text)
-        XCTAssertNotNil(parsed[1].is_url)
-        XCTAssertNotNil(parsed[2].is_text)
+        
+        XCTAssertTrue(parsed[0].isText)
+        XCTAssertFalse(parsed[0].isURL)
+        
+        XCTAssertTrue(parsed[1].isURL)
+        XCTAssertFalse(parsed[1].isText)
+        
+        XCTAssertTrue(parsed[2].isText)
+        XCTAssertFalse(parsed[2].isURL)
     }
 
     func testStringArrayStorage() {
@@ -126,7 +133,11 @@ class damusTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 3)
-        XCTAssertEqual(parsed[1].is_url?.absoluteString, "https://jb55.com")
+        
+        let url = URL(string: "https://jb55.com")
+        XCTAssertNotNil(url)
+        
+        XCTAssertEqual(parsed[1].asURL, url)
     }
     
     func testParseUrlEnd() {
@@ -134,8 +145,13 @@ class damusTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 2)
-        XCTAssertEqual(parsed[0].is_text, "a ")
-        XCTAssertEqual(parsed[1].is_url?.absoluteString, "https://jb55.com")
+        
+        XCTAssertEqual(parsed[0].asString, "a ")
+        
+        let url = URL(string: "https://jb55.com")
+        XCTAssertNotNil(url)
+        
+        XCTAssertEqual(parsed[1].asURL, url)
     }
     
     func testParseUrlStart() {
@@ -143,8 +159,8 @@ class damusTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 2)
-        XCTAssertEqual(parsed[0].is_url?.absoluteString, "https://jb55.com")
-        XCTAssertEqual(parsed[1].is_text, " br")
+//        XCTAssertEqual(parsed[0].is_url?.absoluteString, "https://jb55.com")
+//        XCTAssertEqual(parsed[1].is_text, " br")
     }
     
     func testNoParseUrlWithOnlyWhitespace() {
@@ -152,7 +168,7 @@ class damusTests: XCTestCase {
         let parsed = parse_note_content(content: .content(testString,nil)).blocks
 
         XCTAssertNotNil(parsed)
-        XCTAssertEqual(parsed[0].is_text, testString)
+//        XCTAssertEqual(parsed[0].is_text, testString)
     }
     
     func testNoParseUrlTrailingCharacters() {
@@ -160,7 +176,7 @@ class damusTests: XCTestCase {
         let parsed = parse_note_content(content: .content(testString,nil)).blocks
 
         XCTAssertNotNil(parsed)
-        XCTAssertEqual(parsed[0].is_url?.absoluteString, "https://foo.bar")
+//        XCTAssertEqual(parsed[0].is_url?.absoluteString, "https://foo.bar")
     }
 
 
@@ -194,7 +210,7 @@ class damusTests: XCTestCase {
 
         XCTAssertNotNil(parsed)
         XCTAssertEqual(parsed.count, 1)
-        XCTAssertEqual(parsed[0].is_text, "there is no mention here")
+//        XCTAssertEqual(parsed[0].is_text, "there is no mention here")
         
         guard case .text(let txt) = parsed[0] else {
             XCTAssertTrue(false)

--- a/nostrdb/NdbNote.swift
+++ b/nostrdb/NdbNote.swift
@@ -412,7 +412,15 @@ extension NdbNote {
         // Rely on Apple's NLLanguageRecognizer to tell us which language it thinks the note is in
         // and filter on only the text portions of the content as URLs and hashtags confuse the language recognizer.
         let originalBlocks = self.blocks(keypair).blocks
-        let originalOnlyText = originalBlocks.compactMap { $0.is_text }.joined(separator: " ")
+        let originalOnlyText = originalBlocks.compactMap {
+                if case .text(let txt) = $0 {
+                    return txt
+                }
+                else {
+                    return nil
+                }
+            }
+            .joined(separator: " ")
 
         // Only accept language recognition hypothesis if there's at least a 50% probability that it's accurate.
         let languageRecognizer = NLLanguageRecognizer()


### PR DESCRIPTION
Move the Block helper type to its own file, collapse the various standalone functions for parsing block data, and refactor consumers to initialize a Block with given data and access its members as needed. This is a more "idiomatic" approach to these C-backed data structures, and moves a number of these functions, extensions, and types into fileprivate scope, removing them from the global symbols and generally cleaning up their interface and usage. I plan to continue these "cleanup and refactor" changes as I learn more about the repository. This is the same as a previous pull request that was reverted because it failed to update the block parsing tests; this branch adds helper accessors for testing and updates all tests using the Block parsing functionality.