### PR TITLE
update testdata URL path method

### DIFF
--- a/damus/TestData.swift
+++ b/damus/TestData.swift
@@ -58,7 +58,7 @@ var test_damus_state: DamusState = ({
         let fileManager = FileManager.default
         let temp = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try fileManager.createDirectory(at: temp, withIntermediateDirectories: true, attributes: nil)
-        tempDir = temp.absoluteString
+        tempDir = temp.path(percentEncoded: false)
     } catch {
         tempDir = "."
     }


### PR DESCRIPTION
URL.absoluteString returns "files:///" prefix path, which causes previews error always.
URL.path would be the right method.