### PR TITLE
add relay.chakany.systems to bootstrap relays

### DIFF
--- a/damus/Util/Relays/RelayBootstrap.swift
+++ b/damus/Util/Relays/RelayBootstrap.swift
@@ -13,6 +13,7 @@ fileprivate let BOOTSTRAP_RELAYS = [
     "wss://nostr.land",
     "wss://nostr.wine",
     "wss://nos.lol",
+    "wss://relay.chakany.systems",
 ]
 
 fileprivate let REGION_SPECIFIC_BOOTSTRAP_RELAYS: [Locale.Region: [String]] = [


### PR DESCRIPTION
## Summary

I added `wss://relay.chakany.systems` to the default bootstrap relay list.
It should be very fast, and we have the capacity.

## Checklist

- [X] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [ ] I have tested the changes in this PR
- [X] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [ ] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [X] I do not need to add a changelog entry. Reason: not super major
- [ ] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Other notes

It's a 1 line PR, should work right?
