### PR TITLE
multiple images upload

### DIFF
--- a/damus/Views/MediaPicker.swift
+++ b/damus/Views/MediaPicker.swift
@@ -117,7 +117,7 @@ struct MediaPicker: UIViewControllerRepresentable {
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
         configuration.selectionLimit = 0 // Allows multiple media selection
         configuration.filter = imagesOnly ? .images : .any(of: [.images, .videos])
-        
+        configuration.selection = .ordered // images are returned in the order they were selected + numbered badge displayed
         let picker = PHPickerViewController(configuration: configuration)
         picker.delegate = context.coordinator as any PHPickerViewControllerDelegate
         return picker

--- a/damus/Views/MediaPicker.swift
+++ b/damus/Views/MediaPicker.swift
@@ -115,7 +115,7 @@ struct MediaPicker: UIViewControllerRepresentable {
     
     func makeUIViewController(context: Context) -> PHPickerViewController {
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
-        configuration.selectionLimit = 1
+        configuration.selectionLimit = 0 // Allows multiple media selection
         configuration.filter = imagesOnly ? .images : .any(of: [.images, .videos])
         
         let picker = PHPickerViewController(configuration: configuration)

--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -60,7 +60,7 @@ struct PostView: View {
     @State var newCursorIndex: Int?
     @State var textHeight: CGFloat? = nil
 
-    @State var preUploadedMedia: PreUploadedMedia? = nil
+    @State var preUploadedMedia: [PreUploadedMedia] = []
     
     @StateObject var image_upload: ImageUploadModel = ImageUploadModel()
     @StateObject var tagModel: TagModel = TagModel()
@@ -151,6 +151,7 @@ struct PostView: View {
     
     var ImageButton: some View {
         Button(action: {
+            preUploadedMedia.removeAll()
             attach_media = true
         }, label: {
             Image("images")
@@ -445,16 +446,20 @@ struct PostView: View {
             .background(DamusColors.adaptableWhite.edgesIgnoringSafeArea(.all))
             .sheet(isPresented: $attach_media) {
                 MediaPicker(image_upload_confirm: $image_upload_confirm){ media in
-                    self.preUploadedMedia = media
+                    self.preUploadedMedia.append(media)
                 }
-                .alert(NSLocalizedString("Are you sure you want to upload this media?", comment: "Alert message asking if the user wants to upload media."), isPresented: $image_upload_confirm) {
+                .alert(NSLocalizedString("Are you sure you want to upload the selected media?", comment: "Alert message asking if the user wants to upload media."), isPresented: $image_upload_confirm) {
                     Button(NSLocalizedString("Upload", comment: "Button to proceed with uploading."), role: .none) {
-                        if let mediaToUpload = generateMediaUpload(preUploadedMedia) {
-                            self.handle_upload(media: mediaToUpload)
-                            self.attach_media = false
+                        for media in preUploadedMedia {
+                           if let mediaToUpload = generateMediaUpload(media) {
+                               self.handle_upload(media: mediaToUpload)
+                            }
                         }
+                        self.attach_media = false
                     }
-                    Button(NSLocalizedString("Cancel", comment: "Button to cancel the upload."), role: .cancel) {}
+                    Button(NSLocalizedString("Cancel", comment: "Button to cancel the upload."), role: .cancel) {
+                        preUploadedMedia.removeAll()
+                    }
                 }
             }
             .sheet(isPresented: $attach_camera) {
@@ -486,6 +491,7 @@ struct PostView: View {
                 if isEmpty() {
                     clear_draft()
                 }
+                preUploadedMedia.removeAll()
             }
         }
     }

--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -452,6 +452,7 @@ struct PostView: View {
                 }
                 .alert(NSLocalizedString("Are you sure you want to upload the selected media?", comment: "Alert message asking if the user wants to upload media."), isPresented: $image_upload_confirm) {
                     Button(NSLocalizedString("Upload", comment: "Button to proceed with uploading."), role: .none) {
+                        // initiate asynchronous uploading Task for multiple-images 
                         Task {
                             for media in preUploadedMedia {
                                 if let mediaToUpload = generateMediaUpload(media) {


### PR DESCRIPTION
## Summary

This PR allows selecting multiple images option in the Media Picker Sheet. The selected images are uploaded using the default `handle_upload()` method while performed in an array iteration. 

The motivation comes from the fact that it is often tedious to select one image at a time from the sheet and repeat the same process for multiple uploads.

The demo of the feature is attached here:

https://github.com/user-attachments/assets/f3c4eb7e-02a0-4f7a-9741-60b34cdbbce3



## Checklist

- [ ] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [ ] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [ ] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [ ] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)