### PR TITLE
Reapply and rework "ux: Mute selected text"

### DIFF
--- a/damus/Views/Muting/AddMuteItemView.swift
+++ b/damus/Views/Muting/AddMuteItemView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 struct AddMuteItemView: View {
     let state: DamusState
-    @State var new_text: String = ""
+    @Binding var new_text: String
     @State var expiration: DamusDuration = .indefinite
 
     @Environment(\.dismiss) var dismiss
@@ -108,6 +108,6 @@ struct AddMuteItemView: View {
 
 struct AddMuteItemView_Previews: PreviewProvider {
     static var previews: some View {
-        AddMuteItemView(state: test_damus_state)
+        AddMuteItemView(state: test_damus_state, new_text: .constant(""))
     }
 }

--- a/damus/Views/Muting/MutelistView.swift
+++ b/damus/Views/Muting/MutelistView.swift
@@ -15,6 +15,8 @@ struct MutelistView: View {
     @State var hashtags: [MuteItem] = []
     @State var threads: [MuteItem] = []
     @State var words: [MuteItem] = []
+    
+    @State var new_text: String = ""
 
     func RemoveAction(item: MuteItem) -> some View {
         Button {
@@ -120,13 +122,9 @@ struct MutelistView: View {
             }
         }
         .sheet(isPresented: $show_add_muteitem, onDismiss: { self.show_add_muteitem = false }) {
-            if #available(iOS 16.0, *) {
-                AddMuteItemView(state: damus_state)
-                    .presentationDetents([.height(300)])
-                    .presentationDragIndicator(.visible)
-            } else {
-                AddMuteItemView(state: damus_state)
-            }
+            AddMuteItemView(state: damus_state, new_text: $new_text)
+                .presentationDetents([.height(300)])
+                .presentationDragIndicator(.visible)
         }
     }
 }


### PR DESCRIPTION
This commit reapplies the "ux: Mute selected text" commit, with some manual rework to solve logical conflicts during merge.

Rework testing
--------------

PASS

Device: iPhone 13 Mini
iOS: 17.6.1
Steps:
1. Go to a note
2. Select text and click on the "highlight" button. Ensure that highlight sheet appears with the correct text
3. Select text and click on the "mute" button. Ensure that mute sheet appears with the correct text

Original commit: d66315594137b5478909d3e8c751348d7405860f
Original author: ericholguin <ericholguin@apache.org>
Reworked-by: Daniel D’Aquino <daniel@daquino.me>
Retested-by: Daniel D’Aquino <daniel@daquino.me>