### PR TITLE
ux: add long press to profile to navigate to profile page

### DIFF
--- a/damus/Views/Events/EventProfile.swift
+++ b/damus/Views/Events/EventProfile.swift
@@ -41,6 +41,10 @@ struct EventProfile: View {
                 .onTapGesture {
                     show_profile_action_sheet_if_enabled(damus_state: damus_state, pubkey: pubkey)
                 }
+                .onLongPressGesture(minimumDuration: 0.1) {
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    damus_state.nav.push(route: Route.ProfileByKey(pubkey: pubkey))
+                }
 
             VStack(alignment: .leading, spacing: 0) {
                 EventProfileName(pubkey: pubkey, damus: damus_state, size: size)

--- a/damus/Views/Profile/MaybeAnonPfpView.swift
+++ b/damus/Views/Profile/MaybeAnonPfpView.swift
@@ -32,6 +32,10 @@ struct MaybeAnonPfpView: View {
                     .onTapGesture {
                         show_profile_action_sheet_if_enabled(damus_state: state, pubkey: pubkey)
                     }
+                    .onLongPressGesture(minimumDuration: 0.1) {
+                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                        state.nav.push(route: Route.ProfileByKey(pubkey: pubkey))
+                    }
             }
         }
     }


### PR DESCRIPTION
Changelog-Added: Long press on a profile image navigates to their page 

nostr:note1cvg2de6g83ulvjf8yxju44kf0nx48lp62q4pjx5etjr29s36dfkqpzs5ll

