### PR TITLE
Implement support for reply notification formatting

### DIFF
--- a/DamusNotificationService/NotificationFormatter.swift
+++ b/DamusNotificationService/NotificationFormatter.swift
@@ -70,6 +70,9 @@ struct NotificationFormatter {
             case .zap, .profile_zap:
                 // not handled here. Try `format_message(displayName: String, notify: LocalNotification, state: HeadlessDamusState) async -> (content: UNMutableNotificationContent, identifier: String)?`
                 return nil
+            case .reply:
+                title = String(format: NSLocalizedString("%@ replied to your note", comment: "Heading for local notification indicating a new reply"), displayName)
+                identifier = "myReplyNotification"
         }
         content.title = title
         content.body = notify.content

--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -780,7 +780,7 @@ struct ContentView: View {
             selected_timeline = .dms
             damus_state.dms.set_active_dm(target.pubkey)
             navigationCoordinator.push(route: Route.DMChat(dms: damus_state.dms.active_model))
-        case .like, .zap, .mention, .repost:
+        case .like, .zap, .mention, .repost, .reply:
             open_event(ev: target)
         case .profile_zap:
             break

--- a/damus/Util/LocalNotification.swift
+++ b/damus/Util/LocalNotification.swift
@@ -63,6 +63,7 @@ enum LocalNotificationType: String {
     case dm
     case like
     case mention
+    case reply
     case repost
     case zap
     case profile_zap


### PR DESCRIPTION
This commit implements support for nicely formatting reply push notifications.

Testing
-------

PASS

Device: iPhone 15 simulator
notepush: 11568aa6285142e4c19bb0da30977957a92b7d9b Damus: This commit
Settings: Local push notification setup
Steps:
1. Create a post from account 1
2. On account 2, make a reply to that post
3. Ensure we get a push notification with:
    - A title formatted as "<ACCOUNT_2_NAME> replied to your note"
    - A body with the contents of that reply
5. Click on that push notification. Ensure you are taken to the reply
6. Now make a post from account 2 and mention account 1 in it
7. Ensure push notification says that account 2 mentioned account 1 (i.e. does not talk about a reply)


Closes: https://github.com/damus-io/damus/issues/2403