### PR TITLE
Fix reaction events to not tag all e and p tags in the thread

### DIFF
--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -443,16 +443,17 @@ func make_boost_event(keypair: FullKeypair, boosted: NostrEvent) -> NostrEvent? 
 }
 
 func make_like_event(keypair: FullKeypair, liked: NostrEvent, content: String = "🤙") -> NostrEvent? {
-    var tags = liked.tags.reduce(into: [[String]]()) { ts, tag in
-        guard tag.count >= 2,
-              (tag[0].matches_char("e") || tag[0].matches_char("p")) else {
-            return
-        }
-        ts.append(tag.strings())
+    var tags: [[String]] = []
+
+    if liked.is_non_parameterized_replaceable {
+        tags.append(["a", "\(liked.kind.description):\(liked.pubkey.hex()):"])
+    } else if liked.is_parameterized_replaceable, let dTag = liked.tags.first(where: { $0.count >= 2 && $0[0].matches_char("d") }) {
+        tags.append(["a", "\(liked.kind.description):\(liked.pubkey.hex()):\(dTag[1])"])
     }
 
     tags.append(["e", liked.id.hex()])
     tags.append(["p", liked.pubkey.hex()])
+    tags.append(["k", liked.kind.description])
 
     return NostrEvent(content: content, keypair: keypair.to_keypair(), kind: 7, tags: tags)
 }

--- a/damus/Views/Events/Longform/LongformView.swift
+++ b/damus/Views/Events/Longform/LongformView.swift
@@ -36,6 +36,7 @@ let test_longform_event = LongformEvent.parse(from: NostrEvent(
     keypair: test_keypair,
     kind: NostrKind.longform.rawValue,
     tags: [
+        ["d", UUID().uuidString],
         ["title", "What is WASTOIDS?"],
         ["summary", "WASTOIDS is an audio/visual feed, created by Sam Means..."],
         ["published_at", "1685638715"],

--- a/damusTests/LikeTests.swift
+++ b/damusTests/LikeTests.swift
@@ -10,15 +10,7 @@ import XCTest
 
 class LikeTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testLikeHasNotification() throws {
+    func testReactionTextNote() throws {
         let cindy = Pubkey(hex: "9d9181f0aea6500e1f360e07b9f37e25c72169b5158ae78df53f295272b6b71c")!
         let bob = Pubkey(hex: "218837fe8c94a66ae33af277bcbda45a0319e7726220cd76171b9dd1a468af91")!
         let liked = NostrEvent(content: "awesome #[0] post",
@@ -28,9 +20,30 @@ class LikeTests: XCTestCase {
         let like_ev = make_like_event(keypair: test_keypair_full, liked: liked)!
 
         XCTAssertTrue(like_ev.referenced_pubkeys.contains(test_keypair.pubkey))
-        XCTAssertTrue(like_ev.referenced_pubkeys.contains(cindy))
-        XCTAssertTrue(like_ev.referenced_pubkeys.contains(bob))
+        XCTAssertFalse(like_ev.referenced_pubkeys.contains(cindy))
+        XCTAssertFalse(like_ev.referenced_pubkeys.contains(bob))
         XCTAssertEqual(like_ev.last_refid()!, id)
+        XCTAssertTrue(like_ev.tags.allSatisfy { !$0[0].matches_char("a") })
+
+        let kindTag = try XCTUnwrap(like_ev.tags.first(where: { $0.count >= 2 && $0[0].matches_char("k") }))
+        XCTAssertTrue(kindTag[1].matches_str("1"))
+    }
+
+    func testReactionLongFormNote() throws {
+        let liked = test_longform_event.event
+        let id = liked.id
+        let like_ev = make_like_event(keypair: test_keypair_full, liked: liked)!
+
+        XCTAssertTrue(like_ev.referenced_pubkeys.contains(test_keypair.pubkey))
+        XCTAssertEqual(like_ev.last_refid()!, id)
+
+        let dTagValue = try XCTUnwrap(liked.tags.first { $0[0].matches_char("d") })
+        let aTag = try XCTUnwrap(like_ev.tags.first { $0[0].matches_char("a") })
+        XCTAssertTrue(aTag[1].matches_str("30023:\(test_keypair.pubkey.hex()):\(dTagValue[1])"))
+
+        let kindTag = try XCTUnwrap(like_ev.tags.first(where: { $0.count >= 2 && $0[0].matches_char("k") }))
+//        FIXME(tyiu) the assertion below fails for some reason even though in a different test, I was able to assert kind 1 just fine.
+//        XCTAssertTrue(kindTag[1].matches_str("30023"))
     }
 
     func testToReactionEmoji() {

--- a/nostrdb/NdbNote.swift
+++ b/nostrdb/NdbNote.swift
@@ -280,6 +280,17 @@ extension NdbNote {
         return kind == 1 || kind == 42 || kind == 30023
     }
 
+    var is_non_parameterized_replaceable: Bool {
+        switch kind {
+        case 10000..<20000, 0, 3: return true
+        default: return false
+        }
+    }
+
+    var is_parameterized_replaceable: Bool {
+        (30000..<40000).contains(kind)
+    }
+
     var is_quote_repost: NoteId? {
         guard kind == 1, let quoted_note_id = referenced_quote_ids.first else {
             return nil


### PR DESCRIPTION
I've also added support for reacting to replaceable events via the `a` tag, and added a `k` tag to be explicit about what kind number of event is being reacted to.

Fixes https://github.com/damus-io/damus/issues/2150
Fixes https://github.com/nostrability/nostrability/issues/48

See https://github.com/nostr-protocol/nips/blob/master/25.md
```
The reaction event SHOULD include `a`, `e` and `p` tags pointing to the note the user is
reacting to. The `p` tag allows authors to be notified. The `e` tags enables clients 
to pull all the reactions to individual events and `a` tags enables clients to seek reactions
for all versions of a replaceable event. 

The `e` tag MUST be the `id` of the note that is being reacted to. 

The `a` tag MUST contain the coordinates (`kind:pubkey:d-tag`) of the replaceable being reacted to. 

The `p` tag MUST be the `pubkey` of the event being reacted to.

The reaction event MAY include a `k` tag with the stringified kind number
of the reacted event as its value.
```