### PR TITLE
Implement developer feature to avoid distractions

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -1617,6 +1617,9 @@
 		D7DB1FEE2D5AC51B00CF06DA /* NIP44v2EncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7DB1FED2D5AC50F00CF06DA /* NIP44v2EncryptionTests.swift */; };
 		D7DB1FF12D5AC5D700CF06DA /* nip44.vectors.json in Resources */ = {isa = PBXBuildFile; fileRef = D7DB1FF02D5AC5D700CF06DA /* nip44.vectors.json */; };
 		D7DB1FF32D5AC5EA00CF06DA /* LICENSES in Resources */ = {isa = PBXBuildFile; fileRef = D7DB1FF22D5AC5E400CF06DA /* LICENSES */; };
+		D7DB93052D66A44100DA1EE5 /* Undistractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7DB93042D66A43B00DA1EE5 /* Undistractor.swift */; };
+		D7DB93062D66A44100DA1EE5 /* Undistractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7DB93042D66A43B00DA1EE5 /* Undistractor.swift */; };
+		D7DB93072D66A44100DA1EE5 /* Undistractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7DB93042D66A43B00DA1EE5 /* Undistractor.swift */; };
 		D7DBD41F2B02F15E002A6197 /* NostrKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C3BEFD32819DE8F00B3DE84 /* NostrKind.swift */; };
 		D7DEEF2F2A8C021E00E0C99F /* NostrEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7DEEF2E2A8C021E00E0C99F /* NostrEventTests.swift */; };
 		D7EB00B02CD59C8D00660C07 /* PresentFullScreenItemNotify.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EB00AF2CD59C8300660C07 /* PresentFullScreenItemNotify.swift */; };
@@ -2495,6 +2498,7 @@
 		D7DB1FED2D5AC50F00CF06DA /* NIP44v2EncryptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NIP44v2EncryptionTests.swift; sourceTree = "<group>"; };
 		D7DB1FF02D5AC5D700CF06DA /* nip44.vectors.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = nip44.vectors.json; sourceTree = "<group>"; };
 		D7DB1FF22D5AC5E400CF06DA /* LICENSES */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSES; sourceTree = "<group>"; };
+		D7DB93042D66A43B00DA1EE5 /* Undistractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Undistractor.swift; sourceTree = "<group>"; };
 		D7DEEF2E2A8C021E00E0C99F /* NostrEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrEventTests.swift; sourceTree = "<group>"; };
 		D7EB00AF2CD59C8300660C07 /* PresentFullScreenItemNotify.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentFullScreenItemNotify.swift; sourceTree = "<group>"; };
 		D7EDED1B2B1178FE0018B19C /* NoteContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteContent.swift; sourceTree = "<group>"; };
@@ -3235,6 +3239,7 @@
 		4C7FF7D628233637009601DB /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				D7DB93042D66A43B00DA1EE5 /* Undistractor.swift */,
 				D73E5F7E2C6AA066007EB227 /* DamusAliases.swift */,
 				E04A37C52B544F090029650D /* URIParsing.swift */,
 				4C1D4FB02A7958E60024F453 /* VersionInfo.swift */,
@@ -4543,6 +4548,7 @@
 				4CE8794829941DA700F758CC /* RelayFilters.swift in Sources */,
 				4CEE2B02280B39E800AB5EEF /* EventActionBar.swift in Sources */,
 				4C3BEFE0281DE1ED00B3DE84 /* DamusState.swift in Sources */,
+				D7DB93062D66A44100DA1EE5 /* Undistractor.swift in Sources */,
 				D72E12782BEED22500F4F781 /* Array.swift in Sources */,
 				4C198DF529F88D2E004C165C /* ImageMetadata.swift in Sources */,
 				4CCEB7AE29B53D260078AA28 /* SearchingEventView.swift in Sources */,
@@ -5012,6 +5018,7 @@
 				82D6FB082CD99F7900C925F4 /* UserStatusSheet.swift in Sources */,
 				82D6FB092CD99F7900C925F4 /* SearchHeaderView.swift in Sources */,
 				82D6FB0A2CD99F7900C925F4 /* DamusGradient.swift in Sources */,
+				D7DB93052D66A44100DA1EE5 /* Undistractor.swift in Sources */,
 				82D6FB0B2CD99F7900C925F4 /* AlbyGradient.swift in Sources */,
 				82D6FB0C2CD99F7900C925F4 /* GoldSupportGradient.swift in Sources */,
 				82D6FB0D2CD99F7900C925F4 /* PinkGradient.swift in Sources */,
@@ -5430,6 +5437,7 @@
 				D73E5E412C6A97F4007EB227 /* GoldSupportGradient.swift in Sources */,
 				D73E5E422C6A97F4007EB227 /* PinkGradient.swift in Sources */,
 				D73E5E432C6A97F4007EB227 /* GrayGradient.swift in Sources */,
+				D7DB93072D66A44100DA1EE5 /* Undistractor.swift in Sources */,
 				D73E5E442C6A97F4007EB227 /* DamusLogoGradient.swift in Sources */,
 				D73E5E452C6A97F4007EB227 /* DamusBackground.swift in Sources */,
 				D73E5E462C6A97F4007EB227 /* DamusLightGradient.swift in Sources */,

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -201,6 +201,10 @@ class UserSettingsStore: ObservableObject {
     @Setting(key: "developer_mode", default_value: false)
     var developer_mode: Bool
     
+    /// Makes all post content gibberish and blurhashes images, to avoid distractions when developers are working.
+    @Setting(key: "undistract_mode", default_value: false)
+    var undistractMode: Bool
+    
     @Setting(key: "always_show_onboarding_suggestions", default_value: false)
     var always_show_onboarding_suggestions: Bool
 

--- a/damus/Util/Undistractor.swift
+++ b/damus/Util/Undistractor.swift
@@ -1,0 +1,30 @@
+//
+//  Undistractor.swift
+//  damus
+//
+//  Created by Daniel D’Aquino on 2025-02-19.
+//
+
+/// Keeping the minds of developers safe from the occupational hazard of social media distractions when testing Damus since 2025
+struct Undistractor {
+    static func makeGibberish(text: String) -> String {
+        let lowercaseLetters = "abcdefghijklmnopqrstuvwxyz"
+        let uppercaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        var transformedText = ""
+
+        for char in text {
+            if lowercaseLetters.contains(char) {
+                if let randomLetter = lowercaseLetters.randomElement() {
+                    transformedText.append(randomLetter)
+                }
+            } else if uppercaseLetters.contains(char) {
+                if let randomLetter = uppercaseLetters.randomElement() {
+                    transformedText.append(randomLetter)
+                }
+            } else {
+                transformedText.append(char)
+            }
+        }
+        return transformedText
+    }
+}

--- a/damus/Views/EventView.swift
+++ b/damus/Views/EventView.swift
@@ -57,6 +57,10 @@ struct EventView: View {
 
 // blame the porn bots for this code
 func should_blur_images(settings: UserSettingsStore, contacts: Contacts, ev: NostrEvent, our_pubkey: Pubkey, booster_pubkey: Pubkey? = nil) -> Bool {
+    if settings.undistractMode {
+        return true
+    }
+    
     if !settings.blur_images {
         return false
     }

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -40,6 +40,9 @@ struct NoteContentView: View {
     @ObservedObject var settings: UserSettingsStore
 
     var note_artifacts: NoteArtifacts {
+        if damus_state.settings.undistractMode {
+            return .separated(.just_content(Undistractor.makeGibberish(text: event.get_content(damus_state.keypair))))
+        }
         return self.artifacts_model.state.artifacts ?? .separated(.just_content(event.get_content(damus_state.keypair)))
     }
     

--- a/damus/Views/Settings/DeveloperSettingsView.swift
+++ b/damus/Views/Settings/DeveloperSettingsView.swift
@@ -17,6 +17,7 @@ struct DeveloperSettingsView: View {
                 Toggle(NSLocalizedString("Developer Mode", comment: "Setting to enable developer mode"), isOn: $settings.developer_mode)
                     .toggleStyle(.switch)
                 if settings.developer_mode {
+                    Toggle(NSLocalizedString("Undistract mode", comment: "Developer mode setting to scramble text and images to avoid distractions during development."), isOn: $settings.undistractMode)
                     Toggle(NSLocalizedString("Always show onboarding", comment: "Developer mode setting to always show onboarding suggestions."), isOn: $settings.always_show_onboarding_suggestions)
                     Picker(NSLocalizedString("Push notification environment", comment: "Prompt selection of the Push notification environment (Developer feature to switch between real/production mode to test modes)."),
                            selection: Binding(


### PR DESCRIPTION
## Summary

This commit implements an optional developer feature to scramble text and blur images to prevent distractions during development and testing, called _"Undistract mode"_

It is not perfect (It breaks some mentions and rich text objects, and does not scramble non-alphanumeric languages such as Japanese) — however — it keeps the text size and overall text appearance, so it retains most of the normal app appearance — almost as if all content was in a foreign language (human-looking text, but unintelligible to avoid distractions)

Since this is a developer feature I did not spend much time polishing it.

It does not affect user-facing functionality, and it seems to be effective in preventing distractions during manual testing of Damus features.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [x] I do not need to add a changelog entry. **Reason:** Not user-facing
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone SE simulator

**iOS:** 18.1

**Damus:** 7684f53281319be821c36a0117da885805a719e9

**Setup:**
- Developer settings ON
- Undistract mode ON

**Steps:**
1. Browse for a bit
2. Check that there are no distracting images, and that text has become gibberish.

**Results:**
- [x] PASS

![Simulator Screenshot - iPhone SE (3rd generation) - 2025-02-19 at 17 48 30](https://github.com/user-attachments/assets/d05e4946-9844-4430-a281-f842a87b8687)
