### PR TITLE
Fix Mute button is enabled for empty text

### DIFF
--- a/damus/Views/Muting/AddMuteItemView.swift
+++ b/damus/Views/Muting/AddMuteItemView.swift
@@ -97,6 +97,8 @@ struct AddMuteItemView: View {
                 }
                 .frame(minWidth: 300, maxWidth: .infinity, alignment: .center)
             }
+            .disabled(new_text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .opacity(new_text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? 0.60 : 1.0)
             .buttonStyle(GradientButtonStyle(padding: 10))
             .padding(.vertical)
 


### PR DESCRIPTION
## Summary

The code changes will make the mute button disabled when the input text is empty or consists only of whitespace characters. When disabled, the button’s opacity is reduced to 60%, visually indicating its inactive state. 

### Demo video showing enabled and disabled states of the mute button:

https://github.com/user-attachments/assets/cdea3105-1820-4764-90c2-c6cfde15486e


## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** _[Please specify the device you used for testing]_

**iOS:** _[Please specify the iOS version you used for testing]_

**Damus:** _[Please specify the Damus version or commit hash you used for testing]_

**Setup:** _[Please provide a brief description of the setup you used for testing, if applicable]_

**Steps:** _[Please provide a list of steps you took to test the changes in this PR]_

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_
