### PR TITLE
Don't reconnect when we don't have to

### DIFF
--- a/damus/Nostr/RelayConnection.swift
+++ b/damus/Nostr/RelayConnection.swift
@@ -46,9 +46,10 @@ final class RelayConnection: ObservableObject {
             
             if err == nil {
                 self.last_pong = .now
+                Log.info("Got pong from '%s'", for: .networking, self.relay_url.absoluteString)
                 self.log?.add("Successful ping")
             } else {
-                print("pong failed, reconnecting \(self.relay_url.id)")
+                Log.info("Ping failed, reconnecting to '%s'", for: .networking, self.relay_url.absoluteString)
                 self.isConnected = false
                 self.isConnecting = false
                 self.reconnect_with_backoff()
@@ -126,7 +127,7 @@ final class RelayConnection: ObservableObject {
             self.receive(message: message)
         case .disconnected(let closeCode, let reason):
             if closeCode != .normalClosure {
-                print("⚠️ Warning: RelayConnection (\(self.relay_url)) closed with code \(closeCode), reason: \(String(describing: reason))")
+                Log.error("⚠️ Warning: RelayConnection (%d) closed with code: %s", for: .networking, String(describing: closeCode), String(describing: reason))
             }
             DispatchQueue.main.async {
                 self.isConnected = false
@@ -134,7 +135,7 @@ final class RelayConnection: ObservableObject {
                 self.reconnect()
             }
         case .error(let error):
-            print("⚠️ Warning: RelayConnection (\(self.relay_url)) error: \(error)")
+            Log.error("⚠️ Warning: RelayConnection (%s) error: %s", for: .networking, self.relay_url.absoluteString, error.localizedDescription)
             let nserr = error as NSError
             if nserr.domain == NSPOSIXErrorDomain && nserr.code == 57 {
                 // ignore socket not connected?

--- a/damus/Nostr/RelayPool.swift
+++ b/damus/Nostr/RelayPool.swift
@@ -89,6 +89,7 @@ class RelayPool {
     }
     
     func ping() {
+        Log.info("Pinging %d relays", for: .networking, relays.count)
         for relay in relays {
             relay.connection.ping()
         }

--- a/damus/Util/Log.swift
+++ b/damus/Util/Log.swift
@@ -13,6 +13,7 @@ enum LogCategory: String {
     case nav
     case render
     case storage
+    case networking
     case push_notifications
     case damus_purple
     case image_uploading


### PR DESCRIPTION
We are reconnecting multiple times for two separate reasons:

1. On a cancellation "error" which does not warrant a reconnect

2. In our reconnection backoff it doesn't check If we are already
connecting or connected. We check this so we don't reconnect multiple
times.

This fixes many reconnection issues and makes Damus feel wayyy snappier.
