### PR TITLE
Media Preview Setting

### DIFF
--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -110,6 +110,9 @@ class UserSettingsStore: ObservableObject {
     @Setting(key: "always_show_images", default_value: false)
     var always_show_images: Bool
     
+    @Setting(key: "media_previews", default_value: true)
+    var media_previews: Bool
+    
     @Setting(key: "hide_nsfw_tagged_content", default_value: false)
     var hide_nsfw_tagged_content: Bool
     

--- a/damus/Views/Settings/AppearanceSettingsView.swift
+++ b/damus/Views/Settings/AppearanceSettingsView.swift
@@ -81,6 +81,9 @@ struct AppearanceSettingsView: View {
                 Toggle(NSLocalizedString("Always show images", comment: "Setting to always show and never blur images"), isOn: $settings.always_show_images)
                     .toggleStyle(.switch)
                 
+                Toggle(NSLocalizedString("Media previews", comment: "Setting to show media"), isOn: $settings.media_previews)
+                    .toggleStyle(.switch)
+                
                 Picker(NSLocalizedString("Image uploader", comment: "Prompt selection of user's image uploader"),
                        selection: $settings.default_media_uploader) {
                     ForEach(MediaUploader.allCases, id: \.self) { uploader in


### PR DESCRIPTION
This PR adds the Media preview setting in order to allow users to toggle previewing media such as links, images, videos, gif, etc. or to only preview when tapped.

nostr:note1vm22g8xsv7lqggz7q490rm4n6kze6s8v4xjgfcgzj8rxm8xcwz4qnhr0cy