### PR TITLE
Fix reactions view to not show reactions from replies on parent note

### DIFF
--- a/damus/Views/ReactionsView.swift
+++ b/damus/Views/ReactionsView.swift
@@ -16,7 +16,7 @@ struct ReactionsView: View {
     var body: some View {
         ScrollView {
             LazyVStack {
-                ForEach(model.events.events, id: \.id) { ev in
+                ForEach(model.events.events.filter { $0.last_refid() == model.target }, id: \.id) { ev in
                     ReactionView(damus_state: damus_state, reaction: ev)
                 }
             }


### PR DESCRIPTION
Changelog-Fixed: Fix reactions view to not show reactions from replies on parent note

https://github.com/nostr-protocol/nips/blob/8c47577ecb6b3ae6ad840e5b4d187a3f3a6b97c8/25.md?plain=1#L30
>The last `e` tag MUST be the `id` of the note that is being reacted to.

----------------
| Before | After |
| -------|------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-07-06 at 19 05 19](https://github.com/damus-io/damus/assets/963907/e1d5acb0-183e-4b7e-840c-74622b202651) |  ![Simulator Screenshot - iPhone 15 Pro - 2024-07-06 at 19 04 46](https://github.com/damus-io/damus/assets/963907/21f045ee-0890-4413-a145-31bacf8e48fb) |
---------------