### PR TITLE
Enable m3u8 playback

### DIFF
--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -582,7 +582,7 @@ func classify_url(_ url: URL) -> UrlType {
         return .media(.image(url))
     }
     
-    if str.hasSuffix(".mp4") || str.hasSuffix(".mov") {
+    if str.hasSuffix(".mp4") || str.hasSuffix(".mov") || str.hasSuffix(".m3u8") {
         return .media(.video(url))
     }
     

--- a/damus/Views/Video/DamusVideoPlayer.swift
+++ b/damus/Views/Video/DamusVideoPlayer.swift
@@ -43,6 +43,9 @@ struct DamusVideoPlayer: View {
                 if model.has_audio {
                     mute_button
                 }
+                if model.is_live {
+                    live_indicator
+                }
             }
             .onChange(of: centerY) { _ in
                 update_is_visible(centerY: centerY)
@@ -91,6 +94,25 @@ struct DamusVideoPlayer: View {
                     }
                 }
             }
+        }
+    }
+    
+    private var live_indicator: some View {
+        VStack {
+            HStack {
+                Text("LIVE")
+                    .bold()
+                    .foregroundColor(.red)
+                    .padding(.horizontal)
+                    .padding(.vertical, 5)
+                    .background(
+                        Capsule()
+                            .fill(Color.black.opacity(0.5))
+                    )
+                    .padding([.top, .leading])
+                Spacer()
+            }
+            Spacer()
         }
     }
 }


### PR DESCRIPTION
Fix for #798 with additional fixes for audio track detection and video size setting, so it works with HLS, as well as other video files.