### PR TITLE
Add sharing option in image carousel view

### DIFF
--- a/damus/Views/Images/FullScreenCarouselView.swift
+++ b/damus/Views/Images/FullScreenCarouselView.swift
@@ -14,7 +14,7 @@ struct FullScreenCarouselView<Content: View>: View {
     @Environment(\.presentationMode) var presentationMode
     
     @State var showMenu = true
-    
+    @State private var imageDict: [URL: UIImage] = [:]
     let settings: UserSettingsStore
     @Binding var selectedIndex: Int
     let content: (() -> Content)?
@@ -59,7 +59,7 @@ struct FullScreenCarouselView<Content: View>: View {
                 ForEach(urls.indices, id: \.self) { index in
                     VStack {
                         if case .video = urls[safe: index] {
-                            ImageContainerView(video_controller: video_controller, url: urls[index], settings: settings)
+                            ImageContainerView(video_controller: video_controller, url: urls[index], settings: settings, imageDict: $imageDict)
                                 .clipped()  // SwiftUI hack from https://stackoverflow.com/a/74401288 to make playback controls show up within the TabView
                                 .aspectRatio(contentMode: .fit)
                                 .padding(.top, Theme.safeAreaInsets?.top)
@@ -71,7 +71,7 @@ struct FullScreenCarouselView<Content: View>: View {
                         }
                         else {
                             ZoomableScrollView {
-                                ImageContainerView(video_controller: video_controller, url: urls[index], settings: settings)
+                                ImageContainerView(video_controller: video_controller, url: urls[index], settings: settings, imageDict: $imageDict)
                                     .aspectRatio(contentMode: .fit)
                                     .padding(.top, Theme.safeAreaInsets?.top)
                                     .padding(.bottom, Theme.safeAreaInsets?.bottom)
@@ -102,8 +102,12 @@ struct FullScreenCarouselView<Content: View>: View {
                                     .foregroundColor(.white)
                                 
                                 if let url = urls[safe: selectedIndex],
-                                   case .image = url {
-                                    ShareLink(item: url.url) {
+                                   let image = imageDict[url.url] {
+                                    
+                                    ShareLink(item: Image(uiImage: image),
+                                              preview: SharePreview(NSLocalizedString("Shared Picture",
+                                                                                      comment: "Label for the preview of the image being picture"),
+                                                                    image: Image(uiImage: image))) {
                                         Image(systemName: "ellipsis")
                                             .foregroundColor(.white)
                                             .frame(width: 33, height: 33)

--- a/damus/Views/Images/FullScreenCarouselView.swift
+++ b/damus/Views/Images/FullScreenCarouselView.swift
@@ -96,8 +96,24 @@ struct FullScreenCarouselView<Content: View>: View {
                 GeometryReader { geo in
                     VStack {
                         if showMenu {
-                            NavDismissBarView(navDismissBarContainer: .fullScreenCarousel)
-                                .foregroundColor(.white)
+                            
+                            HStack {
+                                NavDismissBarView(navDismissBarContainer: .fullScreenCarousel)
+                                    .foregroundColor(.white)
+                                
+                                if let url = urls[safe: selectedIndex],
+                                   case .image = url {
+                                    ShareLink(item: url.url) {
+                                        Image(systemName: "ellipsis")
+                                            .foregroundColor(.white)
+                                            .frame(width: 33, height: 33)
+                                            .background(.damusBlack)
+                                            .clipShape(Circle())
+                                    }
+                                    .padding(20)
+                                }
+                            }
+                            
                             Spacer()
                             
                             if urls.count > 1 {

--- a/damus/Views/Images/ImageContainerView.swift
+++ b/damus/Views/Images/ImageContainerView.swift
@@ -14,14 +14,18 @@ struct ImageContainerView: View {
     let url: MediaUrl
     let settings: UserSettingsStore
     
+    @Binding var imageDict: [URL: UIImage]
     @State private var image: UIImage?
     @State private var showShareSheet = false
     
     private struct ImageHandler: ImageModifier {
         @Binding var handler: UIImage?
+        @Binding var imageDict: [URL: UIImage]
+        let url: URL
         
         func modify(_ image: UIImage) -> UIImage {
             handler = image
+            imageDict[url] = image
             return image
         }
     }
@@ -32,7 +36,7 @@ struct ImageContainerView: View {
             .configure { view in
                 view.framePreloadCount = 3
             }
-            .imageModifier(ImageHandler(handler: $image))
+            .imageModifier(ImageHandler(handler: $image, imageDict: $imageDict, url: url))
             .kfClickable()
             .clipped()
             .modifier(ImageContextMenuModifier(url: url, image: image, settings: settings, showShareSheet: $showShareSheet))
@@ -58,10 +62,11 @@ fileprivate let test_video_url = URL(string: "http://cdn.jb55.com/s/zaps-build.m
 
 struct ImageContainerView_Previews: PreviewProvider {
     static var previews: some View {
+        @State var imageDict: [URL: UIImage] = [:]
         Group {
-            ImageContainerView(video_controller: test_damus_state.video, url: .image(test_image_url), settings: test_damus_state.settings)
+            ImageContainerView(video_controller: test_damus_state.video, url: .image(test_image_url), settings: test_damus_state.settings, imageDict: $imageDict)
                 .previewDisplayName("Image")
-            ImageContainerView(video_controller: test_damus_state.video, url: .video(test_video_url), settings: test_damus_state.settings)
+            ImageContainerView(video_controller: test_damus_state.video, url: .video(test_video_url), settings: test_damus_state.settings, imageDict: $imageDict)
                 .previewDisplayName("Video")
         }
         .environmentObject(OrientationTracker())


### PR DESCRIPTION
## Summary
This PR adds an ellipsis (share button) to enable sharing in the full-screen carousel viewer. Tapping the button brings up a share sheet, allowing sharing via messaging and social media apps.







https://github.com/user-attachments/assets/8348f5fd-fb3e-411d-a1c2-89315acba588


### Updated - Sharing an actual image:

<img width="331" alt="Screenshot 2024-10-23 at 11 11 26 AM" src="https://github.com/user-attachments/assets/da891e7a-84b9-4ef9-a829-c934c25ae52c">



## Checklist

- [ ] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)
