### PR TITLE
Fix unit test build

### DIFF
--- a/damus/Models/Post.swift
+++ b/damus/Models/Post.swift
@@ -51,7 +51,7 @@ struct NostrPost {
     }
     
     /// Parse the post's contents to find more tags to apply to the final nostr event
-    private func make_post_tags(post_blocks: [Block], tags: [[String]]) -> PostTags {
+    func make_post_tags(post_blocks: [Block], tags: [[String]]) -> PostTags {
         var new_tags = tags
 
         for post_block in post_blocks {
@@ -89,10 +89,12 @@ struct NostrPost {
 
 // MARK: - Helper structures and functions
 
-/// A struct used for temporarily holding tag information that was parsed from a post contents to aid in building a nostr event
-fileprivate struct PostTags {
-    let blocks: [Block]
-    let tags: [[String]]
+extension NostrPost {
+    /// A struct used for temporarily holding tag information that was parsed from a post contents to aid in building a nostr event
+    struct PostTags {
+        let blocks: [Block]
+        let tags: [[String]]
+    }
 }
 
 func parse_post_blocks(content: String) -> [Block] {

--- a/damusTests/ReplyTests.swift
+++ b/damusTests/ReplyTests.swift
@@ -57,7 +57,8 @@ class ReplyTests: XCTestCase {
         let ev = NostrEvent(content: content, keypair: test_keypair, tags: [])!
         let blocks = parse_note_content(content: .init(note: ev, keypair: test_keypair)).blocks
         let post_blocks = parse_post_blocks(content: content)
-        let post_tags = make_post_tags(post_blocks: post_blocks, tags: [])
+        let post = NostrPost(content: content, kind: NostrKind.text, tags: [])
+        let post_tags = post.make_post_tags(post_blocks: post_blocks, tags: [])
         let tr = interpret_event_refs(tags: ev.tags)
 
         XCTAssertNil(tr)


### PR DESCRIPTION
A change around the NostrPost interfaces caused unit tests to fail compilation. This commit fixes that.