### PR TITLE
refactor: add customizable properties to neutral button style

### DIFF
--- a/damus/Components/NeutralButtonStyle.swift
+++ b/damus/Components/NeutralButtonStyle.swift
@@ -7,37 +7,49 @@
 
 import SwiftUI
 
+enum NeutralButtonShape {
+    case rounded, capsule, circle
+
+    var style: NeutralButtonStyle {
+        switch self {
+        case .rounded:
+            return NeutralButtonStyle(padding: EdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10), cornerRadius: 12)
+        case .capsule:
+            return NeutralButtonStyle(padding: EdgeInsets(top: 5, leading: 15, bottom: 5, trailing: 15), cornerRadius: 20)
+        case .circle:
+            return NeutralButtonStyle(padding: EdgeInsets(top: 20, leading: 20, bottom: 20, trailing: 20), cornerRadius: 9999)
+        }
+    }
+}
+
 struct NeutralButtonStyle: ButtonStyle {
-    func makeBody(configuration: Self.Configuration) -> some View {
-        return configuration.label
+    let padding: EdgeInsets
+    let cornerRadius: CGFloat
+    let scaleEffect: CGFloat
+    
+    init(padding: EdgeInsets = EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0), cornerRadius: CGFloat = 15, scaleEffect: CGFloat = 0.95) {
+        self.padding = padding
+        self.cornerRadius = cornerRadius
+        self.scaleEffect = scaleEffect
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(padding)
             .background(DamusColors.neutral1)
-            .cornerRadius(12)
+            .cornerRadius(cornerRadius)
             .overlay(
-                RoundedRectangle(cornerRadius: 12)
+                RoundedRectangle(cornerRadius: cornerRadius)
                     .stroke(DamusColors.neutral3, lineWidth: 1)
             )
-            .scaleEffect(configuration.isPressed ? 0.95 : 1)
+            .scaleEffect(configuration.isPressed ? scaleEffect : 1)
     }
 }
-
-struct NeutralCircleButtonStyle: ButtonStyle {
-    func makeBody(configuration: Self.Configuration) -> some View {
-        return configuration.label
-            .padding(20)
-            .background(DamusColors.neutral1)
-            .cornerRadius(9999)
-            .overlay(
-                RoundedRectangle(cornerRadius: 9999)
-                    .stroke(DamusColors.neutral3, lineWidth: 1)
-            )
-            .scaleEffect(configuration.isPressed ? 0.95 : 1)
-    }
-}
-
 
 struct NeutralButtonStyle_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
+            
             Button(action: {
                 print("dynamic size")
             }) {
@@ -45,8 +57,7 @@ struct NeutralButtonStyle_Previews: PreviewProvider {
                     .padding()
             }
             .buttonStyle(NeutralButtonStyle())
-
-
+            
             Button(action: {
                 print("infinite width")
             }) {
@@ -58,6 +69,17 @@ struct NeutralButtonStyle_Previews: PreviewProvider {
             }
             .buttonStyle(NeutralButtonStyle())
             .padding()
+            
+            Button("Rounded Button", action: {})
+                .buttonStyle(NeutralButtonShape.rounded.style)
+                .padding()
+
+            Button("Capsule Button", action: {})
+                .buttonStyle(NeutralButtonShape.capsule.style)
+                .padding()
+
+            Button(action: {}, label: {Image("messages")})
+                .buttonStyle(NeutralButtonShape.circle.style)
         }
     }
 }

--- a/damus/Views/ProfileActionSheetView.swift
+++ b/damus/Views/ProfileActionSheetView.swift
@@ -58,7 +58,7 @@ struct ProfileActionSheetView: View {
                         .profile_button_style(scheme: colorScheme)
                 }
             )
-            .buttonStyle(NeutralCircleButtonStyle())
+            .buttonStyle(NeutralButtonShape.circle.style)
             Text(NSLocalizedString("Message", comment: "Button label that allows the user to start a direct message conversation with the user shown on-screen"))
                 .foregroundStyle(.secondary)
                 .font(.caption)
@@ -121,8 +121,7 @@ struct ProfileActionSheetView: View {
                     
                 }
             )
-            
-            .buttonStyle(NeutralCircleButtonStyle())
+            .buttonStyle(NeutralButtonShape.circle.style)
         }
         .padding()
         .padding(.top, 20)
@@ -165,7 +164,7 @@ fileprivate struct ProfileActionSheetFollowButton: View {
                     
                 }
             )
-            .buttonStyle(NeutralCircleButtonStyle())
+            .buttonStyle(NeutralButtonShape.circle.style)
             
             Text(verbatim: "\(follow_btn_txt(follow_state, follows_you: follows_you))")
             .foregroundStyle(.secondary)
@@ -292,7 +291,7 @@ fileprivate struct ProfileActionSheetZapButton: View {
                         return true
                 }
             }())
-            .buttonStyle(NeutralCircleButtonStyle())
+            .buttonStyle(NeutralButtonShape.circle.style)
             
             Text(button_label)
             .foregroundStyle(.secondary)


### PR DESCRIPTION
This PR refactors the NeutralButtonStyle to take in customizable properties for different button layouts instead of creating a struct for each situation that may arise, for example a small capsule button which I needed. Also added shape representations using NeutralButtonShape for ease of use. 

![neutral buttons](https://github.com/damus-io/damus/assets/14004132/188d8bcd-2fa5-49bc-bd3c-1ccea5c39c02)
