### PR TITLE
Add PR template with checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Summary
+
+_[Please provide a summary of the changes in this PR.]_
+
+## Checklist
+
+- [ ] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
+- [ ] I have tested the changes in this PR
+- [ ] My PR is either small, or I have split it into smaller logical commits that are easier to review
+- [ ] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
+- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
+    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
+- [ ] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)
+
+## Test report
+
+_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._
+
+**Device:** _[Please specify the device you used for testing]_
+
+**iOS:** _[Please specify the iOS version you used for testing]_
+
+**Damus:** _[Please specify the Damus version or commit hash you used for testing]_
+
+**Setup:** _[Please provide a brief description of the setup you used for testing, if applicable]_
+
+**Steps:** _[Please provide a list of steps you took to test the changes in this PR]_
+
+**Results:**
+- [ ] PASS
+- [ ] Partial PASS
+  - Details: _[Please provide details of the partial pass]_
+
+## Other notes
+
+_[Please provide any other information that you think is relevant to this PR.]_


### PR DESCRIPTION
This adds a PR template that will be applied to every new pull request, to help both contributors and reviewers make sure that the contribution guidelines are being met.

A rendered preview with working links can be found here: https://github.com/danieldaquino/damus/blob/pr_template/.github/pull_request_template.md