### PR TITLE
Fix reposts banner to be localizable

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		3A4647CF2A413ADC00386AD8 /* CondensedProfilePicturesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4647CE2A413ADC00386AD8 /* CondensedProfilePicturesView.swift */; };
 		3A48E7B029DFBE9D006E787E /* MutedThreadsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A48E7AF29DFBE9D006E787E /* MutedThreadsManager.swift */; };
 		3A8CC6CC2A2CFEF900940F5F /* StringUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8CC6CB2A2CFEF900940F5F /* StringUtil.swift */; };
+		3A96E3FE2D6BCE3800AE1630 /* RepostedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A96E3FD2D6BCE3800AE1630 /* RepostedTests.swift */; };
 		3AA247FF297E3D900090C62D /* RepostsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA247FE297E3D900090C62D /* RepostsView.swift */; };
 		3AA24802297E3DC20090C62D /* RepostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA24801297E3DC20090C62D /* RepostView.swift */; };
 		3AA59D1D2999B0400061C48E /* DraftsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA59D1C2999B0400061C48E /* DraftsModel.swift */; };
@@ -1805,6 +1806,7 @@
 		3A96D41A298DA94500388A2A /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3A96D41B298DA94500388A2A /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3A96D41C298DA94500388A2A /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = nl; path = nl.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		3A96E3FD2D6BCE3800AE1630 /* RepostedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepostedTests.swift; sourceTree = "<group>"; };
 		3A994C4C2BE5B9370019F632 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = th; path = th.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		3A994C4D2BE5B9370019F632 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3A994C4E2BE5B9370019F632 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -3689,6 +3691,7 @@
 				D753CEA92BE9DE04001C3A5D /* MutingTests.swift */,
 				4C2D34402BDAF1B300F9FB44 /* NIP10Tests.swift */,
 				D72E12792BEEEED000F4F781 /* NostrFilterTests.swift */,
+				3A96E3FD2D6BCE3800AE1630 /* RepostedTests.swift */,
 			);
 			path = damusTests;
 			sourceTree = "<group>";
@@ -4882,6 +4885,7 @@
 				D78525252A7B2EA4002FA637 /* NoteContentViewTests.swift in Sources */,
 				4C3EA67B28FF7B3900C48A62 /* InvoiceTests.swift in Sources */,
 				4C363A9E2828A822006E126D /* ReplyTests.swift in Sources */,
+				3A96E3FE2D6BCE3800AE1630 /* RepostedTests.swift in Sources */,
 				4C7D097E2A0C58B900943473 /* WalletConnectTests.swift in Sources */,
 				4CB883AA297612FF00DC99E7 /* ZapTests.swift in Sources */,
 				D72A2D022AD9C136002AFF62 /* EventViewTests.swift in Sources */,

--- a/damus/Components/Reposted.swift
+++ b/damus/Components/Reposted.swift
@@ -10,36 +10,42 @@ import SwiftUI
 struct Reposted: View {
     let damus: DamusState
     let pubkey: Pubkey
-    let target: NoteId
+    let target: NostrEvent
     @State var reposts: Int
 
-    init(damus: DamusState, pubkey: Pubkey, target: NoteId) {
+    init(damus: DamusState, pubkey: Pubkey, target: NostrEvent) {
         self.damus = damus
         self.pubkey = pubkey
         self.target = target
-        self.reposts = damus.boosts.counts[target] ?? 1
+        self.reposts = damus.boosts.counts[target.id] ?? 1
     }
 
     var body: some View {
         HStack(alignment: .center) {
             Image("repost")
                 .foregroundColor(Color.gray)
-            ProfileName(pubkey: pubkey, damus: damus, show_nip5_domain: false)
-                    .foregroundColor(Color.gray)
-            NavigationLink(value: Route.Reposts(reposts: .reposts(state: damus, target: target))) {
-                let other_reposts = reposts - 1
-                if other_reposts > 0 {
-                        Text(" and \(other_reposts) others reposted", comment: "Text indicating that the note was reposted (i.e. re-shared) by multiple people")
-                            .foregroundColor(Color.gray)
-                } else {
-                    Text("reposted", comment: "Text indicating that the note was reposted (i.e. re-shared).")
-                        .foregroundColor(Color.gray)
-                }
+
+            // Show profile picture of the reposter only if the reposter is not the author of the reposted note.
+            if pubkey != target.pubkey {
+                ProfilePicView(pubkey: pubkey, size: eventview_pfp_size(.small), highlight: .none, profiles: damus.profiles, disable_animation: damus.settings.disable_animation)
+                    .onTapGesture {
+                        show_profile_action_sheet_if_enabled(damus_state: damus, pubkey: pubkey)
+                    }
+                    .onLongPressGesture(minimumDuration: 0.1) {
+                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                        damus.nav.push(route: Route.ProfileByKey(pubkey: pubkey))
+                    }
+            }
+
+            NavigationLink(value: Route.Reposts(reposts: .reposts(state: damus, target: target.id))) {
+                Text(people_reposted_text(profiles: damus.profiles, pubkey: pubkey, reposts: reposts))
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
             }
         }
         .onReceive(handle_notify(.update_stats), perform: { note_id in
-            guard note_id == target else { return }
-            let repost_count = damus.boosts.counts[target]
+            guard note_id == target.id else { return }
+            let repost_count = damus.boosts.counts[target.id]
             if let repost_count, reposts != repost_count {
                 reposts = repost_count
             }
@@ -47,9 +53,25 @@ struct Reposted: View {
     }
 }
 
+func people_reposted_text(profiles: Profiles, pubkey: Pubkey, reposts: Int, locale: Locale = Locale.current) -> String {
+    guard reposts > 0 else {
+        return ""
+    }
+
+    let bundle = bundleForLocale(locale: locale)
+    let other_reposts = reposts - 1
+    let display_name = event_author_name(profiles: profiles, pubkey: pubkey)
+
+    if other_reposts == 0 {
+        return String(format: NSLocalizedString("%@ reposted", bundle: bundle, comment: "Text indicating that the note was reposted (i.e. re-shared)."), locale: locale, display_name)
+    } else {
+        return String(format: localizedStringFormat(key: "people_reposted_count", locale: locale), locale: locale, other_reposts, display_name)
+    }
+}
+
 struct Reposted_Previews: PreviewProvider {
     static var previews: some View {
         let test_state = test_damus_state
-        Reposted(damus: test_state, pubkey: test_state.pubkey, target: test_note.id)
+        Reposted(damus: test_state, pubkey: test_state.pubkey, target: test_note)
     }
 }

--- a/damus/Views/Reposts/RepostedEvent.swift
+++ b/damus/Views/Reposts/RepostedEvent.swift
@@ -16,7 +16,7 @@ struct RepostedEvent: View {
     var body: some View {
         VStack(alignment: .leading) {
             NavigationLink(value: Route.ProfileByKey(pubkey: event.pubkey)) {
-                Reposted(damus: damus, pubkey: event.pubkey, target: inner_ev.id)
+                Reposted(damus: damus, pubkey: event.pubkey, target: inner_ev)
                     .padding(.horizontal)
             }
            .buttonStyle(PlainButtonStyle())

--- a/damus/en-US.lproj/Localizable.stringsdict
+++ b/damus/en-US.lproj/Localizable.stringsdict
@@ -66,6 +66,22 @@
 			<string>Imports</string>
 		</dict>
 	</dict>
+	<key>people_reposted_count</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@REPOSTED@</string>
+		<key>REPOSTED</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%2$@ and %1$d other reposted</string>
+			<key>other</key>
+			<string>%2$@ and %1$d others reposted</string>
+		</dict>
+	</dict>
 	<key>reacted_tagged_in_3</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/damusTests/RepostedTests.swift
+++ b/damusTests/RepostedTests.swift
@@ -1,0 +1,37 @@
+//
+//  RepostedTests.swift
+//  damusTests
+//
+//  Created by Terry Yiu on 2/23/25.
+//
+
+import XCTest
+@testable import damus
+
+final class RepostedTests: XCTestCase {
+
+    func testPeopleRepostedText() throws {
+        let enUsLocale = Locale(identifier: "en-US")
+        let damusState = test_damus_state
+        let pubkey = test_pubkey
+
+        // reposts must be greater than 0. Empty string is returned as a fallback if not.
+        XCTAssertEqual(people_reposted_text(profiles: damusState.profiles, pubkey: pubkey, reposts: -1, locale: enUsLocale), "")
+        XCTAssertEqual(people_reposted_text(profiles: damusState.profiles, pubkey: pubkey, reposts: 0, locale: enUsLocale), "")
+
+        // Verify the English pluralization variations.
+        XCTAssertEqual(people_reposted_text(profiles: damusState.profiles, pubkey: pubkey, reposts: 1, locale: enUsLocale), "17ldvg64:nq5mhr77 reposted")
+        XCTAssertEqual(people_reposted_text(profiles: damusState.profiles, pubkey: pubkey, reposts: 2, locale: enUsLocale), "17ldvg64:nq5mhr77 and 1 other reposted")
+        XCTAssertEqual(people_reposted_text(profiles: damusState.profiles, pubkey: pubkey, reposts: 3, locale: enUsLocale), "17ldvg64:nq5mhr77 and 2 others reposted")
+
+        // Sanity check that the non-English translations are likely not malformed.
+        Bundle.main.localizations.map { Locale(identifier: $0) }.forEach {
+            // -1...11 covers a lot (but not all) pluralization rules for different languages.
+            // However, it is good enough for a sanity check.
+            for reposts in -1...11 {
+                XCTAssertNoThrow(people_reposted_text(profiles: damusState.profiles, pubkey: pubkey, reposts: reposts, locale: $0))
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

The problem is that the reposts banner hardcoded assumptions that the sentence structure follows English rules. It incorrectly pieced together the reposter's username with the rest of the sentence in a way that would not be translatable in languages that don't follow grammar that is similar to English. Moreover, it hardcoded repost count conditional logic in a way that did not allow for proper localization of the plurality of the sentence.

This PR fixes all of that by:
1. Adding a profile picture that is tappable to navigate to the reposter's profile.
2. Collapses the repost sentence into a single string with the reposter's username as an argument so that it can be translated by the translators into non-English languages.

(Apologies, I had to speed up the video to reduce the file size below GitHub's 10MB limit)
(Also, I made this screen recording before I amended my commit to not show the zap icon on the reposter profile picture)

https://github.com/user-attachments/assets/bb9c20e2-3b94-4485-9d7a-2fa887f89f3f

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.3.1

**Damus:** a87ba731605890d521b0892ef80bfd8f2bd0ff01

**Steps:**
1. Run `RepostedTests` to ensure the tests pass.
2. Build and run Damus to the simulator or device.
3. Scroll the timeline on the home tab until you encounter a repost.
4. Observe that the profile picture of the reposter appears (unless the reposter is also the author of the original post).
5. Observe that if the original post was only reposted by one person, the sentence will read "<username> reposted" in English.
6. Observe that if the original post was reposted by two people, the sentence will read "<username> and 1 other reposted" in English.
7. Observe that if the original post was reposted by more than two people, the sentence will read "<username> and 2 others reposted" in English.
8. Tap on any part of the repost banner sentence. It should navigate to the reposters list view. Tap the back arrow.
9. Tap on the profile picture in the repost banner. It should pull up the profile action sheet (if enabled in Damus settings) or navigate to the reposter's profile (if disabled) -- unless you're already viewing the profile.

Steps 3-7 hold true if you're on the home tab timeline view OR in the profile view.
Example profiles to verify:
- [Ava](damus://npub1f6ugxyxkknket3kkdgu4k0fu74vmshawermkj8d06sz6jts9t4kslazcka) who frequently reposts her own posts
- [jack](damus://npub1sg6plzptd64u62a878hep2kev88swjh3tw00gjsfl8f237lmu63q0uf63m) who frequently reposts other people's posts

**Results:**
- [x] PASS