### PR TITLE
A few notification fixes

### DIFF
--- a/DamusNotificationService/NotificationFormatter.swift
+++ b/DamusNotificationService/NotificationFormatter.swift
@@ -93,10 +93,11 @@ struct NotificationFormatter {
         
         // If it does not work, try async formatting methods
         let content = UNMutableNotificationContent()
-        
+
         switch notify.type {
             case .zap, .profile_zap:
                 guard let zap = await get_zap(from: notify.event, state: state) else {
+                    Log.debug("format_message: async get_zap failed", for: .push_notifications)
                     return nil
                 }
                 content.title = Self.zap_notification_title(zap)

--- a/DamusNotificationService/NotificationFormatter.swift
+++ b/DamusNotificationService/NotificationFormatter.swift
@@ -55,6 +55,9 @@ struct NotificationFormatter {
         var identifier = ""
         
         switch notify.type {
+            case .tagged:
+                title = String(format: NSLocalizedString("Tagged by %@", comment: "Tagged by heading in local notification"), displayName)
+                identifier = "myMentionNotification"
             case .mention:
                 title = String(format: NSLocalizedString("Mentioned by %@", comment: "Mentioned by heading in local notification"), displayName)
                 identifier = "myMentionNotification"

--- a/DamusNotificationService/NotificationService.swift
+++ b/DamusNotificationService/NotificationService.swift
@@ -58,6 +58,7 @@ class NotificationService: UNNotificationServiceExtension {
         }
         
         guard should_display_notification(state: state, event: nostr_event, mode: .push) else {
+            Log.debug("should_display_notification failed", for: .push_notifications)
             // We should not display notification for this event. Suppress notification.
             // contentHandler(UNNotificationContent())
             // TODO: We cannot really suppress until we have the notification supression entitlement. Show the raw notification
@@ -66,6 +67,7 @@ class NotificationService: UNNotificationServiceExtension {
         }
         
         guard let notification_object = generate_local_notification_object(from: nostr_event, state: state) else {
+            Log.debug("generate_local_notification_object failed", for: .push_notifications)
             // We could not process this notification. Probably an unsupported nostr event kind. Suppress.
             // contentHandler(UNNotificationContent())
             // TODO: We cannot really suppress until we have the notification supression entitlement. Show the raw notification
@@ -74,9 +76,13 @@ class NotificationService: UNNotificationServiceExtension {
         }
         
         Task {
-            if let (improvedContent, _) = await NotificationFormatter.shared.format_message(displayName: display_name, notify: notification_object, state: state) {
-                contentHandler(improvedContent)
+            guard let (improvedContent, _) = await NotificationFormatter.shared.format_message(displayName: name, notify: notification_object, state: state) else {
+
+                Log.debug("NotificationFormatter.format_message failed", for: .push_notifications)
+                return
             }
+
+            contentHandler(improvedContent)
         }
     }
     

--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -722,7 +722,7 @@ struct ContentView: View {
             selected_timeline = .dms
             damus_state.dms.set_active_dm(target.pubkey)
             navigationCoordinator.push(route: Route.DMChat(dms: damus_state.dms.active_model))
-        case .like, .zap, .mention, .repost, .reply:
+        case .like, .zap, .mention, .repost, .reply, .tagged:
             open_event(ev: target)
         case .profile_zap:
             break

--- a/damus/Util/LocalNotification.swift
+++ b/damus/Util/LocalNotification.swift
@@ -48,10 +48,24 @@ struct LossyLocalNotification {
     }
 }
 
+enum NotificationTarget {
+    case note(NostrEvent)
+    case note_id(NoteId)
+
+    var id: NoteId {
+        switch self {
+        case .note(let note):
+            return note.id
+        case .note_id(let id):
+            return id
+        }
+    }
+}
+
 struct LocalNotification {
     let type: LocalNotificationType
     let event: NostrEvent
-    let target: NostrEvent
+    let target: NotificationTarget
     let content: String
     
     func to_lossy() -> LossyLocalNotification {
@@ -64,6 +78,7 @@ enum LocalNotificationType: String {
     case like
     case mention
     case reply
+    case tagged
     case repost
     case zap
     case profile_zap

--- a/nostrdb/Ndb.swift
+++ b/nostrdb/Ndb.swift
@@ -111,8 +111,10 @@ class Ndb {
             var ok = false
             while !ok && mapsize > 1024 * 1024 * 700 {
                 var cfg = ndb_config(flags: 0, ingester_threads: ingest_threads, mapsize: mapsize, filter_context: nil, ingest_filter: nil)
-                ok = ndb_init(&ndb_p, testdir, &cfg) != 0
+                let res = ndb_init(&ndb_p, testdir, &cfg)
+                ok = res != 0;
                 if !ok {
+                    Log.error("ndb_init failed: %d, reducing mapsize from %d to %d", for: .storage, res, mapsize, mapsize / 2)
                     mapsize /= 2
                 }
             }


### PR DESCRIPTION
there are many states in which it will just outright fail to format unnecessarily. For example, if there is no display_name (which might not be there, so we shouldn't fail outright on these). This PR fixes that.

We also accept kind1 notes where you are tagged but where there are no mentions in the contents. We call these "Tagged" notifications.