### PR TITLE
ux: Mute selected text

### DIFF
--- a/damus/Components/SelectableText.swift
+++ b/damus/Components/SelectableText.swift
@@ -14,6 +14,7 @@ struct SelectableText: View {
     let attributedString: AttributedString
     let textAlignment: NSTextAlignment
     @State private var showHighlightPost = false
+    @State private var showMutePost = false
     @State private var selectedText = ""
     @State private var selectedTextHeight: CGFloat = .zero
     @State private var selectedTextWidth: CGFloat = .zero
@@ -38,6 +39,7 @@ struct SelectableText: View {
                 textAlignment: self.textAlignment,
                 enableHighlighting: self.enableHighlighting(),
                 showHighlightPost: $showHighlightPost,
+                showMutePost: $showMutePost,
                 selectedText: $selectedText,
                 height: $selectedTextHeight
             )
@@ -60,6 +62,11 @@ struct SelectableText: View {
                     .presentationDetents([.height(selectedTextHeight + 150), .medium, .large])
             }
         }
+        .sheet(isPresented: $showMutePost) {
+            AddMuteItemView(state: damus_state, new_text: $selectedText)
+                .presentationDragIndicator(.visible)
+                .presentationDetents([.height(300), .medium, .large])
+        }
         .frame(height: selectedTextHeight)
     }
     
@@ -70,10 +77,12 @@ struct SelectableText: View {
 
 fileprivate class TextView: UITextView {
     @Binding var showHighlightPost: Bool
+    @Binding var showMutePost: Bool
     @Binding var selectedText: String
 
-    init(frame: CGRect, textContainer: NSTextContainer?, showHighlightPost: Binding<Bool>, selectedText: Binding<String>) {
+    init(frame: CGRect, textContainer: NSTextContainer?, showHighlightPost: Binding<Bool>, showMutePost: Binding<Bool>, selectedText: Binding<String>) {
         self._showHighlightPost = showHighlightPost
+        self._showMutePost = showMutePost
         self._selectedText = selectedText
         super.init(frame: frame, textContainer: textContainer)
     }
@@ -86,6 +95,11 @@ fileprivate class TextView: UITextView {
         if action == #selector(highlightText(_:)) {
             return true
         }
+        
+        if action == #selector(muteText(_:)) {
+            return true
+        }
+        
         return super.canPerformAction(action, withSender: sender)
     }
 
@@ -93,6 +107,12 @@ fileprivate class TextView: UITextView {
         guard let selectedRange = self.selectedTextRange else { return }
         selectedText = self.text(in: selectedRange) ?? ""
         showHighlightPost.toggle()
+    }
+    
+    @objc public func muteText(_ sender: Any?) {
+        guard let selectedRange = self.selectedTextRange else { return }
+        selectedText = self.text(in: selectedRange) ?? ""
+        showMutePost.toggle()
     }
 
 }
@@ -106,11 +126,12 @@ fileprivate class TextView: UITextView {
     let textAlignment: NSTextAlignment
     let enableHighlighting: Bool
     @Binding var showHighlightPost: Bool
+    @Binding var showMutePost: Bool
     @Binding var selectedText: String
     @Binding var height: CGFloat
 
     func makeUIView(context: UIViewRepresentableContext<Self>) -> TextView {
-        let view = TextView(frame: .zero, textContainer: nil, showHighlightPost: $showHighlightPost, selectedText: $selectedText)
+        let view = TextView(frame: .zero, textContainer: nil, showHighlightPost: $showHighlightPost, showMutePost: $showMutePost, selectedText: $selectedText)
         view.isEditable = false
         view.dataDetectorTypes = .all
         view.isSelectable = true
@@ -123,7 +144,8 @@ fileprivate class TextView: UITextView {
 
         let menuController = UIMenuController.shared
         let highlightItem = UIMenuItem(title: "Highlight", action: #selector(view.highlightText(_:)))
-        menuController.menuItems = self.enableHighlighting ? [highlightItem] : []
+        let muteItem = UIMenuItem(title: "Mute", action: #selector(view.muteText(_:)))
+        menuController.menuItems = self.enableHighlighting ? [highlightItem, muteItem] : []
 
         return view
     }

--- a/damus/Views/Muting/AddMuteItemView.swift
+++ b/damus/Views/Muting/AddMuteItemView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 struct AddMuteItemView: View {
     let state: DamusState
-    @State var new_text: String = ""
+    @Binding var new_text: String
     @State var expiration: DamusDuration = .indefinite
 
     @Environment(\.dismiss) var dismiss
@@ -108,6 +108,6 @@ struct AddMuteItemView: View {
 
 struct AddMuteItemView_Previews: PreviewProvider {
     static var previews: some View {
-        AddMuteItemView(state: test_damus_state)
+        AddMuteItemView(state: test_damus_state, new_text: .constant(""))
     }
 }

--- a/damus/Views/Muting/MutelistView.swift
+++ b/damus/Views/Muting/MutelistView.swift
@@ -15,6 +15,8 @@ struct MutelistView: View {
     @State var hashtags: [MuteItem] = []
     @State var threads: [MuteItem] = []
     @State var words: [MuteItem] = []
+    
+    @State var new_text: String = ""
 
     func RemoveAction(item: MuteItem) -> some View {
         Button {
@@ -120,13 +122,9 @@ struct MutelistView: View {
             }
         }
         .sheet(isPresented: $show_add_muteitem, onDismiss: { self.show_add_muteitem = false }) {
-            if #available(iOS 16.0, *) {
-                AddMuteItemView(state: damus_state)
-                    .presentationDetents([.height(300)])
-                    .presentationDragIndicator(.visible)
-            } else {
-                AddMuteItemView(state: damus_state)
-            }
+            AddMuteItemView(state: damus_state, new_text: $new_text)
+                .presentationDetents([.height(300)])
+                .presentationDragIndicator(.visible)
         }
     }
 }


### PR DESCRIPTION
This PR adds the Mute action to the selected text menu. Pressing the mute action will pop up a sheet which allows users to confirm their selection and choose for how long they would like to mute the selected text for.

Changelog-Added: Added mute action to selected text menu