### PR TITLE
Hide NIP-36 notes as #nsfw

### DIFF
--- a/damus/Models/ContentFilters.swift
+++ b/damus/Models/ContentFilters.swift
@@ -25,7 +25,7 @@ enum FilterState : Int {
 
 /// Simple filter to determine whether to show posts with #nsfw tags
 func nsfw_tag_filter(ev: NostrEvent) -> Bool {
-    return ev.referenced_hashtags.first(where: { t in t.hashtag == "nsfw" }) == nil
+    return ev.referenced_hashtags.first(where: { t in t.hashtag == "nsfw" }) == nil && References<ContentWarningTag>(tags: ev.tags).first == nil
 }
 
 func get_repost_of_muted_user_filter(damus_state: DamusState) -> ((_ ev: NostrEvent) -> Bool) {

--- a/damus/Nostr/Id.swift
+++ b/damus/Nostr/Id.swift
@@ -130,6 +130,29 @@ struct ReplaceableParam: TagConvertible {
     var keychar: AsciiCharacter { "d" }
 }
 
+struct ContentWarningTag: TagConvertible {
+    let reason: String?
+
+    static func from_tag(tag: TagSequence) -> ContentWarningTag? {
+        var i = tag.makeIterator()
+
+        guard tag.count >= 1,
+              let t0 = i.next(),
+              t0.matches_str("content-warning") else {
+            return nil
+        }
+        
+        guard let t1 = i.next() else {
+            return ContentWarningTag(reason: nil)
+        }
+
+        return ContentWarningTag(reason: t1.string())
+    }
+    var tag: [String] {
+        self.reason == nil ? ["content-warning"] : ["content-warning", self.reason!]
+    }
+}
+
 struct Signature: Hashable, Equatable {
     let data: Data
 


### PR DESCRIPTION
Filters posts with the NIP-36 "content-warning" tag in the same way as the #nsfw hashtag.
https://github.com/nostr-protocol/nips/blob/master/36.md

Related issues: #910, #1412

Screenshots:
Show #nsfw and NIP-36
![Show #nsfw and NIP-36](https://github.com/damus-io/damus/assets/1298867/5b217e93-a6cf-4882-b87b-f8137d74f748)
Hide #nsfw and NIP-36
![Hide #nsfw and NIP-36](https://github.com/damus-io/damus/assets/1298867/d9776360-998a-4822-a8d7-d188838ee6c9)


This is a test post.
https://damus.io/note1z0jcu9wgevaajcvk947ea2aj8wv9nxlttj5dvj6wxfyz0v5ehpnq8t9l2p

The post on Rabbit.
https://rabbit.syusui.net/#/npub1l6gzvpjar07swqqq9gg9eshgtvtp2tyynv405jrsgxwrhpcupgcqqvy0hm
![Rabbit Screenshot hide NIP-36](https://github.com/damus-io/damus/assets/1298867/1e37491a-e21b-41ef-b910-f88f05487ed4)
![Rabbit Screenshot show NIP-36](https://github.com/damus-io/damus/assets/1298867/8e4c4909-da2b-4d97-bc35-4df60690c3bb)
