### PR TITLE
Improve notification view filtering UX

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -77,7 +77,12 @@ struct ContentView: View {
     
     @State var active_sheet: Sheets? = nil
     @State var damus_state: DamusState!
-    @SceneStorage("ContentView.selected_timeline") var selected_timeline: Timeline = .home
+    @State var menu_subtitle: String? = nil
+    @SceneStorage("ContentView.selected_timeline") var selected_timeline: Timeline = .home {
+        willSet {
+            self.menu_subtitle = nil
+        }
+    }
     @State var muting: MuteItem? = nil
     @State var confirm_mute: Bool = false
     @State var hide_bar: Bool = false
@@ -159,9 +164,16 @@ struct ContentView: View {
         isSideBarOpened = false
     }
     
-    var timelineNavItem: Text {
-        return Text(timeline_name(selected_timeline))
-            .bold()
+    var timelineNavItem: some View {
+        VStack {
+            Text(timeline_name(selected_timeline))
+                .bold()
+            if let menu_subtitle {
+                Text(menu_subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
     
     func MainContent(damus: DamusState) -> some View {
@@ -180,7 +192,7 @@ struct ContentView: View {
                 PostingTimelineView
                 
             case .notifications:
-                NotificationsView(state: damus, notifications: home.notifications)
+                NotificationsView(state: damus, notifications: home.notifications, subtitle: $menu_subtitle)
                 
             case .dms:
                 DirectMessagesView(damus_state: damus_state!, model: damus_state!.dms, settings: damus_state!.settings)

--- a/damus/Models/FriendFilter.swift
+++ b/damus/Models/FriendFilter.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum FriendFilter: String, StringCodable {
     case all
-    case friends
+    case friends_of_friends
     
     init?(from string: String) {
         guard let ff = FriendFilter(rawValue: string) else {
@@ -27,8 +27,17 @@ enum FriendFilter: String, StringCodable {
         switch self {
         case .all:
             return true
-        case .friends:
+        case .friends_of_friends:
             return contacts.is_in_friendosphere(pubkey)
+        }
+    }
+    
+    func description() -> String {
+        switch self {
+            case .all:
+                return NSLocalizedString("All", comment: "Human-readable short description of the 'friends filter' when it is set to 'all'")
+            case .friends_of_friends:
+                return NSLocalizedString("Friends of friends", comment: "Human-readable short description of the 'friends filter' when it is set to 'friends-of-friends'")
         }
     }
 }

--- a/damus/Views/Buttons/FriendsButton.swift
+++ b/damus/Views/Buttons/FriendsButton.swift
@@ -14,12 +14,12 @@ struct FriendsButton: View {
         Button(action: {
             switch self.filter {
             case .all:
-                self.filter = .friends
-            case .friends:
+                self.filter = .friends_of_friends
+            case .friends_of_friends:
                 self.filter = .all
             }
         }) {
-            if filter == .friends {
+            if filter == .friends_of_friends {
                 LINEAR_GRADIENT
                     .mask(Image("user-added")
                         .resizable()

--- a/damus/Views/Buttons/FriendsButton.swift
+++ b/damus/Views/Buttons/FriendsButton.swift
@@ -28,7 +28,7 @@ struct FriendsButton: View {
                 Image("user-added")
                     .resizable()
                     .frame(width: 28, height: 28)
-                    .foregroundColor(DamusColors.adaptableGrey)
+                    .foregroundColor(.gray)
             }
         }
         .buttonStyle(.plain)

--- a/damus/Views/DirectMessagesView.swift
+++ b/damus/Views/DirectMessagesView.swift
@@ -103,7 +103,7 @@ struct DirectMessagesView: View {
 
 func would_filter_non_friends_from_dms(contacts: Contacts, dms: [DirectMessageModel]) -> Bool {
     for dm in dms {
-        if !FriendFilter.friends.filter(contacts: contacts, pubkey: dm.pubkey) {
+        if !FriendFilter.friends_of_friends.filter(contacts: contacts, pubkey: dm.pubkey) {
             return true
         }
     }


### PR DESCRIPTION
Improvements to the UX around notification view filtering, as discussed on standup — related to https://github.com/damus-io/damus/issues/2480 

| light mode | dark mode | light mode with filter |
|--------|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-09-16 at 12 52 01](https://github.com/user-attachments/assets/b0eba4b2-5706-48a6-9c4d-df8dccb2bebe) | ![Simulator Screenshot - iPhone 15 - 2024-09-16 at 12 52 13](https://github.com/user-attachments/assets/f1a7b7fa-440f-494b-8a67-198f7c028f62) | ![Simulator Screenshot - iPhone 15 - 2024-09-16 at 12 52 03](https://github.com/user-attachments/assets/3299eef9-e414-4f66-8036-530a0e38254e) | 
