### PR TITLE
Resolve image ordering

### DIFF
--- a/damus/Views/MediaPicker.swift
+++ b/damus/Views/MediaPicker.swift
@@ -22,6 +22,7 @@ struct MediaPicker: UIViewControllerRepresentable {
     final class Coordinator: NSObject, PHPickerViewControllerDelegate {
         var parent: MediaPicker
         
+        // properties used for returning medias in the same order as picking
         let dispatchGroup: DispatchGroup = DispatchGroup()
         var orderIds: [String] = []
         var orderMap: [String: PreUploadedMedia] = [:]


### PR DESCRIPTION
## Summary

This PR will order the images in the order of their picking. The ordered images will be returned to Post View for the preview in correct sequence.

This PR is a followup from:
https://github.com/damus-io/damus/pull/2580

https://github.com/user-attachments/assets/4c014ee5-9a26-4416-a914-c71d1694359c

Nostr.build link for more quality demo video:
https://video.nostr.build/17f2684ed5719da39389220694609511a14e03dc3e0dee0b541bd32e88c6d2fb.mp4

## Checklist



- [ ] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [ ] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [ ] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [ ] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)
