### PR TITLE
refactor: rename show image references to blur images

### DIFF
--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -107,8 +107,8 @@ class UserSettingsStore: ObservableObject {
     @Setting(key: "left_handed", default_value: false)
     var left_handed: Bool
     
-    @Setting(key: "always_show_images", default_value: false)
-    var always_show_images: Bool
+    @Setting(key: "blur_images", default_value: true)
+    var blur_images: Bool
     
     @Setting(key: "hide_nsfw_tagged_content", default_value: false)
     var hide_nsfw_tagged_content: Bool

--- a/damus/Views/DMView.swift
+++ b/damus/Views/DMView.swift
@@ -39,10 +39,10 @@ struct DMView: View {
                 Spacer(minLength: UIScreen.main.bounds.width * 0.2)
             }
 
-            let should_show_img = should_show_images(settings: damus_state.settings, contacts: damus_state.contacts, ev: event, our_pubkey: damus_state.pubkey)
+            let should_blur_img = should_blur_images(settings: damus_state.settings, contacts: damus_state.contacts, ev: event, our_pubkey: damus_state.pubkey)
 
             VStack(alignment: .trailing) {
-                NoteContentView(damus_state: damus_state, event: event, show_images: should_show_img, size: .normal, options: dm_options)
+                NoteContentView(damus_state: damus_state, event: event, blur_images: should_blur_img, size: .normal, options: dm_options)
                     .fixedSize(horizontal: false, vertical: true)
                     .padding([.top, .leading, .trailing], 10)
                     .padding([.bottom], 25)

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -54,21 +54,21 @@ struct EventView: View {
 }
 
 // blame the porn bots for this code
-func should_show_images(settings: UserSettingsStore, contacts: Contacts, ev: NostrEvent, our_pubkey: Pubkey, booster_pubkey: Pubkey? = nil) -> Bool {
-    if settings.always_show_images {
-        return true
+func should_blur_images(settings: UserSettingsStore, contacts: Contacts, ev: NostrEvent, our_pubkey: Pubkey, booster_pubkey: Pubkey? = nil) -> Bool {
+    if !settings.blur_images {
+        return false
     }
     
     if ev.pubkey == our_pubkey {
-        return true
+        return false
     }
     if contacts.is_in_friendosphere(ev.pubkey) {
-        return true
+        return false
     }
     if let boost_key = booster_pubkey, contacts.is_in_friendosphere(boost_key) {
-        return true
+        return false
     }
-    return false
+    return true
 }
 
 func format_relative_time(_ created_at: UInt32) -> String

--- a/damus/Views/Events/EventBody.swift
+++ b/damus/Views/Events/EventBody.swift
@@ -11,19 +11,19 @@ struct EventBody: View {
     let damus_state: DamusState
     let event: NostrEvent
     let size: EventViewKind
-    let should_show_img: Bool
+    let should_blur_img: Bool
     let options: EventViewOptions
     
-    init(damus_state: DamusState, event: NostrEvent, size: EventViewKind, should_show_img: Bool? = nil, options: EventViewOptions) {
+    init(damus_state: DamusState, event: NostrEvent, size: EventViewKind, should_blur_img: Bool? = nil, options: EventViewOptions) {
         self.damus_state = damus_state
         self.event = event
         self.size = size
         self.options = options
-        self.should_show_img = should_show_img ?? should_show_images(settings: damus_state.settings, contacts: damus_state.contacts, ev: event, our_pubkey: damus_state.pubkey)
+        self.should_blur_img = should_blur_img ?? should_blur_images(settings: damus_state.settings, contacts: damus_state.contacts, ev: event, our_pubkey: damus_state.pubkey)
     }
 
     var note_content: some View {
-        NoteContentView(damus_state: damus_state, event: event, show_images: should_show_img, size: size, options: options)
+        NoteContentView(damus_state: damus_state, event: event, blur_images: should_blur_img, size: size, options: options)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 

--- a/damus/Views/Events/Longform/LongformView.swift
+++ b/damus/Views/Events/Longform/LongformView.swift
@@ -54,7 +54,7 @@ struct LongformView: View {
         EventShell(state: state, event: event.event, options: options) {
             SelectableText(attributedString: AttributedString(stringLiteral: event.title ?? "Untitled"), size: .title)
 
-            NoteContentView(damus_state: state, event: event.event, show_images: true, size: .selected, options: options)
+            NoteContentView(damus_state: state, event: event.event, blur_images: false, size: .selected, options: options)
         }
     }
 }

--- a/damus/Views/Events/TextEvent.swift
+++ b/damus/Views/Events/TextEvent.swift
@@ -45,11 +45,11 @@ struct TextEvent: View {
     }
 
     func EvBody(options: EventViewOptions) -> some View {
-        let show_imgs = should_show_images(settings: damus.settings, contacts: damus.contacts, ev: event, our_pubkey: damus.pubkey)
+        let blur_imgs = should_blur_images(settings: damus.settings, contacts: damus.contacts, ev: event, our_pubkey: damus.pubkey)
         return NoteContentView(
             damus_state: damus,
             event: event,
-            show_images: show_imgs,
+            blur_images: blur_imgs,
             size: .normal,
             options: options
         )

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -26,7 +26,7 @@ struct NoteContentView: View {
     
     let damus_state: DamusState
     let event: NostrEvent
-    @State var show_images: Bool
+    @State var blur_images: Bool
     let size: EventViewKind
     let preview_height: CGFloat?
     let options: EventViewOptions
@@ -39,10 +39,10 @@ struct NoteContentView: View {
         return self.artifacts_model.state.artifacts ?? .separated(.just_content(event.get_content(damus_state.keypair)))
     }
     
-    init(damus_state: DamusState, event: NostrEvent, show_images: Bool, size: EventViewKind, options: EventViewOptions) {
+    init(damus_state: DamusState, event: NostrEvent, blur_images: Bool, size: EventViewKind, options: EventViewOptions) {
         self.damus_state = damus_state
         self.event = event
-        self.show_images = show_images
+        self.blur_images = blur_images
         self.size = size
         self.options = options
         self.preview_height = lookup_cached_preview_size(previews: damus_state.previews, evid: event.id)
@@ -61,7 +61,7 @@ struct NoteContentView: View {
     }
     
     var preview: LinkViewRepresentable? {
-        guard show_images,
+        guard blur_images,
               case .loaded(let preview) = preview_model.state,
               case .value(let cached) = preview else {
             return nil
@@ -92,7 +92,7 @@ struct NoteContentView: View {
     
     func previewView(links: [URL]) -> some View {
         Group {
-            if let preview = self.preview, show_images {
+            if let preview = self.preview, blur_images {
                 if let preview_height {
                     preview
                         .frame(height: preview_height)
@@ -133,14 +133,14 @@ struct NoteContentView: View {
                 }
             }
 
-            if show_images && artifacts.media.count > 0 {
+            if !blur_images && artifacts.media.count > 0 {
                 ImageCarousel(state: damus_state, evid: event.id, urls: artifacts.media)
-            } else if !show_images && artifacts.media.count > 0 {
+            } else if blur_images && artifacts.media.count > 0 {
                 ZStack {
                     ImageCarousel(state: damus_state, evid: event.id, urls: artifacts.media)
                     Blur()
                         .onTapGesture {
-                            show_images = true
+                            blur_images = false
                         }
                 }
                 //.cornerRadius(10)
@@ -618,17 +618,17 @@ struct NoteContentView_Previews: PreviewProvider {
 
         Group {
             VStack {
-                NoteContentView(damus_state: state, event: test_note, show_images: true, size: .normal, options: [])
+                NoteContentView(damus_state: state, event: test_note, blur_images: false, size: .normal, options: [])
             }
             .previewDisplayName("Short note")
             
             VStack {
-                NoteContentView(damus_state: state, event: test_encoded_note_with_image!, show_images: true, size: .normal, options: [])
+                NoteContentView(damus_state: state, event: test_encoded_note_with_image!, blur_images: false, size: .normal, options: [])
             }
             .previewDisplayName("Note with image")
 
             VStack {
-                NoteContentView(damus_state: state2, event: test_longform_event.event, show_images: true, size: .normal, options: [.wide])
+                NoteContentView(damus_state: state2, event: test_longform_event.event, blur_images: false, size: .normal, options: [.wide])
                     .border(Color.red)
             }
             .previewDisplayName("Long-form note")

--- a/damus/Views/Settings/AppearanceSettingsView.swift
+++ b/damus/Views/Settings/AppearanceSettingsView.swift
@@ -78,7 +78,7 @@ struct AppearanceSettingsView: View {
             // MARK: - Images
             Section(NSLocalizedString("Images", comment: "Section title for images configuration.")) {
                 self.EnableAnimationsToggle
-                Toggle(NSLocalizedString("Always show images", comment: "Setting to always show and never blur images"), isOn: $settings.always_show_images)
+                Toggle(NSLocalizedString("Blur images", comment: "Setting to blur images"), isOn: $settings.blur_images)
                     .toggleStyle(.switch)
                 
                 Picker(NSLocalizedString("Image uploader", comment: "Prompt selection of user's image uploader"),


### PR DESCRIPTION
This PR renames the "Always show images" setting to "Blur images"