### PR TITLE
postview: add haptic feedback on media upload result

### DIFF
--- a/damus/Models/ImageUploadModel.swift
+++ b/damus/Models/ImageUploadModel.swift
@@ -56,9 +56,20 @@ class ImageUploadModel: NSObject, URLSessionTaskDelegate, ObservableObject {
     
     func start(media: MediaUpload, uploader: MediaUploader, keypair: Keypair? = nil) async -> ImageUploadResult {
         let res = await create_upload_request(mediaToUpload: media, mediaUploader: uploader, progress: self, keypair: keypair)
-        DispatchQueue.main.async {
-            self.progress = nil
+                
+        switch res {
+        case .success(_):
+            DispatchQueue.main.async {
+                self.progress = nil
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+            }
+        case .failed(_):
+            DispatchQueue.main.async {
+                self.progress = nil
+                UINotificationFeedbackGenerator().notificationOccurred(.error)
+            }
         }
+
         return res
     }
     


### PR DESCRIPTION
Closes: https://github.com/damus-io/damus/issues/2094

I'll point out that haptic feedback implementation on media upload is a little different than the zap vibration in two ways.
1. The media upload haptic feedback is not configurable, see below
2. The haptic feedback applies on success and failure using built-in Swift iOS API https://developer.apple.com/documentation/uikit/uinotificationfeedbackgenerator

I chose to avoid touching the Damus state as I'm new to this project as well as mobile development. I thought about a few potential solutions but didn't feel confident in approaching any of them or felt it was better to do nothing. If making this feature configurable is required for acceptance I am happy to implement that if I can get a little guidance on best practices.