### PR TITLE
Add Apple translation popovers for notes for iOS 17.4+ and macOS 14.4+

### DIFF
--- a/damus/Models/TranslationService.swift
+++ b/damus/Models/TranslationService.swift
@@ -38,7 +38,13 @@ enum TranslationService: String, CaseIterable, Identifiable, StringCodable {
     var model: Model {
         switch self {
         case .none:
-            return .init(tag: self.rawValue, displayName: NSLocalizedString("none_translation_service", value: "None", comment: "Dropdown option for selecting no translation service."))
+            let displayName: String
+            if TranslationService.isAppleTranslationPopoverSupported {
+                displayName = NSLocalizedString("apple_translation_service", value: "Apple", comment: "Dropdown option for selecting Apple as a translation service.")
+            } else {
+                displayName = NSLocalizedString("none_translation_service", value: "None", comment: "Dropdown option for selecting no translation service.")
+            }
+            return .init(tag: self.rawValue, displayName: displayName)
         case .purple:
             return .init(tag: self.rawValue, displayName: NSLocalizedString("Damus Purple", comment: "Dropdown option for selecting Damus Purple as a translation service."))
         case .libretranslate:
@@ -49,6 +55,14 @@ enum TranslationService: String, CaseIterable, Identifiable, StringCodable {
             return .init(tag: self.rawValue, displayName: NSLocalizedString("NoKYCTranslate.com (Prepay with BTC)", comment: "Dropdown option for selecting NoKYCTranslate.com as the translation service."))
          case .winetranslate:
             return .init(tag: self.rawValue, displayName: NSLocalizedString("translate.nostr.wine (DeepL, Pay with BTC)", comment: "Dropdown option for selecting translate.nostr.wine as the translation service."))
+        }
+    }
+
+    static var isAppleTranslationPopoverSupported: Bool {
+        if #available(iOS 17.4, macOS 14.4, *) {
+            return true
+        } else {
+            return false
         }
     }
 }


### PR DESCRIPTION
Changelog-Added: Add Apple translation popovers for notes for iOS 17.4+ and macOS 14.4+

https://github.com/damus-io/damus/assets/963907/4fdddb61-9cd0-4514-80fe-79298d9c92a6

![Simulator Screenshot - iPhone 15 Pro - 2024-07-16 at 13 07 06 Medium](https://github.com/user-attachments/assets/4c88f5ce-c2bb-498a-b38e-6ae5f60ffe5b)

These changes are gated around iOS and macOS versions. If an older OS is being run, Apple translations won't be offered.