### PR TITLE
Fix issue where note persisted after note publication

### DIFF
--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -230,6 +230,7 @@ struct PostView: View {
                 damus_state.drafts.post = nil
         }
 
+        damus_state.drafts.save(damus_state: damus_state)
     }
     
     func load_draft() -> Bool {


### PR DESCRIPTION
## Summary

This fixes https://github.com/damus-io/damus/issues/2836

This was fixed by persistently saving the drafts in the cache persistently to storage after it has been cleared (from posting)

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report


**Device:** iPhone SE simulator

**iOS:** 18.1

**Damus:** 981821a6bcdbe5f1cb660acd0deec182fd045684

**Steps:**
1. Open post view
2. Type something, wait for it to save
3. Restart app
4. Open post view, draft should be there
5. Publish
6. Restart the app
7. Open post view, should be blank
8. Type something and post
9. Open post view again, should be blank again
10. Repeat steps 1–7 with reply drafts

**Results:**
- [x] PASS