### PR TITLE
Add release process issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/app_release.md
+++ b/.github/ISSUE_TEMPLATE/app_release.md
@@ -1,0 +1,52 @@
+---
+name: App release process
+about: Begin preparing for a new app release
+title: 'Release: '
+labels: release-tasks
+assignees: ''
+
+---
+
+A new version release. Please attempt to follow the release process steps below in the order they are shown.
+
+## TestFlight release candidates
+
+### Release candidate 1
+
+**Version:** _[Enter full build information for the release candidate, including major and minor version number, build number, and commit hash]_
+
+1. [ ] Merge in all needed changes to `master`
+2. [ ] Check CI, make sure it is passing
+3. [ ] Prepare preliminary changelog as a draft PR: _[Enter PR link to changelog here]_
+4. [ ] Make a _release_ build and submit to the internal TestFlight group via our new Release candidate workflow in Xcode Cloud.
+5. [ ] Prepare short screencast style video with main changes for the announcement
+6. [ ] Publish release build to these TestFlight groups:
+    - [ ] Alpha testers group
+    - [ ] Translators group
+    - [ ] Purple group
+7. [ ] Publish announcement on Nostr
+
+
+_[Duplicate this release candidate section if there is more than one release candidate]_
+
+
+## App Store release
+
+1. [ ] Release candidate checks:
+    - [ ] Release candidate has been on Purple TestFlight for at least one week
+    - [ ] No blocker issues came from feedback from Purple users (double-check)
+    - [ ] Check with stakeholders
+    - [ ] Check with developers & product for any release showstoppers (e.g., critical newfound bugs)
+2. [ ] Thorough check on release notes
+3. [ ] Submit to App Store review (with manual publishing setting enabled)
+4. [ ] Get App Store approval from Apple
+5. [ ] Prepare announcement
+7. [ ] Publish on the App Store and make announcement
+8. [ ] Publish changelog and tag commit hash corresponding to the release
+9. [ ] Perform a version bump on the repository, in preparation for the next release
+
+
+## Notes/others
+
+_Enter any relevant notes here_
+


### PR DESCRIPTION
## Summary

A Github issue template to help formalizing the release process, in order to avoid human errors in the process.

I captured the checklist used for the 1.12 release into this issue template, to help us stay consistent with this process.

Closes: https://github.com/damus-io/damus/issues/2752

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [x] I do not need to add a changelog entry. **Reason:** No user-facing changes
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

We used this checklist during the 1.12 release (https://github.com/damus-io/damus/issues/2772), which I believe captures everything we need.

**Results:**
- [x] PASS
