### PR TITLE
Fix push notification DM decryption

### DIFF
--- a/DamusNotificationService/DamusNotificationService.entitlements
+++ b/DamusNotificationService/DamusNotificationService.entitlements
@@ -10,5 +10,9 @@
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.jb55.damus2</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
This commit fixes an issue where DM contents would not be displayed on a push notification, by giving the notification extension access to the keychain group which contains the user's private key

Testing
--------

PASS

Device: iPhone 13 mini
iOS: 17.6.1
Damus: This commit
Setup:
- Make sure that device is setup with push notifications
- DM notifications enabled
- Device registered with push notification server Steps:
1. Send a DM push notification to yourself
2. Ensure DM contents can be decrypted on the push notification body


Closes: https://github.com/damus-io/damus/issues/2388