### PR TITLE
Add double star for Purple members that have been active for over a year

### DIFF
--- a/damus/Components/SupporterBadge.swift
+++ b/damus/Components/SupporterBadge.swift
@@ -12,6 +12,14 @@ struct SupporterBadge: View {
     let purple_account: DamusPurple.Account?
     let style: Style
     let text_color: Color
+    var badge_variant: BadgeVariant {
+        if purple_account?.attributes.contains(.memberForMoreThanOneYear) == true {
+            return .oneYearSpecial
+        }
+        else {
+            return .normal
+        }
+    }
     
     init(percent: Int?, purple_account: DamusPurple.Account? = nil, style: Style, text_color: Color = .secondary) {
         self.percent = percent
@@ -26,13 +34,18 @@ struct SupporterBadge: View {
         HStack {
             if let purple_account, purple_account.active == true {
                 HStack(spacing: 1) {
-                    Image("star.fill")
-                        .resizable()
-                        .frame(width:size, height:size)
-                        .foregroundStyle(GoldGradient)
-                    if self.style == .full {
-                        let date = format_date(date: purple_account.created_at, time_style: .none)
-                        Text(date)
+                    switch self.badge_variant {
+                    case .normal:
+                        StarShape()
+                            .frame(width:size, height:size)
+                            .foregroundStyle(GoldGradient)
+                    case .oneYearSpecial:
+                        DoubleStar(size: size)
+                    }
+                    
+                    if self.style == .full,
+                       let ordinal = self.purple_account?.ordinal() {
+                        Text(ordinal)
                             .foregroundStyle(text_color)
                             .font(.caption)
                     }
@@ -56,7 +69,101 @@ struct SupporterBadge: View {
         case full       // Shows the entire badge with a purple subscriber number if present
         case compact    // Does not show purple subscriber number. Only shows the star (if applicable)
     }
+    
+    enum BadgeVariant {
+        /// A normal badge that people are used to
+        case normal
+        /// A special badge for users who have been members for more than a year
+        case oneYearSpecial
+    }
 }
+
+
+struct StarShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius: CGFloat = min(rect.width, rect.height) / 2
+        let points = 5
+        let adjustment: CGFloat = .pi / 2
+        
+        for i in 0..<points * 2 {
+            let angle = (CGFloat(i) * .pi / CGFloat(points)) - adjustment
+            let pointRadius = i % 2 == 0 ? radius : radius * 0.4
+            let point = CGPoint(x: center.x + pointRadius * cos(angle), y: center.y + pointRadius * sin(angle))
+            if i == 0 {
+                path.move(to: point)
+            } else {
+                path.addLine(to: point)
+            }
+        }
+        path.closeSubpath()
+        return path
+    }
+}
+
+struct DoubleStar: View {
+    let size: CGFloat
+    var starOffset: CGFloat = 5
+    
+    var body: some View {
+        if #available(iOS 17.0, *) {
+            DoubleStarShape(starOffset: starOffset)
+                .frame(width: size, height: size)
+                .foregroundStyle(GoldGradient)
+                .padding(.trailing, starOffset)
+        } else {
+            Fallback(size: size, starOffset: starOffset)
+        }
+    }
+    
+    @available(iOS 17.0, *)
+    struct DoubleStarShape: Shape {
+        var strokeSize: CGFloat = 3
+        var starOffset: CGFloat
+
+        func path(in rect: CGRect) -> Path {
+            let normalSizedStarPath = StarShape().path(in: rect)
+            let largerStarPath = StarShape().path(in: rect.insetBy(dx: -strokeSize, dy: -strokeSize))
+            
+            let finalPath = normalSizedStarPath
+                .subtracting(
+                    largerStarPath.offsetBy(dx: starOffset, dy: 0)
+                )
+                .union(
+                    normalSizedStarPath.offsetBy(dx: starOffset, dy: 0)
+                )
+            
+            return finalPath
+        }
+    }
+    
+    /// A fallback view for those who cannot run iOS 17
+    struct Fallback: View {
+        var size: CGFloat
+        var starOffset: CGFloat
+        
+        var body: some View {
+            HStack {
+                StarShape()
+                    .frame(width: size, height: size)
+                    .foregroundStyle(GoldGradient)
+                
+                StarShape()
+                    .fill(GoldGradient)
+                    .overlay(
+                        StarShape()
+                            .stroke(Color.damusAdaptableWhite, lineWidth: 1)
+                    )
+                    .frame(width: size + 1, height: size + 1)
+                    .padding(.leading, -size - starOffset)
+            }
+            .padding(.trailing, -3)
+        }
+    }
+}
+
+
 
 func support_level_color(_ percent: Int) -> Color {
     if percent == 0 {
@@ -86,7 +193,7 @@ struct SupporterBadge_Previews: PreviewProvider {
         HStack(alignment: .center) {
             SupporterBadge(
                 percent: nil,
-                purple_account: DamusPurple.Account(pubkey: test_pubkey, created_at: .now, expiry: .now.addingTimeInterval(10000), subscriber_number: subscriber_number, active: true),
+                purple_account: DamusPurple.Account(pubkey: test_pubkey, created_at: .now, expiry: .now.addingTimeInterval(10000), subscriber_number: subscriber_number, active: true, attributes: []),
                 style: .full
             )
                 .frame(width: 100)
@@ -115,6 +222,54 @@ struct SupporterBadge_Previews: PreviewProvider {
             Purple(100)
             Purple(1971)
         }
+    }
+}
+
+#Preview("1 yr badge") {
+    VStack {
+        HStack(alignment: .center) {
+            SupporterBadge(
+                percent: nil,
+                purple_account: DamusPurple.Account(pubkey: test_pubkey, created_at: .now, expiry: .now.addingTimeInterval(10000), subscriber_number: 3, active: true, attributes: []),
+                style: .full
+            )
+                .frame(width: 100)
+        }
+        
+        HStack(alignment: .center) {
+            SupporterBadge(
+                percent: nil,
+                purple_account: DamusPurple.Account(pubkey: test_pubkey, created_at: .now, expiry: .now.addingTimeInterval(10000), subscriber_number: 3, active: true, attributes: [.memberForMoreThanOneYear]),
+                style: .full
+            )
+                .frame(width: 100)
+        }
+        
+        Text("Double star (just shape itself, with alt background color, to show it adapts to background well)")
+            .multilineTextAlignment(.center)
+        
+        if #available(iOS 17.0, *) {
+            HStack(alignment: .center) {
+                DoubleStar.DoubleStarShape(starOffset: 5)
+                    .frame(width: 17, height: 17)
+                    .padding(.trailing, -8)
+            }
+            .background(Color.blue)
+        }
+        
+        Text("Double star (fallback for iOS 16 and below)")
+        
+        HStack(alignment: .center) {
+            DoubleStar.Fallback(size: 17, starOffset: 5)
+        }
+        
+        Text("Double star (fallback for iOS 16 and below, with alt color limitation shown)")
+            .multilineTextAlignment(.center)
+        
+        HStack(alignment: .center) {
+            DoubleStar.Fallback(size: 17, starOffset: 5)
+        }
+        .background(Color.blue)
     }
 }
 

--- a/damus/Models/Purple/DamusPurple.swift
+++ b/damus/Models/Purple/DamusPurple.swift
@@ -382,6 +382,13 @@ class DamusPurple: StoreObserverDelegate {
         let expiry: Date
         let subscriber_number: Int
         let active: Bool
+        let attributes: PurpleAccountAttributes
+        
+        struct PurpleAccountAttributes: OptionSet {
+            let rawValue: Int
+            
+            static let memberForMoreThanOneYear = PurpleAccountAttributes(rawValue: 1 << 0)
+        }
 
         func ordinal() -> String? {
             let number = Int(self.subscriber_number)
@@ -402,7 +409,8 @@ class DamusPurple: StoreObserverDelegate {
                 created_at: Date.init(timeIntervalSince1970: TimeInterval(payload.created_at)),
                 expiry: Date.init(timeIntervalSince1970: TimeInterval(payload.expiry)),
                 subscriber_number: Int(payload.subscriber_number),
-                active: payload.active
+                active: payload.active,
+                attributes: (payload.attributes?.member_for_more_than_one_year ?? false) ? [.memberForMoreThanOneYear] : []
             )
         }
         
@@ -412,6 +420,11 @@ class DamusPurple: StoreObserverDelegate {
             let expiry: UInt64              // Unix timestamp
             let subscriber_number: UInt
             let active: Bool
+            let attributes: Attributes?
+            
+            struct Attributes: Codable {
+                let member_for_more_than_one_year: Bool
+            }
         }
     }
 }

--- a/damus/Views/Purple/DamusPurpleAccountView.swift
+++ b/damus/Views/Purple/DamusPurpleAccountView.swift
@@ -136,7 +136,8 @@ struct DamusPurpleAccountView: View {
             created_at: Date.now,
             expiry: Date.init(timeIntervalSinceNow: 60 * 60 * 24 * 30),
             subscriber_number: 7,
-            active: true
+            active: true,
+            attributes: []
         )
     )
 }
@@ -149,7 +150,8 @@ struct DamusPurpleAccountView: View {
             created_at: Date.init(timeIntervalSinceNow: -60 * 60 * 24 * 37),
             expiry: Date.init(timeIntervalSinceNow: -60 * 60 * 24 * 7),
             subscriber_number: 7,
-            active: false
+            active: false,
+            attributes: []
         )
     )
 }


### PR DESCRIPTION
## Summary

This commit adds a special badge for purple members who have been active for more than one entire year.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone SE simulator
**iOS:** 18.1
**Damus:** cc0dba213cc90dd285a0448c55e6d000ce823744
**damus-api:** damus-io/api@f6750d74dc5fd5ce552022076845d28b754f0dcf
**Setup:**
1. damus-api server running locally
2. Purple environment setup to local
3. Xcode IAP environment
4. `MOCK_VERIFY` set to true on the server
5. Clean local DB at the start of the test

**Steps:**
1. Simulate one month IAP purchase (Server constant needs to be locally changed)
2. Check there is only one star
3. Simulate one year IAP purchase
4. Check star is now a double-star
5. Load SwiftUI previews in the `SupporterBadge` and check appearance of all variants.

**Results:**
- [x] PASS
- [ ] Partial PASS
