### PR TITLE
ux: Simplify Onboarding

### DIFF
--- a/damus/Models/CreateAccountModel.swift
+++ b/damus/Models/CreateAccountModel.swift
@@ -9,31 +9,31 @@ import Foundation
 
 
 class CreateAccountModel: ObservableObject {
-    @Published var real_name: String = ""
-    @Published var nick_name: String = ""
+    @Published var display_name: String = ""
+    @Published var name: String = ""
     @Published var about: String = ""
     @Published var pubkey: Pubkey = .empty
     @Published var privkey: Privkey = .empty
     @Published var profile_image: URL? = nil
 
     var rendered_name: String {
-        if real_name.isEmpty {
-            return nick_name
+        if display_name.isEmpty {
+            return name
         }
-        return real_name
+        return display_name
     }
     
     var keypair: Keypair {
         return Keypair(pubkey: self.pubkey, privkey: self.privkey)
     }
     
-    init(real: String = "", nick: String = "", about: String = "") {
+    init(display_name: String = "", name: String = "", about: String = "") {
         let keypair = generate_new_keypair()
         self.pubkey = keypair.pubkey
         self.privkey = keypair.privkey
 
-        self.real_name = real
-        self.nick_name = nick
+        self.display_name = display_name
+        self.name = name
         self.about = about
     }
 }

--- a/damus/Views/CreateAccountView.swift
+++ b/damus/Views/CreateAccountView.swift
@@ -25,68 +25,44 @@ struct CreateAccountView: View {
     var body: some View {
         ZStack(alignment: .top) {
             VStack {
+                Spacer()
                 VStack(alignment: .center) {
-                    EditPictureControl(uploader: .nostrBuild, pubkey: account.pubkey, image_url: $account.profile_image , uploadObserver: profileUploadObserver, callback: uploadedProfilePicture)
-
-                    Text("Public Key", comment: "Label to indicate the public key of the account.")
+                   
+                    EditPictureControl(uploader: .nostrBuild, pubkey: account.pubkey, size: 75, setup: true, image_url: $account.profile_image , uploadObserver: profileUploadObserver, callback: uploadedProfilePicture)
+                        .shadow(radius: 2)
+                        .padding(.top, 100)
+                    
+                    Text("Add Photo", comment: "Label to indicate user can add a photo.")
                         .bold()
-                        .padding()
-                        .onTapGesture {
-                            regen_key()
-                        }
-
-                    KeyText($account.pubkey)
-                        .padding(.horizontal, 20)
-                        .onTapGesture {
-                            regen_key()
-                        }
-                }
-                .frame(minWidth: 300, maxWidth: .infinity, minHeight: 250, alignment: .center)
-                .background {
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(DamusColors.adaptableGrey, strokeBorder: .gray.opacity(0.5), lineWidth: 1)
+                        .foregroundColor(DamusColors.neutral6)
                 }
                 
                 SignupForm {
-                    FormLabel(NSLocalizedString("Display name", comment: "Label to prompt display name entry."), optional: true)
-                    FormTextInput(NSLocalizedString("Satoshi Nakamoto", comment: "Name of Bitcoin creator(s)."), text: $account.real_name)
+                    FormLabel(NSLocalizedString("Name", comment: "Label to prompt name entry."), optional: false)
+                        .foregroundColor(DamusColors.neutral6)
+                    FormTextInput(NSLocalizedString("Satoshi Nakamoto", comment: "Name of Bitcoin creator(s)."), text: $account.name)
                         .textInputAutocapitalization(.words)
 
-                    FormLabel(NSLocalizedString("About", comment: "Label to prompt for about text entry for user to describe about themself."), optional: true)
-                    FormTextInput(NSLocalizedString("Creator(s) of Bitcoin. Absolute legend.", comment: "Example description about Bitcoin creator(s), Satoshi Nakamoto."), text: $account.about)
+                    FormLabel(NSLocalizedString("Bio", comment: "Label to prompt bio entry for user to describe themself."), optional: true)
+                        .foregroundColor(DamusColors.neutral6)
+                    FormTextInput(NSLocalizedString("Absolute legend.", comment: "Example Bio"), text: $account.about)
                 }
-                .padding(.top, 10)
+                .padding(.top, 25)
 
                 Button(action: {
                     nav.push(route: Route.SaveKeys(account: account))
                 }) {
                     HStack {
-                        Text("Create account now", comment: "Button to create account.")
+                        Text("Next", comment: "Button to continue with account creation.")
                             .fontWeight(.semibold)
                     }
                     .frame(minWidth: 300, maxWidth: .infinity, maxHeight: 12, alignment: .center)
                 }
                 .buttonStyle(GradientButtonStyle())
-                .disabled(profileUploadObserver.isLoading)
-                .opacity(profileUploadObserver.isLoading ? 0.5 : 1)
+                .disabled(profileUploadObserver.isLoading || account.name.isEmpty)
+                .opacity(profileUploadObserver.isLoading || account.name.isEmpty ? 0.5 : 1)
                 .padding(.top, 20)
                 
-                HStack(spacing: 0) {
-                    Text("By signing up, you agree to our ", comment: "Ask the user if they already have an account on Nostr")
-                        .font(.subheadline)
-                        .foregroundColor(Color("DamusMediumGrey"))
-
-                    Button(action: {
-                        nav.push(route: Route.EULA)
-                    }, label: {
-                        Text("EULA")
-                            .font(.subheadline)
-                    })
-                    .padding(.vertical, 5)
-
-                    Spacer()
-                }
-
                 LoginPrompt()
                     .padding(.top)
                 
@@ -94,8 +70,8 @@ struct CreateAccountView: View {
             }
             .padding()
         }
+        .background(DamusBackground(maxHeight: UIScreen.main.bounds.size.height/2), alignment: .top)
         .dismissKeyboardOnTap()
-        .navigationTitle("Create account")
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
         .navigationBarItems(leading: BackNav())
@@ -111,7 +87,7 @@ struct LoginPrompt: View {
     var body: some View {
         HStack {
             Text("Already on Nostr?", comment: "Ask the user if they already have an account on Nostr")
-                .foregroundColor(Color("DamusMediumGrey"))
+                .foregroundColor(DamusColors.neutral6)
 
             Button(NSLocalizedString("Login", comment: "Button to navigate to login view.")) {
                 self.dismiss()
@@ -127,8 +103,8 @@ struct BackNav: View {
     var body: some View {
         Image("chevron-left")
             .foregroundColor(DamusColors.adaptableBlack)
-        .onTapGesture {
-            self.dismiss()
+            .onTapGesture {
+                self.dismiss()
         }
     }
 }
@@ -148,18 +124,9 @@ extension View {
 
 struct CreateAccountView_Previews: PreviewProvider {
     static var previews: some View {
-        let model = CreateAccountModel(real: "", nick: "jb55", about: "")
+        let model = CreateAccountModel(display_name: "", name: "jb55", about: "")
         return CreateAccountView(account: model, nav: .init())
     }
-}
-
-func KeyText(_ pubkey: Binding<Pubkey>) -> some View {
-    let bechkey = bech32_encode(hrp: PUBKEY_HRP, pubkey.wrappedValue.bytes)
-    return Text(bechkey)
-        .textSelection(.enabled)
-        .multilineTextAlignment(.center)
-        .font(.callout.monospaced())
-        .foregroundStyle(DamusLogoGradient.gradient)
 }
 
 func FormTextInput(_ title: String, text: Binding<String>) -> some View {
@@ -171,6 +138,10 @@ func FormTextInput(_ title: String, text: Binding<String>) -> some View {
         .background {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(.gray.opacity(0.5), lineWidth: 1)
+                .background {
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundColor(.damusAdaptableWhite)
+                }
         }
         .font(.body.bold())
 }
@@ -181,6 +152,10 @@ func FormLabel(_ title: String, optional: Bool = false) -> some View {
                 .bold()
         if optional {
             Text("optional", comment: "Label indicating that a form input is optional.")
+                .font(.callout)
+                .foregroundColor(DamusColors.mediumGrey)
+        } else {
+            Text("required", comment: "Label indicating that a form input is required.")
                 .font(.callout)
                 .foregroundColor(DamusColors.mediumGrey)
         }

--- a/damus/Views/LoginView.swift
+++ b/damus/Views/LoginView.swift
@@ -62,8 +62,9 @@ struct LoginView: View {
     var body: some View {
         ZStack(alignment: .top) {
             VStack {
+                Spacer()
+                
                 SignInHeader()
-                    .padding(.top, 100)
                 
                 SignInEntry(key: $key, shouldSaveKey: $shouldSaveKey)
                 
@@ -112,8 +113,9 @@ struct LoginView: View {
                 Spacer()
             }
             .padding()
+            .padding(.bottom, 50)
         }
-        .background(DamusBackground(maxHeight: 350), alignment: .top)
+        .background(DamusBackground(maxHeight: UIScreen.main.bounds.size.height/2), alignment: .top)
         .onAppear {
             credential_handler.check_credentials()
         }
@@ -320,9 +322,13 @@ struct KeyInput: View {
         }
         .padding(.vertical, 2)
         .padding(.horizontal, 10)
-        .overlay {
+        .background {
             RoundedRectangle(cornerRadius: 12)
                 .stroke(.gray, lineWidth: 1)
+                .background {
+                    RoundedRectangle(cornerRadius: 12)
+                        .foregroundColor(.damusAdaptableWhite)
+                }
         }
     }
 }
@@ -337,11 +343,12 @@ struct SignInHeader: View {
                 .padding(.bottom)
             
             Text("Sign in", comment: "Title of view to log into an account.")
+                .foregroundColor(DamusColors.neutral6)
                 .font(.system(size: 32, weight: .bold))
                 .padding(.bottom, 5)
             
             Text("Welcome to the social network you control", comment: "Welcome text")
-                .foregroundColor(Color("DamusMediumGrey"))
+                .foregroundColor(DamusColors.neutral6)
         }
     }
 }
@@ -353,6 +360,7 @@ struct SignInEntry: View {
     var body: some View {
         VStack(alignment: .leading) {
             Text("Enter your account key", comment: "Prompt for user to enter an account key to login.")
+                .foregroundColor(DamusColors.neutral6)
                 .fontWeight(.medium)
                 .padding(.top, 30)
             
@@ -444,7 +452,9 @@ struct LoginView_Previews: PreviewProvider {
         let bech32_pubkey = "KeyInput"
         Group {
             LoginView(key: pubkey, nav: .init())
+                .previewDevice(PreviewDevice(rawValue: "iPhone SE (3rd generation)"))
             LoginView(key: bech32_pubkey, nav: .init())
+                .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro Max"))
         }
     }
 }

--- a/damus/Views/SetupView.swift
+++ b/damus/Views/SetupView.swift
@@ -28,93 +28,59 @@ struct SetupView: View {
                         .fontWeight(.heavy)
                         .foregroundStyle(DamusLogoGradient.gradient)
 
-                    Text("The go-to iOS Nostr client", comment: "Quick description of what Damus is")
-                        .foregroundColor(DamusColors.mediumGrey)
+                    Text("The social network you control", comment: "Quick description of what Damus is")
+                        .foregroundColor(DamusColors.neutral6)
                         .padding(.top, 10)
                     
-                    WhatIsNostr()
-                        .padding()
-                    
-                    WhyWeNeedNostr()
-                        .padding()
-                    
                     Spacer()
+                    
+                    Button(action: {
+                        navigationCoordinator.push(route: Route.CreateAccount)
+                    }) {
+                        HStack {
+                            Text("Create Account", comment: "Button to continue to the create account page.")
+                                .fontWeight(.semibold)
+                        }
+                        .frame(minWidth: 300, maxWidth: .infinity, maxHeight: 12, alignment: .center)
+                    }
+                    .buttonStyle(GradientButtonStyle())
+                    .padding(.horizontal)
                     
                     Button(action: {
                         navigationCoordinator.push(route: Route.Login)
                     }) {
                         HStack {
-                            Text("Let's get started!", comment: "Button to continue to login page.")
+                            Text("Sign In", comment: "Button to continue to login page.")
                                 .fontWeight(.semibold)
                         }
                         .frame(minWidth: 300, maxWidth: .infinity, maxHeight: 12, alignment: .center)
                     }
                     .buttonStyle(GradientButtonStyle())
                     .padding()
+                    
+                    HStack(spacing: 0) {
+                        Text("By continuing you agree to our ")
+                            .font(.subheadline)
+                            .foregroundColor(DamusColors.neutral6)
+
+                        Button(action: {
+                            navigationCoordinator.push(route: Route.EULA)
+                        }, label: {
+                            Text("EULA", comment: "End User License Agreement")
+                                .font(.subheadline)
+                        })
+                        .padding(.vertical, 5)
+                    }
+                    .padding(.bottom)
                 }
             }
-            .background(DamusBackground(maxHeight: 300), alignment: .top)
+            .background(DamusBackground(maxHeight: UIScreen.main.bounds.size.height/2), alignment: .top)
             .navigationDestination(for: Route.self) { route in
                 route.view(navigationCoordinator: navigationCoordinator, damusState: DamusState.empty)
             }
         }
         .navigationBarTitleDisplayMode(.inline)
         .navigationViewStyle(StackNavigationViewStyle())
-    }
-}
-
-struct LearnAboutNostrLink: View {
-    @Environment(\.openURL) var openURL
-    var body: some View {
-        HStack {
-            Button(action: {
-                openURL(URL(string: "https://nostr.com")!)
-            }, label: {
-                Text("Learn more about Nostr", comment: "Button that opens up a webpage where the user can learn more about Nostr.")
-                    .foregroundColor(.accentColor)
-            })
-            
-            Image(systemName: "arrow.up.right")
-                .font(.footnote)
-                .foregroundColor(.accentColor)
-        }
-    }
-}
-
-struct WhatIsNostr: View {
-    var body: some View {
-        HStack(alignment: .top) {
-            Image("nostr-logo")
-            VStack(alignment: .leading) {
-                Text("What is Nostr?", comment: "Heading text for section describing what is Nostr.")
-                    .fontWeight(.bold)
-                    .padding(.vertical, 10)
-                
-                Text("Nostr is a protocol, designed for simplicity, that aims to create a censorship-resistant global social network", comment: "Description about what is Nostr.")
-                    .foregroundColor(DamusColors.mediumGrey)
-                
-                LearnAboutNostrLink()
-                    .padding(.top, 10)
-            }
-            Spacer()
-        }
-    }
-}
-
-struct WhyWeNeedNostr: View {
-    var body: some View {
-        HStack(alignment: .top) {
-            Image("lightbulb")
-            VStack(alignment: .leading) {
-                Text("Why we need Nostr?", comment: "Heading text for section describing why Nostr is needed.")
-                    .fontWeight(.bold)
-                    .padding(.vertical, 10)
-                
-                Text("Social media has developed into a key way information flows around the world. Unfortunately, our current social media systems are broken", comment: "Description about why Nostr is needed.")
-                    .foregroundColor(DamusColors.mediumGrey)
-            }
-            Spacer()
-        }
     }
 }
 


### PR DESCRIPTION
This patch simplifies the onboarding flow based on Jeroen's suggestions.

Setup view:
  - Removes extra nostr information
  - Only shows two buttons, create account and sign in.

Create Account view:
  - When a user uploads a photo it is now displayed
  - Name is now required
  - Public key is now hidden
  - Create account model has been updated to match metadata

Save Keys view:
  - Removes the requirement to copy the nsec
  - Simplified explanation
  - Only shows two buttons, save and not now

Testing
——
iPhone 15 Pro Max (17.0) Light Mode:
https://v.nostr.build/3P75x.mp4

iPhone SE (3rd generation) (16.4) Dark Mode:
https://v.nostr.build/wGBQL.mp4

——

Changelog-Fixed: Create Account model now uses correct metadata
Changelog-Changed: Onboarding design