### PR TITLE
Fix translation export script by upgrading nostr-sdk-swift dependency to support Mac Catalyst

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -6782,7 +6782,7 @@
 			repositoryURL = "https://github.com/rust-nostr/nostr-sdk-swift";
 			requirement = {
 				kind = revision;
-				revision = 999316a0962d49ad8b7b98d214b9ee6eea694149;
+				revision = 27711a03ea7d977162595eea1d9b2d5a45f0b628;
 			};
 		};
 		D7C48C092D12DE0C00A3BACF /* XCRemoteSwiftPackageReference "SwiftyCrop" */ = {

--- a/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cc593053634546d736b9cbddccd9952f1f568c97012df5400d99fa313a1100d2",
+  "originHash" : "fa2b0ad84b4bd1a962ffbe49810548db7c9d7131f4a1fd4b4af06ff4c6de0a44",
   "pins" : [
     {
       "identity" : "codescanner",
@@ -50,7 +50,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rust-nostr/nostr-sdk-swift",
       "state" : {
-        "revision" : "999316a0962d49ad8b7b98d214b9ee6eea694149"
+        "revision" : "27711a03ea7d977162595eea1d9b2d5a45f0b628"
       }
     },
     {


### PR DESCRIPTION
## Summary

A new dependency on nostr-sdk-swift (rust-nostr) was added to support NIP-37 drafts, but the version we were using did not support Mac Catalyst, which meant that the translation export script was broken. @yukibtc [added](https://github.com/rust-nostr/nostr/pull/749) [support](https://github.com/rust-nostr/nostr-sdk-swift/commit/27711a03ea7d977162595eea1d9b2d5a45f0b628) for Mac Catalyst, which fixed the issue, so this PR pulls in that version update to fix the translation script.

Closes: https://github.com/damus-io/damus/issues/2841
Fixes: https://github.com/damus-io/damus/commit/24c3e61a4bd57ed64edee704416bb3c6598deabe

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** MacBook Pro 16-inch 2023

**OS:** macOS Sequoia 15.3 (24D60)

**Xcode:** 16.2 (16C5032a)

**Damus:** f7a7e7ed8ae7d572d74a7fd5bddc955f1d5f620b

**Steps:**
1. Check out this branch in git.
2. Build and run Damus in Xcode to ensure that it succeeds with the dependency upgrade.
3. Draft a note, close the app, and reopen. Ensure that note drafts persist and can be recalled.
4. Run `./devtools/export-source-translation.sh`
5. Run `git diff` and notice that there are changed files in `damus/en-US.xcloc/` with string updates.

**Results:**
- [x] PASS