### PR TITLE
ui: replace search notes button with searched word

### DIFF
--- a/damus/Views/SearchResultsView.swift
+++ b/damus/Views/SearchResultsView.swift
@@ -54,7 +54,6 @@ struct InnerSearchResults: View {
         let search_model = SearchModel(state: damus_state, search: .filter_hashtag([ht]))
         return NavigationLink(value: Route.Search(search: search_model)) {
             HStack {
-                Image("search")
                 Text("#\(ht)", comment: "Navigation link to search hashtag.")
             }
             .padding(.horizontal, 15)
@@ -71,8 +70,7 @@ struct InnerSearchResults: View {
     func TextSearch(_ txt: String) -> some View {
         return NavigationLink(value: Route.NDBSearch(results: $results)) {
             HStack {
-                Image("search")
-                Text("Notes", comment: "Navigation link to search text.")
+                Text("\(txt)", comment: "Navigation link to search text.")
             }
             .padding(.horizontal, 15)
             .padding(.vertical, 5)
@@ -119,10 +117,12 @@ struct InnerSearchResults: View {
                 SearchingEventView(state: damus_state, search_type: .naddr(naddr))
             case .multi(let multi):
                 VStack(alignment: .leading) {
-                    HStack {
+                    HStack(spacing: 20) {
                         HashtagSearch(multi.hashtag)
                         TextSearch(multi.text)
                     }
+                    .padding(.bottom, 10)
+                    
                     ProfilesSearch(multi.profiles)
                 }
                 


### PR DESCRIPTION
## Summary

This PR replaces the search notes button with the searched word. This also removes the magnifying glass image from the search buttons.

Closes: #2601

Changelog-Changed: Changed search notes button with searched keyword
## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** _[Please specify the device you used for testing]_

iPhone 16 Pro Max

**iOS:** _[Please specify the iOS version you used for testing]_

18.0

**Damus:** _[Please specify the Damus version or commit hash you used for testing]_

1.11 (1) b7b8c7f1

**Setup:** _[Please provide a brief description of the setup you used for testing, if applicable]_

XCode Simulator

**Steps:** _[Please provide a list of steps you took to test the changes in this PR]_

Verified the search notes button contained the keyword being searched.

<img src="https://github.com/user-attachments/assets/ed0f4557-d4bc-48cf-ae81-4829854610c2" width="400">


**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_

