### PR TITLE
Fix issue where theme would be changed to black and can't be switched back on iOS 18

### DIFF
--- a/damus/Components/SupporterBadge.swift
+++ b/damus/Components/SupporterBadge.swift
@@ -11,11 +11,13 @@ struct SupporterBadge: View {
     let percent: Int?
     let purple_account: DamusPurple.Account?
     let style: Style
+    let text_color: Color
     
-    init(percent: Int?, purple_account: DamusPurple.Account? = nil, style: Style) {
+    init(percent: Int?, purple_account: DamusPurple.Account? = nil, style: Style, text_color: Color = .secondary) {
         self.percent = percent
         self.purple_account = purple_account
         self.style = style
+        self.text_color = text_color
     }
     
     let size: CGFloat = 17
@@ -31,7 +33,7 @@ struct SupporterBadge: View {
                     if self.style == .full {
                         let date = format_date(date: purple_account.created_at, time_style: .none)
                         Text(date)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(text_color)
                             .font(.caption)
                     }
                 }

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -120,8 +120,7 @@ struct NoteContentView: View {
             EventView(damus: damus_state, event: self.event, options: .embedded_text_only)
                 .padding(.top)
         }
-        .background(.thinMaterial)
-        .preferredColorScheme(.dark)
+        .background(.thickMaterial)
         .onTapGesture(perform: {
             damus_state.nav.push(route: Route.Thread(thread: .init(event: self.event, damus_state: damus_state)))
             dismiss()

--- a/damus/Views/Purple/DamusPurpleAccountView.swift
+++ b/damus/Views/Purple/DamusPurpleAccountView.swift
@@ -64,7 +64,6 @@ struct DamusPurpleAccountView: View {
                 .padding(.bottom, 20)
             }
             .foregroundColor(.white.opacity(0.8))
-            .preferredColorScheme(.dark)
             .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
             .padding()
         }
@@ -81,7 +80,8 @@ struct DamusPurpleAccountView: View {
             SupporterBadge(
                 percent: nil,
                 purple_account: account,
-                style: .full
+                style: .full,
+                text_color: .white
             )
         }
     }


### PR DESCRIPTION
Removed line which forces preferred colour scheme to dark on iOS 18, and made adjustments to the styling to maintain text legibility

Changelog-Fixed: Fixed issue where theme would be changed to black and can't be switched back on iOS 18
Closes: https://github.com/damus-io/damus/issues/2373