### PR TITLE
Trim whitespaces from Lightning addresses

### DIFF
--- a/damus/Nostr/Nostr.swift
+++ b/damus/Nostr/Nostr.swift
@@ -31,7 +31,8 @@ class ProfileRecord {
         }
         
         guard let profile = data.profile,
-              let addr = profile.lud16 ?? profile.lud06 else {
+              let addr = (profile.lud16 ?? profile.lud06)?.trimmingCharacters(in: .whitespaces)
+        else {
             return nil;
         }
         
@@ -301,7 +302,7 @@ class Profile: Codable {
 */
 
 func make_test_profile() -> Profile {
-    return Profile(name: "jb55", display_name: "Will", about: "Its a me", picture: "https://cdn.jb55.com/img/red-me.jpg", banner: "https://pbs.twimg.com/profile_banners/9918032/1531711830/600x200",  website: "jb55.com", lud06: "jb55@jb55.com", lud16: nil, nip05: "jb55@jb55.com", damus_donation: 1)
+    return Profile(name: "jb55", display_name: "Will", about: "Its a me", picture: "https://cdn.jb55.com/img/red-me.jpg", banner: "https://pbs.twimg.com/profile_banners/9918032/1531711830/600x200", website: "jb55.com", lud06: nil, lud16: "jb55@jb55.com", nip05: "jb55@jb55.com", damus_donation: 1)
 }
 
 func make_ln_url(_ str: String?) -> URL? {

--- a/damus/Views/Profile/EditMetadataView.swift
+++ b/damus/Views/Profile/EditMetadataView.swift
@@ -170,6 +170,9 @@ struct EditMetadataView: View {
                     TextField(NSLocalizedString("Lightning Address or LNURL", comment: "Placeholder text for entry of Lightning Address or LNURL."), text: $ln)
                         .autocorrectionDisabled(true)
                         .textInputAutocapitalization(.never)
+                        .onReceive(Just(ln)) { newValue in
+                            self.ln = newValue.trimmingCharacters(in: .whitespaces)
+                        }
                 }
                                 
                 Section(content: {

--- a/damus/Views/Zaps/ProfileZapLinkView.swift
+++ b/damus/Views/Zaps/ProfileZapLinkView.swift
@@ -24,8 +24,8 @@ struct ProfileZapLinkView<Content: View>: View {
         self.label = label
         self.action = action
         self.reactions_enabled = reactions_enabled
-        self.lud16 = lud16
-        self.lnurl = lnurl
+        self.lud16 = lud16?.trimmingCharacters(in: .whitespaces)
+        self.lnurl = lnurl?.trimmingCharacters(in: .whitespaces)
     }
     
     init(damus_state: DamusState, pubkey: Pubkey, action: ActionFunction? = nil, @ViewBuilder label: @escaping ContentViewFunction) {
@@ -36,8 +36,8 @@ struct ProfileZapLinkView<Content: View>: View {
         let profile_txn = damus_state.profiles.lookup_with_timestamp(pubkey)
         let record = profile_txn?.unsafeUnownedValue
         self.reactions_enabled = record?.profile?.reactions ?? true
-        self.lud16 = record?.profile?.lud06
-        self.lnurl = record?.lnurl
+        self.lud16 = record?.profile?.lud06?.trimmingCharacters(in: .whitespaces)
+        self.lnurl = record?.lnurl?.trimmingCharacters(in: .whitespaces)
     }
     
     init(unownedProfileRecord: ProfileRecord?, profileModel: ProfileModel, action: ActionFunction? = nil, @ViewBuilder label: @escaping ContentViewFunction) {
@@ -46,8 +46,8 @@ struct ProfileZapLinkView<Content: View>: View {
         self.action = action
         
         self.reactions_enabled = unownedProfileRecord?.profile?.reactions ?? true
-        self.lud16 = unownedProfileRecord?.profile?.lud16
-        self.lnurl = unownedProfileRecord?.lnurl
+        self.lud16 = unownedProfileRecord?.profile?.lud16?.trimmingCharacters(in: .whitespaces)
+        self.lnurl = unownedProfileRecord?.lnurl?.trimmingCharacters(in: .whitespaces)
     }
     
     var body: some View {
@@ -81,12 +81,13 @@ struct ProfileZapLinkView<Content: View>: View {
                 }
             }
         }
-        .disabled(lnurl == nil)
+        .disabled(lnurl == nil && lud16 == nil)
     }
 }
 
 #Preview {
-    ProfileZapLinkView(pubkey: test_pubkey, reactions_enabled: true, lud16: make_test_profile().lud16, lnurl: "test@sendzaps.lol", label: { reactions_enabled, lud16, lnurl in
+    let profile = make_test_profile()
+    ProfileZapLinkView(pubkey: test_pubkey, reactions_enabled: true, lud16: profile.lud16, lnurl: profile.lud06, label: { reactions_enabled, lud16, lnurl in
         Image("zap.fill")
     })
 }


### PR DESCRIPTION
## Summary

Whitespaces can prevent clients from being able to zap recipients. This fixes Damus to:
1. Not allow leading or trailing whitespaces from being added to Lightning addresses or LNURL, and
2. Filter out leading or trailing whitespaces from existing Lightning addresses or LNURLs in profiles.

Example of this issue impacting users in the wild:
https://damus.io/nevent1qqsf9rgw2fmh0uup9ss8advc2pemara7q5h54c7nn07gz7880k2fjmqpzamhxue69uhkxun9v968ytnwdaehgu3wwa5kuegpzemhxw309aehgunfvd5zumr0vdskcw358q6rsqgcwaehxw309acxcetzdahx2tnwdaehgu339e3k7mgpzemhxue69uhhyetvv9ujumn0wd68ytnzv9hxgsfp3c7

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.3

**Damus:** 46db94b94d942d075fc6b91f75a5abeced39d7cf

**Steps:**
1. Build and run Damus on simulator on master.
3. Create a new account (or use an existing test account).
4. Open left sidebar and tap Profile.
5. Tap `Edit` on the top right of the profile view. Add a Lightning address to the profile with leading and trailing whitespaces. Observe that it is possible to do that. Tap Save.
6. Observe that long-pressing the Lightning icon in the profile shows the Lightning address with the leading and trailing whitespaces included.
7. Build and run Damus on simulator using SHA 46db94b94d942d075fc6b91f75a5abeced39d7cf (this branch)
8. Observe that long-pressing the Lightning icon in the profile shows the Lightning address without the leading and trailing whitespaces included.
9. Tap `Edit` on the top right of the profile view. Replace the Lightning address with a different one. Observe that it is no longer possible to add leading or trailing whitespaces to the Lightning address. Tap Save.
10. Observe that long-pressing the Lightning icon in the profile shows the new Lightning address.

**Results:**
- [x] PASS