### PR TITLE
Fix button hidden behind software keyboard in create account view

### DIFF
--- a/damus/Views/Profile/EditPictureControl.swift
+++ b/damus/Views/Profile/EditPictureControl.swift
@@ -72,14 +72,14 @@ struct EditPictureControl: View {
                         view.framePreloadCount = 3
                     }
                     .scaledToFill()
-                    .frame(width: (size ?? 25) + 10, height: (size ?? 25) + 10)
+                    .frame(width: (size ?? 25) + 30, height: (size ?? 25) + 30)
                     .kfClickable()
                     .foregroundColor(DamusColors.white)
                     .clipShape(Circle())
                     .overlay(Circle().stroke(.white, lineWidth: 4))
             } else {
                 if setup ?? false {
-                    Image(systemName: "person")
+                    Image(systemName: "person.fill")
                         .resizable()
                         .scaledToFit()
                         .frame(width: size, height: size)
@@ -90,6 +90,20 @@ struct EditPictureControl: View {
                             Circle()
                                 .fill(PinkGradient, strokeBorder: .white, lineWidth: 4)
                         }
+                        .overlay(
+                            Image(systemName: "plus.circle.fill")
+                                .resizable()
+                                .frame(
+                                    width: max((size ?? 30)/3, 20),
+                                    height: max((size ?? 30)/3, 20)
+                                )
+                                .background(.damusDeepPurple)
+                                .clipShape(Circle())
+                                .padding(.leading, -10)
+                                .padding(.top, -10)
+                                .foregroundStyle(.white)
+                                .shadow(color: .black.opacity(0.2), radius: 4)
+                        , alignment: .bottomTrailing)
                         
                 } else {
                     Image("camera")


### PR DESCRIPTION
## Summary

This commit fixes an issue where the "next" button is hidden behind the software keyboard in the account creation view, where it is very hard to press.

The fix was done by dynamically shrinking the profile picture size when keyboard appears in smartphone screens, so that there is enough space for all content to appear.

Closes: https://github.com/damus-io/damus/issues/2771

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Devices:**
- iPhone SE simulator
- iPhone 16 Pro Max simulator
- iPad Air 11-inch (M2) simulator

**iOS:** 18.1
**Damus:** `fbe2225554e9baa2de8ca6f6dae847fbc1e2220c`
**Setup:**
- Software keyboard enabled on the simulator

**Steps:**
1. Create account
2. Enable and disable software keyboard. Make sure that profile image looks smaller when software keyboard appears (if it needs space), and that the screen has enough space to show the "next" button (i.e. Not hidden behind the keyboard)
3. Upload image
4. Repeat step 2
5. Check the other usages of `EditPictureControl` to make sure they still work as expected.

**Results:**
- [x] PASS
- [ ] Partial PASS

### Accompanying pictures from the test

<img width="869" alt="Screenshot 2024-12-18 at 18 05 18" src="https://github.com/user-attachments/assets/4c7f003d-acba-4dcd-8c8f-ca2cd7ccfa91" />
<img width="869" alt="Screenshot 2024-12-18 at 18 05 32" src="https://github.com/user-attachments/assets/9b2ce545-167b-4b7f-89b5-e9e6719c3101" />
<img width="869" alt="Screenshot 2024-12-18 at 18 06 13" src="https://github.com/user-attachments/assets/2932892d-6c44-4cff-8f38-7042192d3c3c" />
<img width="869" alt="Screenshot 2024-12-18 at 18 06 22" src="https://github.com/user-attachments/assets/dd29a914-581a-463f-954e-d1e24f1ea1ce" />
<img width="1051" alt="Screenshot 2024-12-18 at 18 08 45" src="https://github.com/user-attachments/assets/e218f0f6-ff8c-425c-b7f1-1f78afa57509" />
<img width="1051" alt="Screenshot 2024-12-18 at 18 08 57" src="https://github.com/user-attachments/assets/2b6d2535-6447-4c5e-a0d6-8bf9f5a5f4c2" />


## Other notes

- I tried to implement an automated screenshot test, but it does not work as expected, likely due to the way the screenshot tests are setup by the library.
- Sending as a PR to better show the test results via screenshots
- The transitions are animated
