### PR TITLE
[#1527] Separate NIP-05 and username/display name onto their own lines.

### DIFF
--- a/damus/Views/Profile/ProfileName.swift
+++ b/damus/Views/Profile/ProfileName.swift
@@ -80,22 +80,24 @@ struct ProfileName: View {
     }
     
     var body: some View {
-        HStack(spacing: 2) {
-            Text(verbatim: "\(prefix)\(name_choice)")
-                .font(.body)
-                .fontWeight(prefix == "@" ? .none : .bold)
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 2) {
+                Text(verbatim: "\(prefix)\(name_choice)")
+                    .font(.body)
+                    .fontWeight(prefix == "@" ? .none : .bold)
+                if let friend = friend_type, current_nip05 == nil {
+                    FriendIcon(friend: friend)
+                }
+                if onlyzapper {
+                    Image("zap-hashtag")
+                        .frame(width: 14, height: 14)
+                }
+                if let supporter {
+                    SupporterBadge(percent: supporter)
+                }
+            }
             if let nip05 = current_nip05 {
                 NIP05Badge(nip05: nip05, pubkey: pubkey, contacts: damus_state.contacts, show_domain: show_nip5_domain, profiles: damus_state.profiles)
-            }
-            if let friend = friend_type, current_nip05 == nil {
-                FriendIcon(friend: friend)
-            }
-            if onlyzapper {
-                Image("zap-hashtag")
-                    .frame(width: 14, height: 14)
-            }
-            if let supporter {
-                SupporterBadge(percent: supporter)
             }
         }
         .onReceive(handle_notify(.profile_updated)) { update in


### PR DESCRIPTION
Addresses the additional requests for #1527

The profile username header now separates each name onto its own line: display name, username, and NIP-05 domain.
<img width="582" alt="Screenshot 2023-09-04 at 00 46 40" src="https://github.com/damus-io/damus/assets/1031501/d2691c8c-62dc-4a84-83e8-3422ad956b84">

For tips/bounties:
Zap name through Alby: fragrantleaf46245@getalby.com
LNURL:
`LNURL1DP68GURN8GHJ7EM9W3SKCCNE9E3K7MF0D3H82UNVWQHKVUNPVAEXZMN5D3JKZE35XCERGDG5SVQTZ`