### PR TITLE
Translate notes even if they are in a preferred language but not the current language as that is what users expect, and remove language filtering in Universe feed

### DIFF
--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -185,9 +185,6 @@ class UserSettingsStore: ObservableObject {
 
     @Setting(key: "show_music_statuses", default_value: true)
     var show_music_statuses: Bool
-
-    @Setting(key: "show_only_preferred_languages", default_value: false)
-    var show_only_preferred_languages: Bool
     
     @Setting(key: "multiple_events_per_pubkey", default_value: false)
     var multiple_events_per_pubkey: Bool

--- a/damus/Util/EventCache.swift
+++ b/damus/Util/EventCache.swift
@@ -259,11 +259,10 @@ func should_translate(event: NostrEvent, our_keypair: Keypair, note_lang: String
     }
 
     if let note_lang {
-        let preferredLanguages = Set(Locale.preferredLanguages.map { localeToLanguage($0) })
+        let currentLanguage = localeToLanguage(Locale.current.identifier)
 
-        // Don't translate if its in our preferred languages
-        guard !preferredLanguages.contains(note_lang) else {
-            // if its the same, give up and don't retry
+        // Don't translate if the note is in our current language
+        guard currentLanguage != note_lang else {
             return false
         }
     }

--- a/damus/Views/SearchHomeView.swift
+++ b/damus/Views/SearchHomeView.swift
@@ -20,8 +20,6 @@ struct SearchHomeView: View {
         return ContentFilters(filters: filters).filter
     }
 
-    let preferredLanguages = Set(Locale.preferredLanguages.map { localeToLanguage($0) })
-    
     var SearchInput: some View {
         HStack {
             HStack{
@@ -74,7 +72,8 @@ struct SearchHomeView: View {
                     return true
                 }
 
-                return preferredLanguages.contains(note_lang)
+                let currentLanguage = localeToLanguage(Locale.current.identifier)
+                return currentLanguage == note_lang
             },
             content: {
                 AnyView(VStack {

--- a/damus/Views/SearchHomeView.swift
+++ b/damus/Views/SearchHomeView.swift
@@ -62,18 +62,7 @@ struct SearchHomeView: View {
                     return false
                 }
 
-                if damus_state.settings.show_only_preferred_languages == false {
-                    return true
-                }
-
-                // If we can't determine the note's language with 50%+ confidence, lean on the side of caution and show it anyway.
-                let note_lang = damus_state.events.get_cache_data(ev.id).translations_model.note_language
-                guard let note_lang else {
-                    return true
-                }
-
-                let currentLanguage = localeToLanguage(Locale.current.identifier)
-                return currentLanguage == note_lang
+                return true
             },
             content: {
                 AnyView(VStack {

--- a/damus/Views/Settings/TranslationSettingsView.swift
+++ b/damus/Views/Settings/TranslationSettingsView.swift
@@ -16,9 +16,6 @@ struct TranslationSettingsView: View {
     var body: some View {
         Form {
             Section(NSLocalizedString("Translations", comment: "Section title for selecting the translation service.")) {
-                Toggle(NSLocalizedString("Show only preferred languages on Universe feed", comment: "Toggle to show notes that are only in the device's preferred languages on the Universe feed and hide notes that are in other languages."), isOn: $settings.show_only_preferred_languages)
-                    .toggleStyle(.switch)
-
                 Picker(NSLocalizedString("Service", comment: "Prompt selection of translation service provider."), selection: $settings.translation_service) {
                     ForEach(TranslationService.allCases.filter({ damus_state.purple.enable_purple ? true : $0 != .purple }), id: \.self) { server in
                         Text(server.model.displayName)


### PR DESCRIPTION
## Summary

When automatic translations are enabled, users expect that any note that is in a language that is not their current language should be translated.

From user feedback, it appears that some people have languages that they are not their first/native language in their list of preferred languages in iOS settings. As a result, they want to have the notes in those languages translated.

Language filtering in the Universe feed was also removed because it is ineffective. Language detection can be inaccurate, so notes in other languages will almost always leak through anyway. Also, with note translations, seeing notes in other languages should no longer be an issue as they can just translate them.

Before:
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-19 at 12 55 19 Medium](https://github.com/user-attachments/assets/714bd3bd-0706-4576-a60e-9a6ae5ca3319) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-19 at 13 34 58 Medium](https://github.com/user-attachments/assets/e9d9b399-4962-4da6-a792-7804adf00b0c) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-19 at 12 55 26 Medium](https://github.com/user-attachments/assets/8a678830-0158-49d3-bee6-04c5dcab1d4f) |

After:
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-19 at 12 55 19 Medium](https://github.com/user-attachments/assets/714bd3bd-0706-4576-a60e-9a6ae5ca3319) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-19 at 13 30 25 Medium](https://github.com/user-attachments/assets/d816cf84-ec3e-421d-bbdd-84194f695dfd) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-19 at 12 55 55 Medium](https://github.com/user-attachments/assets/1aa88682-eb1f-4c44-9755-353266ced8ed) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-19 at 12 56 16 Medium](https://github.com/user-attachments/assets/dd725898-2149-499b-8727-e349a79b0002) |


## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro (Simulator)

**iOS:** 18.2

**Damus:** 8e852ed74239e601c059674ba1926d60513f75f0

**Steps:**
1. Set Spanish (Latin America) (or whichever non-English of your choice) as the first/current language in iOS settings. Ensure that English is still listed as one of the preferred languages (but not the first/current language).
2. Open Damus.
3. Go to Damus > Settings > Translation.
4. Notice that there is no longer a toggle for `Show only preferred languages on Universe feed`.
5. Ensure that Service is using `Apple` (but it could also be `Damus Purple` if you are logged in with a private key with the Purple subscription).
6. Go to the Home feed and observe that each note not in your current language has a button to translate the note to your current language (or if on Damus Purple, that the note is automatically translated to your current language).
7. Go to the Universe feed to sanity check that notes in any language appear.

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_