### PR TITLE
flatbuffers: don't crash if there are flatbuffer errors

### DIFF
--- a/nostrdb/flatcc/flatcc_builder.h
+++ b/nostrdb/flatcc/flatcc_builder.h
@@ -82,7 +82,7 @@ extern "C" {
  * Note: some internal assertion will remain if disabled.
  */
 #ifndef FLATCC_BUILDER_ASSERT_ON_ERROR
-#define FLATCC_BUILDER_ASSERT_ON_ERROR 1
+#define FLATCC_BUILDER_ASSERT_ON_ERROR 0
 #endif
 
 /*


### PR DESCRIPTION
Some japanese user profiles are breaking the flatbuffer profile builder for some reason.

This is a pretty bad crash, we'll need to push this asap

Changelog-Fixed: Fix pretty bad crash when building flatbuffer profiles