### PR TITLE
fixes: Fix padding for views for tabbar

### DIFF
--- a/damus/Views/DMChatView.swift
+++ b/damus/Views/DMChatView.swift
@@ -10,6 +10,7 @@ import Combine
 
 struct DMChatView: View, KeyboardReadable {
     let damus_state: DamusState
+    @FocusState private var isTextFieldFocused: Bool
     @ObservedObject var dms: DirectMessageModel
     
     var pubkey: Pubkey {
@@ -46,6 +47,7 @@ struct DMChatView: View, KeyboardReadable {
                     }
                 }
         }
+        .padding(.bottom, isTextFieldFocused ? 0 : tabHeight)
     }
     
     func scroll_to_end(_ scroller: ScrollViewProxy, animated: Bool = false) {
@@ -74,6 +76,7 @@ struct DMChatView: View, KeyboardReadable {
             .textEditorBackground {
                 InputBackground()
             }
+            .focused($isTextFieldFocused)
             .cornerRadius(8)
             .background(
                 RoundedRectangle(cornerRadius: 8)

--- a/damus/Views/DirectMessagesView.swift
+++ b/damus/Views/DirectMessagesView.swift
@@ -35,6 +35,7 @@ struct DirectMessagesView: View {
             }
             .padding(.horizontal)
         }
+        .padding(.bottom, tabHeight)
     }
     
     func filter_dms(dms: [DirectMessageModel]) -> [DirectMessageModel] {

--- a/damus/Views/Profile/EditMetadataView.swift
+++ b/damus/Views/Profile/EditMetadataView.swift
@@ -203,7 +203,7 @@ struct EditMetadataView: View {
             })
             .buttonStyle(GradientButtonStyle(padding: 15))
             .padding(.horizontal, 10)
-            .padding(.bottom, 10 + tabHeight + getSafeAreaBottom())
+            .padding(.bottom, 10 + tabHeight)
             .disabled(!didChange())
             .opacity(!didChange() ? 0.5 : 1)
             .disabled(profileUploadObserver.isLoading || bannerUploadObserver.isLoading)

--- a/damus/Views/ReactionsView.swift
+++ b/damus/Views/ReactionsView.swift
@@ -22,7 +22,7 @@ struct ReactionsView: View {
             }
             .padding()
         }
-        .padding(.bottom, tabHeight + getSafeAreaBottom())
+        .padding(.bottom, tabHeight)
         .navigationBarTitle(NSLocalizedString("Reactions", comment: "Navigation bar title for Reactions view."))
         .onAppear {
             model.subscribe()

--- a/damus/Views/Reposts/QuoteRepostsView.swift
+++ b/damus/Views/Reposts/QuoteRepostsView.swift
@@ -13,6 +13,7 @@ struct QuoteRepostsView: View {
 
     var body: some View {
         TimelineView<AnyView>(events: model.events, loading: $model.loading, damus: damus_state, show_friend_icon: true, filter: ContentFilters.default_filters(damus_state: damus_state).filter(ev:))
+        .padding(.bottom, tabHeight)
         .navigationBarTitle(NSLocalizedString("Quotes", comment: "Navigation bar title for Quote Reposts view."))
         .onAppear {
             model.subscribe()

--- a/damus/Views/RepostsView.swift
+++ b/damus/Views/RepostsView.swift
@@ -20,7 +20,7 @@ struct RepostsView: View {
             }
             .padding()
         }
-        .padding(.bottom, tabHeight + getSafeAreaBottom())
+        .padding(.bottom, tabHeight)
         .navigationBarTitle(NSLocalizedString("Reposts", comment: "Navigation bar title for Reposts view."))
         .onAppear {
             model.subscribe()

--- a/damus/Views/Zaps/ZapsView.swift
+++ b/damus/Views/Zaps/ZapsView.swift
@@ -28,7 +28,7 @@ struct ZapsView: View {
                 }
             }
         }
-        .padding(.bottom, tabHeight + getSafeAreaBottom())
+        .padding(.bottom, tabHeight)
         .navigationBarTitle(NSLocalizedString("Zaps", comment: "Navigation bar title for the Zaps view."))
         .onAppear {
             model.subscribe()


### PR DESCRIPTION
## Summary

This PR fixes the bottom padding on views to account for the bottom tabbar, now that the tabbar is an overlay we must account for it.

Changelog-Fixed: Fixed bottom padding for tabbar

## Checklist

- [ x ] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [ x ] I have tested the changes in this PR
- [ x ] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [ x ] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ x ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [ x ] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** 
- iPhone SE (3rd Generation)
- iPhone 12 mini
- iPhone 15 Pro Max
- iPhone 16 Pro Max

**iOS:** _[Please specify the iOS version you used for testing]_

- 16.4
- 17.0
- 18.0

**Damus:** 

1.11 (1) c948c7e2

**Setup:** 

Using simulator

**Steps:** 

Verified the views were not being blocked by the bottom tabbar.

**Results:**
- [ x ] PASS

