### PR TITLE
[#1530] Create new controls UI for video playback

### DIFF
--- a/damus/Components/ImageCarousel.swift
+++ b/damus/Components/ImageCarousel.swift
@@ -125,7 +125,7 @@ struct ImageCarousel: View {
                         open_sheet = true
                     }
             case .video(let url):
-                DamusVideoPlayer(url: url, model: video_model(url), video_size: $video_size)
+                DamusVideoPlayer(url: url, model: video_model(url), video_size: $video_size, showControls: false)
                     .onChange(of: video_size) { size in
                         guard let size else { return }
                         

--- a/damus/Views/Images/ImageContainerView.swift
+++ b/damus/Views/Images/ImageContainerView.swift
@@ -47,7 +47,7 @@ struct ImageContainerView: View {
             case .image(let url):
                 Img(url: url)
             case .video(let url):
-                DamusVideoPlayer(url: url, model: cache.get_video_player_model(url: url), video_size: .constant(nil))
+                DamusVideoPlayer(url: url, model: cache.get_video_player_model(url: url), video_size: .constant(nil), showControls: true)
             }
         }
     }

--- a/damus/Views/Video/DamusVideoPlayer.swift
+++ b/damus/Views/Video/DamusVideoPlayer.swift
@@ -122,11 +122,8 @@ struct DamusVideoPlayer: View {
             .popover(isPresented: $isOptionsPopoverPresented,
                      attachmentAnchor: .point(.top),
                      arrowEdge: .top) {
-                if #available(iOS 16.4, macOS 13.3, *) {
-                    OptionsMenu
-                        .presentationCompactAdaptation(.popover)
-                }
-                else {
+                VStack {
+                    Text("Playback Speed").font(.title)
                     OptionsMenu
                 }
             }

--- a/damus/Views/Video/DamusVideoPlayer.swift
+++ b/damus/Views/Video/DamusVideoPlayer.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 /// get coordinates in Global reference frame given a Local point & geometry
-func globalCoordinate(localX x: CGFloat, localY y: CGFloat,
+fileprivate func globalCoordinate(localX x: CGFloat, localY y: CGFloat,
                       localGeometry geo: GeometryProxy) -> CGPoint {
     let localPoint = CGPoint(x: x, y: y)
     return geo.frame(in: .global).origin.applying(
@@ -16,21 +16,45 @@ func globalCoordinate(localX x: CGFloat, localY y: CGFloat,
     )
 }
 
+fileprivate extension Double {
+    /// Extend Double to decode hours, minutes, and seconds into a human-readable timecode (e.g. "02:41:50").
+    var secondsToHumanReadableTimecode: String {
+        guard self > 0.0 else { return "00:00" }
+        let totalSeconds = UInt64(self)
+        let hours = totalSeconds / 3600
+        let minutes = totalSeconds % 3600 / 60
+        let seconds = totalSeconds % 3600 % 60
+        if hours > 0 {
+            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
+        }
+        else {
+            return String(format: "%02d:%02d", minutes, seconds)
+        }
+    }
+}
+
+/// Damus-specific video player that displays controls for seeking, play/pause, volume control, and more.
 struct DamusVideoPlayer: View {
-    var url: URL
+    let url: URL
     @ObservedObject var model: VideoPlayerModel
     @Binding var video_size: CGSize?
     @EnvironmentObject private var orientationTracker: OrientationTracker
+    @State private var isOptionsPopoverPresented = false
+    @State private var isVolumeSliderPresented = false
+    @State private var playbackSpeedOption: PlaybackSpeedMenu.PlaybackSpeedOption = .normal
     
-    var mute_icon: String {
-        if model.has_audio == false || model.muted {
-            return "speaker.slash"
-        } else {
-            return "speaker"
-        }
+    // Track if the video was playing before seeking so we can intelligently resume playing after changing the seek time
+    @State private var wasPlayingBeforeSeek = true
+    
+    @State var showControls: Bool
+    
+    @State var onVideoTapped: (() -> Void)?
+    
+    var isMuted: Bool {
+        return model.has_audio == false || model.muted
     }
     
-    var mute_icon_color: Color {
+    var muteIconColor: Color {
         switch self.model.has_audio {
         case .none:
             return .white
@@ -39,17 +63,106 @@ struct DamusVideoPlayer: View {
         }
     }
     
-    var MuteIcon: some View {
+    func hideControls() -> Self {
+        showControls = false
+        return self
+    }
+    
+    private func VideoButton(imageName: String) -> some View {
         ZStack {
             Circle()
                 .opacity(0.2)
                 .frame(width: 32, height: 32)
                 .foregroundColor(.black)
             
-            Image(systemName: mute_icon)
-                .padding()
-                .foregroundColor(mute_icon_color)
+            Image(systemName: imageName)
+                .padding([.leading, .trailing], 1)
+                .padding([.top, .bottom], nil)
+                .foregroundColor(.white)
         }
+    }
+    
+    private var VolumeButton: some View {
+        func imageName() -> String {
+            if isMuted {
+                return "speaker.slash"
+            }
+            else {
+                switch model.volume {
+                case ..<0.01:
+                    return "speaker.slash.fill"
+                case ..<0.3:
+                    return "speaker.wave.1.fill"
+                case ..<0.6:
+                    return "speaker.wave.2.fill"
+                default:
+                    return "speaker.wave.3.fill"
+                }
+            }
+        }
+        return VideoButton(imageName: imageName())
+            .onTapGesture {
+                isVolumeSliderPresented.toggle()
+                model.muted.toggle()
+            }
+    }
+    
+    private var PlayPauseButton: some View {
+        VideoButton(imageName: model.play ? "pause" : "play")
+            .onTapGesture {
+                self.model.play.toggle()
+            }
+    }
+    
+    private var SettingsButton: some View {
+        VideoButton(imageName: isOptionsPopoverPresented ? "gearshape.fill" : "gearshape")
+            .onTapGesture {
+                isOptionsPopoverPresented.toggle()
+            }
+            .popover(isPresented: $isOptionsPopoverPresented,
+                     attachmentAnchor: .point(.top),
+                     arrowEdge: .top) {
+                if #available(iOS 16.4, macOS 13.3, *) {
+                    OptionsMenu
+                        .presentationCompactAdaptation(.popover)
+                }
+                else {
+                    OptionsMenu
+                }
+            }
+    }
+    
+    private var FullscreenButton: some View {
+        VideoButton(imageName: self.model.contentMode == .scaleAspectFill ?  "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
+            .onTapGesture {
+                switch self.model.contentMode {
+                case .scaleAspectFit:
+                    self.model.contentMode = .scaleAspectFill
+                case .scaleAspectFill:
+                    self.model.contentMode = .scaleAspectFit
+                default:
+                    break
+                }
+            }
+    }
+    
+    private var VideoTime: some View {
+        Text("\(self.model.currentTime.secondsToHumanReadableTimecode) / \(self.model.totalDuration.secondsToHumanReadableTimecode)")
+            .padding([.leading, .trailing], 1)
+            .padding([.top, .bottom], nil)
+            .monospacedDigit()
+            .foregroundColor(muteIconColor)
+            .fixedSize(horizontal: true, vertical: true)
+            .onTapGesture {
+                self.model.play.toggle()
+            }
+    }
+    
+    private var OptionsMenu: some View {
+        PlaybackSpeedMenu(selected: $playbackSpeedOption)
+            .onChange(of: playbackSpeedOption) {
+                self.model.playbackRate = $0.rawValue
+            }
     }
     
     var body: some View {
@@ -57,14 +170,88 @@ struct DamusVideoPlayer: View {
             let localFrame = geo.frame(in: .local)
             let centerY = globalCoordinate(localX: 0, localY: localFrame.midY, localGeometry: geo).y
             let delta = localFrame.height / 2
+            
             ZStack(alignment: .bottomTrailing) {
+                
                 VideoPlayer(url: url, model: model)
-                if model.has_audio == true {
-                    MuteIcon
-                        .zIndex(11.0)
-                        .onTapGesture {
-                            self.model.muted = !self.model.muted
+                    .zIndex(0.0)
+//                    .onAppear {
+//                        self.model.start()
+//                    }
+                    .onTapGesture {
+                        if let tapHandler = onVideoTapped {
+                            tapHandler()
                         }
+                        else {
+                            showControls.toggle()
+                        }
+                    }
+                
+                if showControls {       // TODO: Animate controls in/out
+                    Group {     // Group for all overlayed controls
+                        VStack(alignment: .trailing) {
+                            // Volume slider
+                            if isVolumeSliderPresented {    // TODO: Animate volume slider in/out
+                                VolumeSlider(volume: $model.volume)
+                                { editing in
+                                    // Changing the volume value unmutes
+                                    if self.model.muted {
+                                        _ = self.model.set(muted: false)
+                                    }
+                                }
+                                .frame(width: 12, height: 130)
+                                .padding([.leading, .trailing], 8)
+                                .padding([.top, .bottom], 1)
+                            }
+                            
+                            // Seek slider
+                            SeekSlider(time: Binding(get: { self.model.currentTime },
+                                                     set: { _ in }),
+                                       totalDuration: self.model.totalDuration)
+                            { editing in
+                                if editing {
+                                    self.wasPlayingBeforeSeek = model.play
+                                    model.stop()
+                                }
+                            }
+                        onTimeFinalized: { time in
+                            _ = model.set(seekSeconds: time)
+                            if self.wasPlayingBeforeSeek {
+                                model.start()
+                            }
+                        }
+                        .padding([.leading, .trailing], 8)
+                        .frame(height: 10)
+                            
+                            ZStack(alignment: .bottomTrailing) {     // Group bottom elements
+                                PlayPauseButton
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .padding([.leading, .trailing], 8)
+                                
+                                VideoTime
+                                    .frame(maxWidth: .infinity, alignment: .center)
+                                
+                                // Settings, Fullscreen, and Volume
+                                HStack {
+                                    // TODO: Changing playback speed is currently broken for unknown reasons.
+                                    SettingsButton
+                                    
+                                    if model.has_audio == true {
+                                        FullscreenButton
+                                        
+                                        VolumeButton
+                                            .padding([.trailing], 8)
+                                    }
+                                    else {
+                                        FullscreenButton
+                                        // Keep button spacing even if the VolumeButton is not present
+                                            .padding([.trailing], 32 + 16)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .zIndex(1.0)
                 }
             }
             .onChange(of: model.size) { size in
@@ -84,12 +271,187 @@ struct DamusVideoPlayer: View {
                 }
             }
         }
+        .onDisappear {
+            model.stop()
+        }
     }
 }
+fileprivate extension DamusVideoPlayer {
+    struct PlaybackSpeedMenu : View {
+        enum PlaybackSpeedOption : Float, CaseIterable, Identifiable {
+            case half           = 0.5
+            case normal         = 1.0
+            case oneAndQuarter  = 1.25
+            case oneAndHalf     = 1.5
+            case double         = 2.0
+            var id: String {
+                return String(format: "%1.2f", arguments: [self.rawValue])
+            }
+            var displayName: String {
+                switch self {
+                case .half:             return "0.5x"
+                case .normal:           return "1x"
+                case .oneAndQuarter:    return "1.25x"
+                case .oneAndHalf:       return "1.5x"
+                case .double:           return "2.0x"
+                }
+            }
+        }
+        
+        @Binding var selected: PlaybackSpeedOption
+        
+        var body: some View {
+            VStack {
+                ForEach(PlaybackSpeedOption.allCases) { option in
+                    HStack {
+                        Text(verbatim: option.displayName)
+                            .frame(minWidth: 150, maxWidth: .infinity, alignment: .leading)
+                            .padding()
+                        Image(systemName: (self.selected == option) ? "checkmark" : "circle")
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                            .padding()
+                    }
+                    .onTapGesture {
+                        self.selected = option
+                    }
+                }
+            }
+            .frame(minWidth: 200)
+        }
+    }
+}
+fileprivate extension DamusVideoPlayer {
+    /// A vertical volume slider ranging from 0.0 (silent) to 1.0 (full volume).
+    /// `onEditingChanged` is called when the user begins or ends editing the volume value using this slider
+    /// Inspired by [pratikg29's VerticalVolumeSlider](https://github.com/pratikg29/Custom-Slider-Control/blob/main/AppleMusicSlider/AppleMusicSlider/VerticalVolumeSlider.swift)
+    struct VolumeSlider : View {
+        @Binding var volume: Float
+        @State private var localRealProgress: Float = 0
+        @State private var localTempProgress: Float = 0
+        @GestureState private var isEditing: Bool = false
+        let onEditingChanged: (Bool) -> Void
+        
+        var body: some View {
+            GeometryReader { bounds in
+                ZStack {
+                    GeometryReader { geo in
+                        ZStack(alignment: .bottom) {
+                            RoundedRectangle(cornerRadius: bounds.size.width, style: .continuous)
+                                .fill(Color.black)
+                            RoundedRectangle(cornerRadius: bounds.size.width, style: .continuous)
+                                .foregroundColor(.accentColor)
+                                .mask({
+                                    VStack {
+                                        Spacer(minLength: 0)
+                                        Rectangle()
+                                            .frame(height: max(geo.size.height * CGFloat((localRealProgress + localTempProgress)), 0),
+                                                   alignment: .leading)
+                                    }
+                                })
+                        }
+                        .clipped()
+                    }
+                }
+                .frame(width: bounds.size.width, height: bounds.size.height, alignment: .center)
+                .gesture(DragGesture(minimumDistance: 8, coordinateSpace: .local)
+                    .updating($isEditing) { value, state, transaction in
+                        state = true
+                    }
+                    .onChanged { gesture in
+                        localTempProgress = Float(-gesture.translation.height / bounds.size.height)
+                        volume = max(min(localRealProgress + localTempProgress, 1.0), 0.0)
+                    }.onEnded { value in
+                        localRealProgress = max(min(localRealProgress + localTempProgress, 1), 0)
+                        localTempProgress = 0
+                    })
+                .onChange(of: isEditing) { editing in
+                    onEditingChanged(editing)
+                }
+                .onAppear {
+                    localRealProgress = volume
+                }
+                .onChange(of: volume) { newValue in
+                    if !(isEditing) {
+                        localRealProgress = volume
+                    }
+                }
+            }
+            .frame(alignment: .center)
+        }
+    }
+}
+fileprivate extension DamusVideoPlayer {
+    /// A seek time slider ranging from 0.0 (beginning) to `totalDuration` at the end.
+    /// `onEditingChanged` is called when the user begins or ends editing the current play location using this slider.
+    /// `onTimeFinalized` is called when the user end editing and the new time has been calculated, ready for seek.
+    /// Inspired by [pratikg29's VerticalVolumeSlider](https://github.com/pratikg29/Custom-Slider-Control/blob/main/AppleMusicSlider/AppleMusicSlider/VerticalVolumeSlider.swift)
+    struct SeekSlider : View {
+        @Binding var time: Double
+        @State private var localRealProgress: Double = 0
+        @State private var localTempProgress: Double = 0
+        @GestureState private var isEditing: Bool = false
+        let totalDuration: Double
+        let onEditingChanged: (Bool) -> Void
+        let onTimeFinalized: (Double) -> Void
+        
+        var body: some View {
+            GeometryReader { bounds in
+                ZStack {
+                    GeometryReader { geo in
+                        ZStack(alignment: .leading) {
+                            RoundedRectangle(cornerRadius: bounds.size.height, style: .continuous)
+                                .fill(Color.black)
+                            RoundedRectangle(cornerRadius: bounds.size.height, style: .continuous)
+                                .foregroundColor(.accentColor)
+                                .mask({
+                                    HStack {
+                                        Rectangle()
+                                            .frame(width: max(geo.size.width * CGFloat((localRealProgress + localTempProgress)), 0),
+                                                   alignment: .leading)
+                                        Spacer(minLength: 0)
+                                    }
+                                })
+                        }
+                        .clipped()
+                    }
+                }
+                .frame(width: bounds.size.width, height: bounds.size.height, alignment: .center)
+                .gesture(DragGesture(minimumDistance: 8, coordinateSpace: .local)
+                    .updating($isEditing) { value, state, transaction in
+                        state = true
+                    }
+                    .onChanged { gesture in
+                        localTempProgress = Double(gesture.translation.width / bounds.size.width)
+                        time = max(min(localRealProgress + localTempProgress, 1.0), 0.0)
+                    }.onEnded { value in
+                        localRealProgress = max(min(localRealProgress + localTempProgress, 1.0), 0)
+                        localTempProgress = 0
+                        
+                        onTimeFinalized(localRealProgress * totalDuration)
+                    })
+                .onChange(of: isEditing) { editing in
+                    onEditingChanged(editing)
+                }
+                .onAppear {
+                    localRealProgress = time / totalDuration
+                }
+                .onChange(of: time) { newValue in
+                    if !(isEditing) {
+                        localRealProgress = time / totalDuration
+                    }
+                }
+            }
+            .frame(alignment: .center)
+        }
+    }
+}
+
 struct DamusVideoPlayer_Previews: PreviewProvider {
     @StateObject static var model: VideoPlayerModel = VideoPlayerModel()
     
     static var previews: some View {
-        DamusVideoPlayer(url: URL(string: "http://cdn.jb55.com/s/zaps-build.mp4")!, model: model, video_size: .constant(nil))
+        DamusVideoPlayer(url: URL(string: "http://cdn.jb55.com/s/zaps-build.mp4")!, model: model, video_size: .constant(nil), showControls: true)
+            .environmentObject(OrientationTracker())
+//            .previewInterfaceOrientation(.landscapeLeft)
     }
 }

--- a/damus/Views/Video/DamusVideoPlayer.swift
+++ b/damus/Views/Video/DamusVideoPlayer.swift
@@ -129,20 +129,6 @@ struct DamusVideoPlayer: View {
             }
     }
     
-    private var FullscreenButton: some View {
-        VideoButton(imageName: self.model.contentMode == .scaleAspectFill ?  "arrow.down.right.and.arrow.up.left" : "arrow.up.left.and.arrow.down.right")
-            .onTapGesture {
-                switch self.model.contentMode {
-                case .scaleAspectFit:
-                    self.model.contentMode = .scaleAspectFill
-                case .scaleAspectFill:
-                    self.model.contentMode = .scaleAspectFit
-                default:
-                    break
-                }
-            }
-    }
-    
     private var VideoTime: some View {
         Text("\(self.model.currentTime.secondsToHumanReadableTimecode) / \(self.model.totalDuration.secondsToHumanReadableTimecode)")
             .foregroundColor(muteIconColor)
@@ -226,20 +212,15 @@ struct DamusVideoPlayer: View {
                                     .padding([.leading, .trailing], 1)
                                     .padding([.top, .bottom], nil)
                                 
-                                // Settings, Fullscreen, and Volume
+                                // Settings and Volume
                                 HStack {
                                     SettingsButton
+                                    // Keep button spacing even if the VolumeButton is not present
+                                        .padding([.trailing], model.has_audio == true ? 0 : 47)
                                     
                                     if model.has_audio == true {
-                                        FullscreenButton
-                                        
                                         VolumeButton
                                             .padding([.trailing], 8)
-                                    }
-                                    else {
-                                        FullscreenButton
-                                        // Keep button spacing even if the VolumeButton is not present
-                                            .padding([.trailing], 32 + 16)
                                     }
                                 }
                             }

--- a/damus/Views/Video/DamusVideoPlayer.swift
+++ b/damus/Views/Video/DamusVideoPlayer.swift
@@ -148,10 +148,9 @@ struct DamusVideoPlayer: View {
     
     private var VideoTime: some View {
         Text("\(self.model.currentTime.secondsToHumanReadableTimecode) / \(self.model.totalDuration.secondsToHumanReadableTimecode)")
-            .padding([.leading, .trailing], 1)
-            .padding([.top, .bottom], nil)
-            .monospacedDigit()
             .foregroundColor(muteIconColor)
+            // Both of these ensure that the Text label doesn't jump around from digit width changes
+            .monospacedDigit()
             .fixedSize(horizontal: true, vertical: true)
             .onTapGesture {
                 self.model.play.toggle()
@@ -175,9 +174,6 @@ struct DamusVideoPlayer: View {
                 
                 VideoPlayer(url: url, model: model)
                     .zIndex(0.0)
-//                    .onAppear {
-//                        self.model.start()
-//                    }
                     .onTapGesture {
                         if let tapHandler = onVideoTapped {
                             tapHandler()
@@ -230,10 +226,11 @@ struct DamusVideoPlayer: View {
                                 
                                 VideoTime
                                     .frame(maxWidth: .infinity, alignment: .center)
+                                    .padding([.leading, .trailing], 1)
+                                    .padding([.top, .bottom], nil)
                                 
                                 // Settings, Fullscreen, and Volume
                                 HStack {
-                                    // TODO: Changing playback speed is currently broken for unknown reasons.
                                     SettingsButton
                                     
                                     if model.has_audio == true {
@@ -383,7 +380,7 @@ fileprivate extension DamusVideoPlayer {
 fileprivate extension DamusVideoPlayer {
     /// A seek time slider ranging from 0.0 (beginning) to `totalDuration` at the end.
     /// `onEditingChanged` is called when the user begins or ends editing the current play location using this slider.
-    /// `onTimeFinalized` is called when the user end editing and the new time has been calculated, ready for seek.
+    /// `onTimeFinalized` is called when the user ends editing and the new time has been calculated, ready for seek.
     /// Inspired by [pratikg29's VerticalVolumeSlider](https://github.com/pratikg29/Custom-Slider-Control/blob/main/AppleMusicSlider/AppleMusicSlider/VerticalVolumeSlider.swift)
     struct SeekSlider : View {
         @Binding var time: Double

--- a/damus/Views/Video/VideoPlayer.swift
+++ b/damus/Views/Video/VideoPlayer.swift
@@ -310,10 +310,6 @@ extension VideoPlayer: UIViewRepresentable {
             self.videoPlayer = videoPlayer
         }
         
-        deinit {
-            print("Coordinator.deinit!")
-        }
-        
         @MainActor
         func startObserver(uiView: VideoPlayerView) {
             guard observer == nil else { return }


### PR DESCRIPTION
Addresses #1530

Create a new controls UI layer for the DamusVideoPlayer, providing play/pause, volume control, content scale, playback rate controls, as well as a seek/timecode bar.

<img width="594" alt="Screenshot 2023-09-05 at 11 42 46" src="https://github.com/damus-io/damus/assets/1031501/de89196e-0951-4a59-8430-99a8cd166e60">
<img width="586" alt="Screenshot 2023-09-05 at 11 42 55" src="https://github.com/damus-io/damus/assets/1031501/4a947870-640d-4c7e-89f7-1eab30326aa3">

## Features
- Scrub on the horizontal seek bar to change the playback time
- Play/Pause button
- Mute/Unmute button and volume vertical slider
- Select playback rate from 0.5x up to 2.0x
- Tap video to hide/show controls
- Swap between aspect fill and aspect fit
- Player has option to hide controls on startup
- Player's video tap behavior can be customized
## Fixes
- The VideoPlayer has been reworked from frame-by-frame updating to an event-driven model, significantly improving performance and understandability.
- The VideoPlayer and DamusVideoPlayer had a number of leaks that were preventing resource cleanup and causing a lot of conflicting video playback behavior.
## TODOs
- Animate the volume slider in/out
- Animate the entire control layer in/out
- Create a timer to automatically hide the controls after some time of inactivity
- Color/Theme unification
## Known Issues
- This still suffers from [#1386] as that is a navigation/data model architecture issue, not specific to the video player.
## Notes
- !! This feature *DOES NOT* INCLUDE A FIX FOR #1386 ! That fix will be provided in a future PR. !!
## Support
Bounty: 100k satoshis(BTC) -> 0.001 BTC
Payout Address: `bc1q5sxugecyhq5stxn4d79p4908hdr7ljcn35uyk7`
<img width="341" alt="btc001" src="https://github.com/damus-io/damus/assets/1031501/54552b4f-ad4e-4842-b1a2-2ac44bf47ad7">

