### PR TITLE
nav: prevent duplicated push

### DIFF
--- a/damus/Util/Router.swift
+++ b/damus/Util/Router.swift
@@ -218,6 +218,9 @@ class NavigationCoordinator: ObservableObject {
     @Published var path = [Route]()
 
     func push(route: Route) {
+        guard route != path.last else {
+            return
+        }
         path.append(route)
     }
     


### PR DESCRIPTION
Skip push if the route is already the top route.

Initially intended for #104, I added the precondition in `NavigationCoordinator.push(route:)` because I believe that this might be a generally desirable behavior.

Fixes #104