### PR TITLE
Update EventMenu.swift - deprecate noteID in favor of neventID

### DIFF
--- a/damus/Views/Events/EventMenu.swift
+++ b/damus/Views/Events/EventMenu.swift
@@ -79,9 +79,9 @@ struct MenuItems: View {
             }
 
             Button {
-                UIPasteboard.general.string = event.id.bech32
+                UIPasteboard.general.string = Bech32Object.encode(.nevent(NEvent(noteid: event.id, relays: userProfile.getCappedRelayStrings())))
             } label: {
-                Label(NSLocalizedString("Copy note ID", comment: "Context menu option for copying the ID of the note."), image: "note-book")
+                Label(NSLocalizedString("Copy event ID", comment: "Context menu option for copying the event ID of the note."), image: "note-book")
             }
 
             if damus_state.settings.developer_mode {


### PR DESCRIPTION


## Summary

replaced deprecated noteID with neventID in EventMenu.swift. NoteID currently appears in bubble/context menu of each note (top right three dots ellipsis). Should close https://github.com/damus-io/damus/issues/2822

## Checklist

- [ ] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [ ] I have tested the changes in this PR
- [ ] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [ ] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [ ] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** _[Please specify the device you used for testing]_

**iOS:** _[Please specify the iOS version you used for testing]_

**Damus:** _[Please specify the Damus version or commit hash you used for testing]_

**Setup:** _[Please provide a brief description of the setup you used for testing, if applicable]_

**Steps:** _[Please provide a list of steps you took to test the changes in this PR]_

**Results:**
- [ ] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_
