### PR TITLE
Reduce swipe sensitivity on thread chat view

### DIFF
--- a/damus/Views/Chat/ChatEventView.swift
+++ b/damus/Views/Chat/ChatEventView.swift
@@ -298,7 +298,7 @@ struct ChatEventView: View {
             }
             .swipeSpacing(-20)
             .swipeActionsStyle(.mask)
-            .swipeMinimumDistance(20)
+            .swipeMinimumDistance(40)
             .swipeDragGesturePriority(.normal)
         }
     }


### PR DESCRIPTION
## Summary

Reduce swipe sensitivity on thread chat view.

Value determined by tweaking value up and down and experimenting with it on a real iOS device.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 13 mini

**iOS:** 18.3.1

**Damus:** aad8f9e8d46e57236bea2917dc036323bc2546c3

**Steps:**
1. Go to a thread with many replies
2. Scroll with thumb, with thumb going at a direction around 20º counter-clockwise from the horizontal line (think of a 20º vector in a mathematical unit circle). Ensure there are no horizontal swipe actions detected
3. purposefully swipe chat bubbles left and right, at a 0º angle — several times. Ensure that swipes get detected almost every single time.
4. Try steps 2–3 with an index finger as well.

**Results:**
- [x] PASS

## Other notes

@jb55 please feel free to try it out and see if this new value works for you. The "feel" is kind of subjective, so it might be nice to have a second opinion.