### PR TITLE
Fixed issue where app would need a restart for new NWC wallets to work

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -370,6 +370,8 @@ struct ContentView: View {
             self.confirm_mute = true
         }
         .onReceive(handle_notify(.attached_wallet)) { nwc in
+            try? damus_state.pool.add_relay(.nwc(url: nwc.relay))
+
             // update the lightning address on our profile when we attach a
             // wallet with an associated
             guard let ds = self.damus_state,


### PR DESCRIPTION
## Summary

This PR fixes an issue where the app would need a restart for new NWC wallets to work

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Repro

**Device:** iPhone SE simulator
**iOS:** 18.1
**Damus:** a696ac50841bd4d1339de1315100867ab5e02d4a

**Setup:**
1. Coinos relay disconnected at the start

**Steps:**
1. Connect Coinos NWC wallet
2. Zap a note
3. Check on zap view if the zap is pending

**Results:** Zap shows pending (Issue reproduced)

## Test report

**Device:** iPhone SE simulator
**iOS:** 18.1
**Damus:** 15af686a58721d8e3a7e93610de7a1fcc189fcd7

**Setup:**
1. Coinos relay disconnected at the start

**Steps:**
1. Connect Coinos NWC wallet
2. Zap a note
3. Check on zap view if the zap is pending

**Results:**
- [x] PASS
    - Zap does not show pending, zaps have gone through
