### PR TITLE
Add option to specify custom push notification server for testing

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -1011,6 +1011,8 @@
 		D7ADD3DE2B53854300F104C4 /* DamusPurpleURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7ADD3DD2B53854300F104C4 /* DamusPurpleURL.swift */; };
 		D7ADD3E02B538D4200F104C4 /* DamusPurpleURLSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7ADD3DF2B538D4200F104C4 /* DamusPurpleURLSheetView.swift */; };
 		D7ADD3E22B538E3500F104C4 /* DamusPurpleVerifyNpubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7ADD3E12B538E3500F104C4 /* DamusPurpleVerifyNpubView.swift */; };
+		D7B76C902C825042003A16CB /* PushNotificationClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7D2A3802BF815D000E4B42B /* PushNotificationClient.swift */; };
+		D7B76C912C82507F003A16CB /* NIP98AuthenticatedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C6787D2B2D34CC00BCEAFB /* NIP98AuthenticatedRequest.swift */; };
 		D7C6787E2B2D34CC00BCEAFB /* NIP98AuthenticatedRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C6787D2B2D34CC00BCEAFB /* NIP98AuthenticatedRequest.swift */; };
 		D7CB5D3B2B112FBB00AD4105 /* NotificationFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A3B162B02DCE5008BD568 /* NotificationFormatter.swift */; };
 		D7CB5D3C2B1130C600AD4105 /* LocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDA128B29EB19C40006FA5A /* LocalNotification.swift */; };
@@ -4726,6 +4728,7 @@
 				D7CE1B402B0BE719002EDAD4 /* FlatBufferObject.swift in Sources */,
 				D7CE1B442B0BE719002EDAD4 /* Mutable.swift in Sources */,
 				D798D2212B08594800234419 /* NdbTagElem.swift in Sources */,
+				D7B76C902C825042003A16CB /* PushNotificationClient.swift in Sources */,
 				D7CE1B432B0BE719002EDAD4 /* String+extension.swift in Sources */,
 				D7CB5D3F2B116DAD00AD4105 /* NotificationsManager.swift in Sources */,
 				D7CB5D602B11770C00AD4105 /* FollowState.swift in Sources */,
@@ -4802,6 +4805,7 @@
 				D7CCFC152B05891000323D86 /* Referenced.swift in Sources */,
 				D7CE1B2B2B0BE243002EDAD4 /* hex.c in Sources */,
 				D798D2222B08598A00234419 /* ReferencedId.swift in Sources */,
+				D7B76C912C82507F003A16CB /* NIP98AuthenticatedRequest.swift in Sources */,
 				D7CE1B492B0BE729002EDAD4 /* DisplayName.swift in Sources */,
 				D7CE1B192B0BE132002EDAD4 /* builder.c in Sources */,
 				D7EDED1F2B11797D0018B19C /* LongformEvent.swift in Sources */,

--- a/damus/Models/PushNotificationClient.swift
+++ b/damus/Models/PushNotificationClient.swift
@@ -160,7 +160,7 @@ struct PushNotificationClient {
     }
     
     func current_push_notification_environment() -> Environment {
-        return self.settings.send_device_token_to_localhost ? .local_test(host: nil) : .production
+        return self.settings.push_notification_environment
     }
 }
 
@@ -201,9 +201,10 @@ extension PushNotificationClient {
     }
     
     enum Environment: CaseIterable, Codable, Identifiable, StringCodable, Equatable, Hashable {
-        static var allCases: [Environment] = [.local_test(host: nil), .production]
+        static var allCases: [Environment] = [.local_test(host: nil), .staging, .production]
         
         case local_test(host: String?)
+        case staging
         case production
 
         func text_description() -> String {
@@ -212,6 +213,8 @@ extension PushNotificationClient {
                     return NSLocalizedString("Test (local)", comment: "Label indicating a local test environment for Push notification functionality (Developer feature)")
                 case .production:
                     return NSLocalizedString("Production", comment: "Label indicating the production environment for Push notification functionality")
+                case .staging:
+                    return NSLocalizedString("Staging (for dev builds)", comment: "Label indicating the staging environment for Push notification functionality")
             }
         }
 
@@ -221,6 +224,8 @@ extension PushNotificationClient {
                     URL(string: "http://\(host ?? "localhost:8000")") ?? Constants.PUSH_NOTIFICATION_SERVER_TEST_BASE_URL
                 case .production:
                     Constants.PUSH_NOTIFICATION_SERVER_PRODUCTION_BASE_URL
+                case .staging:
+                    Constants.PUSH_NOTIFICATION_SERVER_STAGING_BASE_URL
                     
             }
         }
@@ -240,6 +245,8 @@ extension PushNotificationClient {
                     self = .local_test(host: nil)
                 case "production":
                     self = .production
+                case "staging":
+                    self = .staging
                 default:
                     let components = string.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
                     if components.count == 2 && components[0] == "local_test" {
@@ -257,6 +264,8 @@ extension PushNotificationClient {
                         return "local_test:\(host)"
                     }
                     return "local_test"
+                case .staging:
+                    return "staging"
                 case .production:
                     return "production"
             }
@@ -273,6 +282,8 @@ extension PushNotificationClient {
                     }
                 case .production:
                     return "production"
+                case .staging:
+                    return "staging"
             }
         }
     }

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -210,8 +210,8 @@ class UserSettingsStore: ObservableObject {
     @Setting(key: "enable_experimental_push_notifications", default_value: false)
     var enable_experimental_push_notifications: Bool
     
-    @Setting(key: "send_device_token_to_localhost", default_value: false)
-    var send_device_token_to_localhost: Bool
+    @StringSetting(key: "push_notification_environment", default_value: .production)
+    var push_notification_environment: PushNotificationClient.Environment
     
     @Setting(key: "enable_experimental_purple_api", default_value: false)
     var enable_experimental_purple_api: Bool

--- a/damus/Util/Constants.swift
+++ b/damus/Util/Constants.swift
@@ -15,6 +15,7 @@ class Constants {
     
     // MARK: Push notification server
     static let PUSH_NOTIFICATION_SERVER_PRODUCTION_BASE_URL: URL = URL(string: "https://notify.damus.io")!
+    static let PUSH_NOTIFICATION_SERVER_STAGING_BASE_URL: URL = URL(string: "https://notify-staging.damus.io")!
     static let PUSH_NOTIFICATION_SERVER_TEST_BASE_URL: URL = URL(string: "http://localhost:8000")!
     
     // MARK: Purple


### PR DESCRIPTION
This commit adds an option that allows a user to choose a custom push notification server, as well as the staging notify server, to help with testing