### PR TITLE
Fixed issue where timeline was scrolling when it isn't supposed to

### DIFF
--- a/damus/Views/TimelineView.swift
+++ b/damus/Views/TimelineView.swift
@@ -15,7 +15,6 @@ struct TimelineView<Content: View>: View {
     let show_friend_icon: Bool
     let filter: (NostrEvent) -> Bool
     let content: Content?
-    let debouncer: Debouncer
     let apply_mute_rules: Bool
 
     init(events: EventHolder, loading: Binding<Bool>, damus: DamusState, show_friend_icon: Bool, filter: @escaping (NostrEvent) -> Bool, apply_mute_rules: Bool = true, content: (() -> Content)? = nil) {
@@ -25,7 +24,6 @@ struct TimelineView<Content: View>: View {
         self.show_friend_icon = show_friend_icon
         self.filter = filter
         self.apply_mute_rules = apply_mute_rules
-        self.debouncer = Debouncer(interval: 0.5)
         self.content = content?()
     }
 
@@ -49,9 +47,7 @@ struct TimelineView<Content: View>: View {
                     .shimmer(loading)
                     .disabled(loading)
                     .background(GeometryReader { proxy -> Color in
-                        debouncer.debounce_immediate {
-                            handle_scroll_queue(proxy, queue: self.events)
-                        }
+                        handle_scroll_queue(proxy, queue: self.events)
                         return Color.clear
                     })
             }


### PR DESCRIPTION
This perf change was experimental and probably minor anyways

This reverts commit d49cf5a505a27585529c6824a0f136a73e7e848f.

Fixes: https://github.com/damus-io/damus/issues/2235
Changelog-Fixed: Fixed issue where timeline was scrolling when it isn't supposed to