### PR TITLE
Fix sensitive chat bubble on iOS 18

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -5564,10 +5564,10 @@
 		};
 		D78DB8572C1CE9CA00F0AB12 /* XCRemoteSwiftPackageReference "SwipeActions" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/aheze/SwipeActions";
+			repositoryURL = "https://github.com/damus-io/SwipeActions.git";
 			requirement = {
-				kind = exactVersion;
-				version = 1.1.0;
+				kind = revision;
+				revision = 33d99756c3112e1a07c1732e3cddc5ad5bd0c5f4;
 			};
 		};
 		D7A343EC2AD0D77C00CED48B /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {

--- a/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "babaf4d5748afecf49bbb702530d8e9576460692f478b0a50ee43195dd4440e2",
+  "originHash" : "1b14e62192b3fa4b04a57cb4601d175b325dc16cb5f22c4c8eb975a675328637",
   "pins" : [
     {
       "identity" : "emojikit",
@@ -92,10 +92,9 @@
     {
       "identity" : "swipeactions",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/aheze/SwipeActions",
+      "location" : "https://github.com/damus-io/SwipeActions.git",
       "state" : {
-        "revision" : "41e6f6dce02d8cfa164f8c5461a41340850ca3ab",
-        "version" : "1.1.0"
+        "revision" : "33d99756c3112e1a07c1732e3cddc5ad5bd0c5f4"
       }
     }
   ],


### PR DESCRIPTION
## Summary

This commit fixes an issue with the chat bubble view where it would unexpectedly trigger the reaction emoji keyboard when scrolling or swiping, which became specially sensitive on iOS 18.

The fix consists of 2 parts:
- Changing the long press gesture logic to better adhere to Apple's API specs
- Modify the SwipeActions library to allow the gesture priority to be configurable, and demote the swiping gesture to have normal priority (it was found that having a high-priority drag gesture prevents long-presses from being activated)
    - To see the code changes in the SwipeActions library, please see: https://github.com/damus-io/SwipeActions/commit/33d99756c3112e1a07c1732e3cddc5ad5bd0c5f4

## Checklist

- [X] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [X] I have tested the changes in this PR
- [X] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [X] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [X] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [X] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 13 mini
**iOS:** 18.0
**Damus:** `a6449020b69772ac6cd735dd1dd6ffdfc03e3fcf`
**Setup:** Nothing in particular
**Steps:**
1. Go to a thread view with comments
2. Long press a chat bubble.
 - Ensure it will show the emoji selector
 - Ensure the gesture can be activated without lifting your finger
 - Ensure the gesture has nice animations and haptics
3. Change to OnlyZaps mode and go back to the thread
4. Long press a chat bubble.
 - Ensure it will show the zap amount selector
 - Ensure the gesture can be activated without lifting your finger
 - Ensure the gesture has nice animations and haptics
5. Start a long-press then immediately scroll. Ensure scrolling will cancel the long-press gesture
6. Start a long-press then immediately swipe. Ensure swiping will cancel the long-press gesture
7. Repeat steps 5–6 several times to ensure it feels robust
8. Tap. Ensure chat bubbles can be tapped
9. Swipe partially. Ensure chat bubbles can be swiped and options show up
10. Swipe all the way. Ensure chat bubbles can be swiped all the way and it will trigger a reply sheet

**Results:**
- [X] PASS

## Other notes

I will open a PR with SwipeActions to see if we can merge this upstream, but we are not blocked on it.
