### PR TITLE
Fix Issue #1820 Hashtags including U+5009 to U+500D are not correctly parsed

### DIFF
--- a/damus-c/cursor.h
+++ b/damus-c/cursor.h
@@ -485,11 +485,11 @@ static inline int parse_str(struct cursor *cur, const char *str) {
     return 1;
 }
 
-static inline int is_whitespace(char c) {
+static inline int is_whitespace(int c) {
     return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
 }
 
-static inline int is_underscore(char c) {
+static inline int is_underscore(int c) {
     return c == '_';
 }
 

--- a/damusTests/HashtagTests.swift
+++ b/damusTests/HashtagTests.swift
@@ -545,4 +545,15 @@ final class HashtagTests: XCTestCase {
         XCTAssertEqual(parsed[2].asText, " is allowed in hashtags")
     }
     
+    // Japanese: bai (倍) (U+500D) (allowed in hashtags)
+    func testHashtagWithBaiKanji() {
+        let parsed = parse_note_content(content: .content("pow! #10倍界王拳 is allowed in hashtags",nil)).blocks
+        
+        XCTAssertNotNil(parsed)
+        XCTAssertEqual(parsed.count, 3)
+        XCTAssertEqual(parsed[0].asText, "pow! ")
+        XCTAssertEqual(parsed[1].asHashtag, "10倍界王拳")
+        XCTAssertEqual(parsed[2].asText, " is allowed in hashtags")
+    }
+
 }


### PR DESCRIPTION
If the hashtag contains the kanji "倍", it cannot be parsed correctly.
![IMG_3691](https://github.com/damus-io/damus/assets/1298867/f34972a0-6e90-4b32-92d9-0634a534b130)

Fix it.
![Simulator Screenshot - iPhone 15 Pro - 2023-12-20 at 23 26 46](https://github.com/damus-io/damus/assets/1298867/f645ac05-ba8c-483d-8e21-62476a96645b)
