### PR TITLE
Fix profile pic banner pic upload

### DIFF
--- a/damus/Views/BannerImageView.swift
+++ b/damus/Views/BannerImageView.swift
@@ -31,7 +31,7 @@ struct EditBannerImageView: View {
                 .onFailureImage(defaultImage)
                 .kfClickable()
             
-            EditPictureControl(uploader: damus_state.settings.default_media_uploader, pubkey: damus_state.pubkey, image_url: $banner_image, uploadObserver: viewModel, callback: callback)
+            EditPictureControl(uploader: damus_state.settings.default_media_uploader, keypair: damus_state.keypair, pubkey: damus_state.pubkey, image_url: $banner_image, uploadObserver: viewModel, callback: callback)
         }
     }
 }

--- a/damus/Views/CreateAccountView.swift
+++ b/damus/Views/CreateAccountView.swift
@@ -28,7 +28,7 @@ struct CreateAccountView: View {
                 Spacer()
                 VStack(alignment: .center) {
                    
-                    EditPictureControl(uploader: .nostrBuild, pubkey: account.pubkey, size: 75, setup: true, image_url: $account.profile_image , uploadObserver: profileUploadObserver, callback: uploadedProfilePicture)
+                    EditPictureControl(uploader: .nostrBuild, keypair: account.keypair, pubkey: account.pubkey, size: 75, setup: true, image_url: $account.profile_image , uploadObserver: profileUploadObserver, callback: uploadedProfilePicture)
                         .shadow(radius: 2)
                         .padding(.top, 100)
                     

--- a/damus/Views/MediaPicker.swift
+++ b/damus/Views/MediaPicker.swift
@@ -9,15 +9,19 @@ import UIKit
 import SwiftUI
 import PhotosUI
 
+enum MediaPickerEntry {
+    case editPictureControl
+    case postView
+}
+
 struct MediaPicker: UIViewControllerRepresentable {
 
     @Environment(\.presentationMode)
     @Binding private var presentationMode
+    let mediaPickerEntry: MediaPickerEntry
 
     @Binding var image_upload_confirm: Bool
-    var imagesOnly: Bool = false
     let onMediaPicked: (PreUploadedMedia) -> Void
-    
 
     final class Coordinator: NSObject, PHPickerViewControllerDelegate {
         let parent: MediaPicker
@@ -115,9 +119,14 @@ struct MediaPicker: UIViewControllerRepresentable {
     
     func makeUIViewController(context: Context) -> PHPickerViewController {
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
-        configuration.selectionLimit = 0 // Allows multiple media selection
-        configuration.filter = imagesOnly ? .images : .any(of: [.images, .videos])
-        configuration.selection = .ordered // images are returned in the order they were selected + numbered badge displayed
+        if case .postView = mediaPickerEntry {
+            configuration.selectionLimit = 0 // Allows multiple media selection
+            configuration.filter = .any(of: [.images, .videos])
+            configuration.selection = .ordered // images are returned in the order they were selected + numbered badge displayed
+        } else if case .editPictureControl = mediaPickerEntry {
+            configuration.selectionLimit = 1 // Allows one media selection
+            configuration.filter = .images
+        }
         let picker = PHPickerViewController(configuration: configuration)
         picker.delegate = context.coordinator as any PHPickerViewControllerDelegate
         return picker

--- a/damus/Views/MediaPicker.swift
+++ b/damus/Views/MediaPicker.swift
@@ -119,13 +119,14 @@ struct MediaPicker: UIViewControllerRepresentable {
     
     func makeUIViewController(context: Context) -> PHPickerViewController {
         var configuration = PHPickerConfiguration(photoLibrary: .shared())
-        if case .postView = mediaPickerEntry {
-            configuration.selectionLimit = 0 // Allows multiple media selection
+        switch mediaPickerEntry {
+        case .postView:
+            configuration.selectionLimit = 0 // allows multiple media selection
             configuration.filter = .any(of: [.images, .videos])
             configuration.selection = .ordered // images are returned in the order they were selected + numbered badge displayed
-        } else if case .editPictureControl = mediaPickerEntry {
-            configuration.selectionLimit = 1 // Allows one media selection
-            configuration.filter = .images
+        case .editPictureControl:
+            configuration.selectionLimit = 1 // allows one media selection
+            configuration.filter = .images // allows image only
         }
         let picker = PHPickerViewController(configuration: configuration)
         picker.delegate = context.coordinator as any PHPickerViewControllerDelegate

--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -451,7 +451,7 @@ struct PostView: View {
             }
             .background(DamusColors.adaptableWhite.edgesIgnoringSafeArea(.all))
             .sheet(isPresented: $attach_media) {
-                MediaPicker(image_upload_confirm: $image_upload_confirm){ media in
+                MediaPicker(mediaPickerEntry: .postView, image_upload_confirm: $image_upload_confirm){ media in
                     self.preUploadedMedia.append(media)
                 }
                 .alert(NSLocalizedString("Are you sure you want to upload the selected media?", comment: "Alert message asking if the user wants to upload media."), isPresented: $image_upload_confirm) {

--- a/damus/Views/Profile/EditPictureControl.swift
+++ b/damus/Views/Profile/EditPictureControl.swift
@@ -14,6 +14,7 @@ class ImageUploadingObserver: ObservableObject {
 
 struct EditPictureControl: View {
     let uploader: MediaUploader
+    let keypair: Keypair?
     let pubkey: Pubkey
     var size: CGFloat? = 25
     var setup: Bool? = false
@@ -195,7 +196,7 @@ struct EditPictureControl: View {
     private func handle_upload(media: MediaUpload) {
         uploadObserver.isLoading = true
         Task {
-            let res = await image_upload.start(media: media, uploader: uploader)
+            let res = await image_upload.start(media: media, uploader: uploader, keypair: keypair)
             
             switch res {
             case .success(let urlString):
@@ -221,7 +222,7 @@ struct EditPictureControl_Previews: PreviewProvider {
         let observer = ImageUploadingObserver()
         ZStack {
             Color.gray
-            EditPictureControl(uploader: .nostrBuild, pubkey: test_pubkey, size: 100, setup: false, image_url: url, uploadObserver: observer) { _ in
+            EditPictureControl(uploader: .nostrBuild, keypair: test_keypair, pubkey: test_pubkey, size: 100, setup: false, image_url: url, uploadObserver: observer) { _ in
                 //
             }
         }

--- a/damus/Views/Profile/EditPictureControl.swift
+++ b/damus/Views/Profile/EditPictureControl.swift
@@ -114,7 +114,7 @@ struct EditPictureControl: View {
             }
         }
         .sheet(isPresented: $show_library) {
-            MediaPicker(image_upload_confirm: $image_upload_confirm, imagesOnly: true) { media in
+            MediaPicker(mediaPickerEntry: .editPictureControl, image_upload_confirm: $image_upload_confirm) { media in
                 self.preUploadedMedia = media
             }
             .alert(NSLocalizedString("Are you sure you want to upload this image?", comment: "Alert message asking if the user wants to upload an image."), isPresented: $image_upload_confirm) {

--- a/damus/Views/Profile/ProfilePictureSelector.swift
+++ b/damus/Views/Profile/ProfilePictureSelector.swift
@@ -33,7 +33,7 @@ struct EditProfilePictureView: View {
                 .scaledToFill()
                 .kfClickable()
     
-            EditPictureControl(uploader: damus_state?.settings.default_media_uploader ?? .nostrBuild, pubkey: pubkey, image_url: $profile_url, uploadObserver: uploadObserver, callback: callback)
+            EditPictureControl(uploader: damus_state?.settings.default_media_uploader ?? .nostrBuild, keypair: damus_state?.keypair, pubkey: pubkey, image_url: $profile_url, uploadObserver: uploadObserver, callback: callback)
         }
         .frame(width: size, height: size)
         .clipShape(Circle())


### PR DESCRIPTION
## Summary
The existing picture-upload flow for Profile and Banner is broken. Root cause analysis of this bug is due to missing KeyPair parameter being passed while instantiating EditPictureControl objects. They KeyPair param is used to create nip98 signature and which is eventually used to create an "Authorization" header for creating an upload request.

## Checklist

- [ ] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [ ] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [ ] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [ ] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)
