### PR TITLE
Normalize requested relay ids

### DIFF
--- a/damus/Nostr/Relay.swift
+++ b/damus/Nostr/Relay.swift
@@ -120,23 +120,10 @@ class Relay: Identifiable {
     }
     
     var id: String {
-        return get_relay_id(descriptor.url)
+        return descriptor.url.id
     }
-
 }
 
 enum RelayError: Error {
     case RelayAlreadyExists
-}
-
-func get_relay_id(_ url: RelayURL) -> String {
-    let trimTrailingSlashes: (String) -> String = { url in
-        var trimmedUrl = url
-        while trimmedUrl.hasSuffix("/") {
-            trimmedUrl.removeLast()
-        }
-        return trimmedUrl
-    }
-    
-    return trimTrailingSlashes(url.url.absoluteString)
 }

--- a/damus/Nostr/RelayPool.swift
+++ b/damus/Nostr/RelayPool.swift
@@ -123,7 +123,7 @@ class RelayPool {
     
     func add_relay(_ desc: RelayDescriptor) throws {
         let url = desc.url
-        let relay_id = get_relay_id(url)
+        let relay_id = url.id
         if get_relay(relay_id) != nil {
             throw RelayError.RelayAlreadyExists
         }
@@ -270,12 +270,23 @@ class RelayPool {
     }
     
     func get_relays(_ ids: [String]) -> [Relay] {
+        get_relays(ids.compactMap { RelayURL($0) })
+    }
+    
+    func get_relays(_ urls: [RelayURL]) -> [Relay] {
         // don't include ephemeral relays in the default list to query
-        relays.filter { ids.contains($0.id) }
+        relays.filter { urls.contains($0.descriptor.url) }
     }
     
     func get_relay(_ id: String) -> Relay? {
-        relays.first(where: { $0.id == id })
+        guard let url = RelayURL(id) else {
+            return nil
+        }
+        return get_relay(url)
+    }
+    
+    func get_relay(_ url: RelayURL) -> Relay? {
+        relays.first(where: { $0.descriptor.url == url })
     }
     
     func run_queue(_ relay_id: String) {

--- a/damus/Nostr/RelayURL.swift
+++ b/damus/Nostr/RelayURL.swift
@@ -15,7 +15,12 @@ public struct RelayURL: Hashable, Equatable, Codable, CodingKeyRepresentable {
     }
     
     init?(_ str: String) {
-        guard let url = URL(string: str) else {
+        var trimmedStr = str
+        while trimmedStr.hasSuffix("/") {
+            trimmedStr.removeLast()
+        }
+
+        guard let url = URL(string: trimmedStr) else {
             return nil
         }
         

--- a/damusTests/WalletConnectTests.swift
+++ b/damusTests/WalletConnectTests.swift
@@ -79,6 +79,20 @@ final class WalletConnectTests: XCTestCase {
         XCTAssertEqual(url_2.relay.id, relay_2)
     }
     
+    func testGetRelayWithTrailingSlashes() {
+        let sec = "8ba3a6b3b57d0f4211bb1ea4d8d1e351a367e9b4ea694746e0a4a452b2bc4d37"
+        let pk =  "89446b900c70d62438dcf66756405eea6225ad94dc61f3856f62f9699111a9a6"
+        let nwc = WalletConnectURL(str: "nostrwalletconnect://\(pk)?relay=ws://127.0.0.1/&secret=\(sec)&lud16=jb55@jb55.com")!
+
+        let pool = RelayPool(ndb: .empty)
+        let box = PostBox(pool: pool)
+
+        nwc_pay(url: nwc, pool: pool, post: box, invoice: "invoice")
+
+        XCTAssertNotNil(pool.get_relay(nwc.relay.id))
+        XCTAssertEqual(pool.get_relays([nwc.relay.id]).count, 1)
+    }
+
     func testNWCEphemeralRelay() {
         let sec = "8ba3a6b3b57d0f4211bb1ea4d8d1e351a367e9b4ea694746e0a4a452b2bc4d37"
         let pk =  "89446b900c70d62438dcf66756405eea6225ad94dc61f3856f62f9699111a9a6"


### PR DESCRIPTION
The relay pool is removing trailing slashes when adding a relay, but not when a relay is requested. This prevents valid relays from being used:

```
get_relay("wss://relay.mutinywallet.com")  => found
get_relay("wss://relay.mutinywallet.com/") => nil
```
