### PR TITLE
Fixed missing tab bar while navigating

### DIFF
--- a/damus/Views/SideMenuView.swift
+++ b/damus/Views/SideMenuView.swift
@@ -174,6 +174,9 @@ struct SideMenuView: View {
                 TopProfile
                     .padding(.bottom, verticalSpacing)
             })
+            .simultaneousGesture(TapGesture().onEnded {
+                isSidebarVisible = false
+            })
 
             ScrollView {
                 SidemenuItems(profile_model: profile_model, followers: followers)


### PR DESCRIPTION
## Summary

Fixed missing tab bar observed while navigating by tapping on top profile part of Side menu.

Root cause analysis:
isSidebarVisible was not set to false

### Video showing the issue:

https://github.com/user-attachments/assets/c8ff2f4e-9512-4758-be68-ed20bf720cb0

### After fixing the issue:


https://github.com/user-attachments/assets/407ee4a0-30f8-497a-86ea-7661ef9f940d





_[Please provide a summary of the changes in this PR.]_

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

