### PR TITLE
Remove mystery tabs meant to fix tab switching bug that no longer exists

### DIFF
--- a/damus/Views/Notifications/NotificationsView.swift
+++ b/damus/Views/Notifications/NotificationsView.swift
@@ -60,21 +60,8 @@ struct NotificationsView: View {
     
     @Environment(\.colorScheme) var colorScheme
     
-    var mystery: some View {
-        let profile_txn = state.profiles.lookup(id: state.pubkey)
-        let profile = profile_txn?.unsafeUnownedValue
-        return VStack(spacing: 20) {
-            Text("Wake up, \(Profile.displayName(profile: profile, pubkey: state.pubkey).displayName.truncate(maxLength: 50))", comment: "Text telling the user to wake up, where the argument is their display name.")
-            Text("You are dreaming...", comment: "Text telling the user that they are dreaming.")
-        }
-        .id("what")
-    }
-    
     var body: some View {
         TabView(selection: $filter_state) {
-            // This is needed or else there is a bug when switching from the 3rd or 2nd tab to first. no idea why.
-            mystery
-            
             NotificationTab(
                 NotificationFilter(
                     state: .all,

--- a/damus/Views/Timeline/PostingTimelineView.swift
+++ b/damus/Views/Timeline/PostingTimelineView.swift
@@ -25,11 +25,6 @@ struct PostingTimelineView: View {
     @State var headerHeight: CGFloat = 0
     @Binding var headerOffset: CGFloat
     @SceneStorage("PostingTimelineView.filter_state") var filter_state : FilterState = .posts_and_replies
-    
-    var mystery: some View {
-        Text("Are you lost?", comment: "Text asking the user if they are lost in the app.")
-        .id("what")
-    }
 
     func content_filter(_ fstate: FilterState) -> ((NostrEvent) -> Bool) {
         var filters = ContentFilters.defaults(damus_state: damus_state)
@@ -95,9 +90,6 @@ struct PostingTimelineView: View {
         VStack {
             ZStack {
                 TabView(selection: $filter_state) {
-                    // This is needed or else there is a bug when switching from the 3rd or 2nd tab to first. no idea why.
-                    mystery
-                    
                     contentTimelineView(filter: content_filter(.posts))
                         .tag(FilterState.posts)
                         .id(FilterState.posts)


### PR DESCRIPTION
## Summary

The mystery tabs were added a long time ago to fix a tab switching bug in the Home and Notification feeds. I removed them and can't seem to reproduce that bug, so perhaps there was some iOS update that fixed it. This PR removes those unnecessary views.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.3.1

**Damus:** 71ec18f6c6f30a0aaab6088b15c430ab69ae5c20

**Steps:**
1. Build and run Damus.
2. Navigate (swipe and tap) between the tabs (and attempt to go out of bounds) on the Home and Notification feeds.
3. Observe that tab switching behavior works fine and as expected.

**Results:**
- [x] PASS