### PR TITLE
Fix for iOS 18 - Opening Video player changes theme to black, and can…

### DIFF
--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -121,7 +121,6 @@ struct NoteContentView: View {
                 .padding(.top)
         }
         .background(.thinMaterial)
-        .preferredColorScheme(.dark)
         .onTapGesture(perform: {
             damus_state.nav.push(route: Route.Thread(thread: .init(event: self.event, damus_state: damus_state)))
             dismiss()

--- a/damus/Views/Purple/DamusPurpleAccountView.swift
+++ b/damus/Views/Purple/DamusPurpleAccountView.swift
@@ -64,7 +64,6 @@ struct DamusPurpleAccountView: View {
                 .padding(.bottom, 20)
             }
             .foregroundColor(.white.opacity(0.8))
-            .preferredColorScheme(.dark)
             .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
             .padding()
         }


### PR DESCRIPTION
…'t be switched afterwards #2373

Removed line which forces preferred colour scheme to dark.