### PR TITLE
Add NostrMedia.com as media uploader option

### DIFF
--- a/damus/Models/MediaUploader.swift
+++ b/damus/Models/MediaUploader.swift
@@ -11,6 +11,7 @@ enum MediaUploader: String, CaseIterable, Identifiable, StringCodable {
     var id: String { self.rawValue }
     case nostrBuild
     case nostrcheck
+    case nostrMedia  // New case for nostrMedia
     
     init?(from string: String) {
         guard let mu = MediaUploader(rawValue: string) else {
@@ -35,9 +36,7 @@ enum MediaUploader: String, CaseIterable, Identifiable, StringCodable {
     
     var supportsVideo: Bool {
         switch self {
-        case .nostrBuild:
-            return true
-        case .nostrcheck:
+        case .nostrBuild, .nostrcheck, .nostrMedia:
             return true
         }
     }
@@ -55,6 +54,8 @@ enum MediaUploader: String, CaseIterable, Identifiable, StringCodable {
             return .init(index: -1, tag: "nostrBuild", displayName: "nostr.build")
         case .nostrcheck:
             return .init(index: 0, tag: "nostrcheck", displayName: "nostrcheck.me")
+        case .nostrMedia:
+            return .init(index: 1, tag: "nostrMedia", displayName: "NostrMedia.com")
         }
     }
     
@@ -64,6 +65,8 @@ enum MediaUploader: String, CaseIterable, Identifiable, StringCodable {
             return "https://nostr.build/api/v2/nip96/upload"
         case .nostrcheck:
             return "https://nostrcheck.me/api/v2/media"
+        case .nostrMedia:
+            return "https://nostrmedia.com/upload"
         }
     }
     


### PR DESCRIPTION
## Summary

I do not believe a SoB is necessary for this small merge request? I'm also not a Swift dev nor mobile app dev, but the code's logic seemed fairly easy to replicate in order to add edits. Please correct if not accurate and if there are other required file edits necessary. However, I could not find the "Appearance" UI that controlled the drop-down menu in user settings in order to add an option for NostrMedia.com. 

Interestingly, I couldn't find the file that controls where "nostrimg.com" is even listed, which appears like it should be deprecated as "nostrimg.com" is no longer a functioning website. Yet, the option for "nostrimg.com" still exists even in the current production v1.10.1 build released in App Store. (see screenshots below) 
![damus1](https://github.com/user-attachments/assets/f0e5f3d8-c7d2-489b-9b68-7e65c19257b1)
![damus2](https://github.com/user-attachments/assets/33da2408-96eb-43e2-8a06-6cd20e5fb619)

Changelog-Added: media uploader support for NostrMedia.com

## Checklist

- [✅ ] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [❌ ] I have tested the changes in this PR
- [✅ ] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [❌ ] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [✅ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [❌ ] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

N/A -- not a mobile app dev and this change seems small enough to not warrant a full blown emulator test. NostrMeida.com API endpoint supports NIP-98 and NIP-96 as well as Blossom. So, if the POST and/or PUT requests are structured to spec, then there shouldn't be an issue with passing uploads or having the uploaded file URL returned in response.

## Other notes

Please let me know if there's anything else required in order to get NostrMedia.com added as a media upload provider. Thank you!
