### PR TITLE
Fix note rendering for those that contain previewable items or leading and trailing whitespaces

### DIFF
--- a/damus/Components/TranslateView.swift
+++ b/damus/Components/TranslateView.swift
@@ -160,7 +160,7 @@ func translate_note(profiles: Profiles, keypair: Keypair, event: NostrEvent, set
 
     // Render translated note
     let translated_blocks = parse_note_content(content: .content(translated_note, event.tags))
-    let artifacts = render_blocks(blocks: translated_blocks, profiles: profiles)
+    let artifacts = render_blocks(blocks: translated_blocks, profiles: profiles, can_hide_last_previewable_refs: true)
     
     // and cache it
     return .translated(Translated(artifacts: artifacts, language: note_lang))

--- a/damus/Models/NoteContent.swift
+++ b/damus/Models/NoteContent.swift
@@ -191,6 +191,7 @@ func reduce_text_block(ind: Int, hide_text_index: Int, txt: String) -> String {
 
 func invoice_str(_ invoice: Invoice) -> CompatibleText {
     var attributedString = AttributedString(stringLiteral: abbrev_identifier(invoice.string))
+    attributedString.link = URL(string: "damus:lightning:\(invoice.string)")
     attributedString.foregroundColor = DamusColors.purple
 
     return CompatibleText(attributed: attributedString)

--- a/damus/Models/NoteContent.swift
+++ b/damus/Models/NoteContent.swift
@@ -206,17 +206,16 @@ func url_str(_ url: URL) -> CompatibleText {
 }
 
 func classify_url(_ url: URL) -> UrlType {
-    let str = url.lastPathComponent.lowercased()
-    
-    if str.hasSuffix(".png") || str.hasSuffix(".jpg") || str.hasSuffix(".jpeg") || str.hasSuffix(".gif") || str.hasSuffix(".webp") {
+    let fileExtension = url.lastPathComponent.lowercased().components(separatedBy: ".").last
+
+    switch fileExtension {
+    case "png", "jpg", "jpeg", "gif", "webp":
         return .media(.image(url))
-    }
-    
-    if str.hasSuffix(".mp4") || str.hasSuffix(".mov") || str.hasSuffix(".m3u8") {
+    case "mp4", "mov", "m3u8":
         return .media(.video(url))
+    default:
+        return .link(url)
     }
-    
-    return .link(url)
 }
 
 func attributed_string_attach_icon(_ astr: inout AttributedString, img: UIImage) {

--- a/damus/Nostr/NostrLink.swift
+++ b/damus/Nostr/NostrLink.swift
@@ -12,6 +12,7 @@ enum NostrLink: Equatable {
     case ref(RefId)
     case filter(NostrFilter)
     case script([UInt8])
+    case invoice(String)
 }
 
 func encode_pubkey_uri(_ pubkey: Pubkey) -> String {
@@ -93,8 +94,15 @@ func decode_nostr_uri(_ s: String) -> NostrLink? {
             return
         }
 
-    if parts.count >= 2 && parts[0] == "t" {
-        return .filter(NostrFilter(hashtag: [parts[1].lowercased()]))
+    if parts.count >= 2 {
+        switch parts[0] {
+        case "t":
+            return .filter(NostrFilter(hashtag: [parts[1].lowercased()]))
+        case "lightning":
+            return .invoice(parts[1])
+        default:
+            break
+        }
     }
 
     guard parts.count == 1 else {

--- a/damus/Types/Block.swift
+++ b/damus/Types/Block.swift
@@ -37,7 +37,23 @@ enum Block: Equatable {
             return false
         }
     }
-    
+
+    var is_previewable: Bool {
+        switch self {
+        case .mention(let m):
+            switch m.ref {
+            case .note, .nevent: return true
+            default: return false
+            }
+        case .invoice:
+            return true
+        case .url:
+            return true
+        default:
+            return false
+        }
+    }
+
     case text(String)
     case mention(Mention<MentionRef>)
     case hashtag(String)

--- a/damus/Util/DisplayName.swift
+++ b/damus/Util/DisplayName.swift
@@ -80,9 +80,9 @@ func parse_display_name(name: String?, display_name: String?, pubkey: Pubkey) ->
 }
 
 func abbrev_bech32_pubkey(pubkey: Pubkey) -> String {
-    return abbrev_pubkey(String(pubkey.npub.dropFirst(4)))
+    return abbrev_identifier(String(pubkey.npub.dropFirst(4)))
 }
 
-func abbrev_pubkey(_ pubkey: String, amount: Int = 8) -> String {
+func abbrev_identifier(_ pubkey: String, amount: Int = 8) -> String {
     return pubkey.prefix(amount) + ":" + pubkey.suffix(amount)
 }

--- a/damus/Views/PubkeyView.swift
+++ b/damus/Views/PubkeyView.swift
@@ -46,7 +46,7 @@ struct PubkeyView: View {
         let bech32 = pubkey.npub
         
         HStack {
-            Text(verbatim: "\(abbrev_pubkey(bech32, amount: sidemenu ? 12 : 16))")
+            Text(verbatim: "\(abbrev_identifier(bech32, amount: sidemenu ? 12 : 16))")
                 .font(sidemenu ? .system(size: 10) : .footnote)
                 .foregroundColor(keyColor())
                 .padding(5)

--- a/damusTests/NoteContentViewTests.swift
+++ b/damusTests/NoteContentViewTests.swift
@@ -84,6 +84,7 @@ class NoteContentViewTests: XCTestCase {
         XCTAssertEqual(runArray.count, 3)
         XCTAssertTrue(runArray[0].description.contains("Donations appreciated: "))
         XCTAssertTrue(runArray[1].description.contains("lnbc100n:qpsql29r"))
+        XCTAssertEqual(runArray[1].link?.absoluteString, "damus:lightning:\(invoiceString)")
         XCTAssertTrue(runArray[2].description.contains(" Pura Vida"))
     }
 
@@ -281,6 +282,7 @@ class NoteContentViewTests: XCTestCase {
         XCTAssertEqual(runArray.count, 4)
         XCTAssertTrue(runArray[0].description.contains("Donations appreciated: "))
         XCTAssertTrue(runArray[1].description.contains("lnbc100n:qpsql29r"))
+        XCTAssertEqual(runArray[1].link?.absoluteString, "damus:lightning:\(invoiceString)")
         XCTAssertTrue(runArray[2].description.contains(" Pura Vida"))
         XCTAssertTrue(runArray[3].description.contains("https://damus.io/nothidden.png"))
         XCTAssertEqual(runArray[3].link?.absoluteString, "https://damus.io/nothidden.png")

--- a/damusTests/damusTests.swift
+++ b/damusTests/damusTests.swift
@@ -36,10 +36,9 @@ class damusTests: XCTestCase {
         XCTAssertEqual(bytes.count, 32)
     }
     
-    func testTrimmingFunctions() {
+    func testTrimSuffix() {
         let txt = "   bobs   "
         
-        XCTAssertEqual(trim_prefix(txt), "bobs   ")
         XCTAssertEqual(trim_suffix(txt), "   bobs")
     }
     


### PR DESCRIPTION
## Summary

There are several issues with rendering notes:
- URLs, note references, and invoices can be removed mid-sentence which makes the content of the note no longer make sense
- Leading and trailing whitespaces cause unnecessary visual noise that make it harder to read the note and can be a spam attack vector.
- Newlines are removed when they shouldn't be and alter the original formatting of the note

This PR fixes it so that:
- The only time the text of URLs, note references, or invoices can be hidden are if they are sequenced at the end of the content and are the only previewable items that exist in the content. If there is more than one link or more than one note reference, nothing is hidden because we can currently preview only one link and one note reference (which will be addressed in a future PR)
- Leading and trailing whitespaces are now trimmed. This also fixes an issue where if there are trailing whitespaces after the last previewable item, the text would not be hidden.
- Newlines are preserved if they precede a previewable block but aren't at the end of the note
- If invoices are shown as text, we now abbreviate the middle and show only the first and last few characters of the invoice string. Tapping on inlined invoice text will bring up the wallet selector.

There's also a minor optimization on the `classify_url` function where it was inefficiently calling `hasSuffix` multiple times on the same string to find the file extension.

Known and preexisting issues:
- If there is more than one referenced event, we render only the first one. On the Damus iOS standup on 2025-05-05, we agreed to render all events inline because that's most likely how the author wants readers to see the note. It was previously discussed about trying an event carousel, but showing events inline makes more sense after discussing it more.
- If there is more than one non-media link, we show the preview of only the first non-media link. We should perhaps consider showing a link carousel. Something to explore in the future.

Closes: https://github.com/damus-io/damus/issues/2187

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** iPhone 16 Pro Simulator

**iOS:** iOS 18.4

**Damus:** eb889a7591dad62eaa39a360031ddfb51b1daae9

**Steps:**
1. Build and run Damus.
2. Open the following notes to observe that they render properly (and compare with the behavior without this change where rendering is broken)

[nevent1qqsgv35vzvyl4eesqm8quk33jgxkddgvvnxntj3r75nk5jkwljgr4vgyx2pse](https://damus.io/nevent1qqsgv35vzvyl4eesqm8quk33jgxkddgvvnxntj3r75nk5jkwljgr4vgyx2pse)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-02 at 00 23 28 Medium](https://github.com/user-attachments/assets/cbe0cd93-1c36-43de-b207-a95a8b785271)

[nevent1qqs04gq030x3ew3mgdumy2j324lpww08enx6q06yldmqmv43vr05x9gpz3mhxue69uhhyetvv9ujumn0wd68ytnzvuq36amnwvaz7tmwdaehgu3dwp6kytnhv4kxcmmjv3jhytnwv46qzxrhwden5te0wfjkccte9ehx7um5wfshg6fwvdhk6qg4waehxw309ajkgetw9ehx7um5wghxcctwvsx36csg](https://damus.io/nevent1qqs04gq030x3ew3mgdumy2j324lpww08enx6q06yldmqmv43vr05x9gpz3mhxue69uhhyetvv9ujumn0wd68ytnzvuq36amnwvaz7tmwdaehgu3dwp6kytnhv4kxcmmjv3jhytnwv46qzxrhwden5te0wfjkccte9ehx7um5wfshg6fwvdhk6qg4waehxw309ajkgetw9ehx7um5wghxcctwvsx36csg)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-01 at 17 18 29 Medium](https://github.com/user-attachments/assets/a877496d-12be-4d55-986c-a4de39402941)

[nevent1qqsv9z59d39e47j86577sun65a5a7pqac0hmqjxfzzvh8mqzz0m7facpz3mhxue69uhhyetvv9ujuerpd46hxtnfduq3vamnwvaz7tmjv4kxz7fwdehhxarj9e3xzmnyqyvhwumn8ghj7mn0wd68ytnsd3jkycmgv95kutn0wfnszrthwden5te0dehhxtnvdakqra33mf](https://damus.io/nevent1qqsv9z59d39e47j86577sun65a5a7pqac0hmqjxfzzvh8mqzz0m7facpz3mhxue69uhhyetvv9ujuerpd46hxtnfduq3vamnwvaz7tmjv4kxz7fwdehhxarj9e3xzmnyqyvhwumn8ghj7mn0wd68ytnsd3jkycmgv95kutn0wfnszrthwden5te0dehhxtnvdakqra33mf)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-02 at 00 24 02 Medium](https://github.com/user-attachments/assets/858e1a2f-405d-48a9-ab7b-140d24a0c796)

[nevent1qqs2qk90sjcwqmn87kclvf5hr23qurafksplsmf30ster4pn7f9rxgqppamhxue69uhkummnw3ezumt0d5q3samnwvaz7tmjv4kxz7fwdehhxarj9e3k7mfwv96szxthwden5te0vfhhxarj9ehx76m0w3shymewwahhy6cpzemhxue69uhkzarvv9ejumn0wd68ytnvv9hxgxl0wqu](https://damus.io/nevent1qqs2qk90sjcwqmn87kclvf5hr23qurafksplsmf30ster4pn7f9rxgqppamhxue69uhkummnw3ezumt0d5q3samnwvaz7tmjv4kxz7fwdehhxarj9e3k7mfwv96szxthwden5te0vfhhxarj9ehx76m0w3shymewwahhy6cpzemhxue69uhkzarvv9ejumn0wd68ytnvv9hxgxl0wqu)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-01 at 17 19 21 Medium](https://github.com/user-attachments/assets/57b003c1-4630-4af5-bc5b-2e68402f6939)

[nevent1qqsfzsfgv4qcp2pmrkxjrpxygzjhvpx723qsr0mpy6hxcxcej26u0lgpz3mhxue69uhhyetvv9ujuerpd46hxtnfduq3vamnwvaz7tmjv4kxz7fwdehhxarj9e3xzmnyqgstvj22wngc5t0687qvak06mt34spm3dl8pqu0ymcv7946xkmv8vps95mdqg](https://damus.io/nevent1qqsfzsfgv4qcp2pmrkxjrpxygzjhvpx723qsr0mpy6hxcxcej26u0lgpz3mhxue69uhhyetvv9ujuerpd46hxtnfduq3vamnwvaz7tmjv4kxz7fwdehhxarj9e3xzmnyqgstvj22wngc5t0687qvak06mt34spm3dl8pqu0ymcv7946xkmv8vps95mdqg)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-02 at 00 24 21 Medium](https://github.com/user-attachments/assets/5eda072c-3e3e-4750-8533-3bce45eb76fc)

[nevent1qqsxxhax8uk9dvguj6mks4awukyvhpazudnmazgs9hjkg365yrchehcpz4mhxue69uhhwmm59eek7anzd96zu6r0wd6qz9thwden5te0vaex2etwwdhh2mpwwdcxzcm9qythwumn8ghj7cmjv4shgu3wdehhxarj9emkjmn9qyd8wumn8ghj7argv4nx7un9wd6zumn0wd68yvfwvdhk6ckaxv2
](https://damus.io/nevent1qqsxxhax8uk9dvguj6mks4awukyvhpazudnmazgs9hjkg365yrchehcpz4mhxue69uhhwmm59eek7anzd96zu6r0wd6qz9thwden5te0vaex2etwwdhh2mpwwdcxzcm9qythwumn8ghj7cmjv4shgu3wdehhxarj9emkjmn9qyd8wumn8ghj7argv4nx7un9wd6zumn0wd68yvfwvdhk6ckaxv2)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-02 at 00 22 50 Medium](https://github.com/user-attachments/assets/077abdc5-7702-4601-8aba-80c8e6de4575)

[nevent1qqs2nflv99gw3sqe7jk4vcl2j69r078anwxdl5ls9hhyh4jetmyj22cpzemhxue69uhhyetvv9ujumn0wd68ytnzv9hxgqgswaehxw309ahx7um5wgh8w6twv5qkvamnwvaz7tmxd9k8getj9ehx7um5wgh8w6twv5hkuur4vgchjct4dsuxkvp48yenwdm489k8xafkxajx2dmexcenwae5df6xwet4wa3k66p4dcmnwwpcdsm8smnvdeexwuenw3mx5mtx8a38ymmpv33kzum58468yat9qy28wumn8ghj7un9d3shjtnyv9kh2uewd9hsv67rrj](https://damus.io/nevent1qqs2nflv99gw3sqe7jk4vcl2j69r078anwxdl5ls9hhyh4jetmyj22cpzemhxue69uhhyetvv9ujumn0wd68ytnzv9hxgqgswaehxw309ahx7um5wgh8w6twv5qkvamnwvaz7tmxd9k8getj9ehx7um5wgh8w6twv5hkuur4vgchjct4dsuxkvp48yenwdm489k8xafkxajx2dmexcenwae5df6xwet4wa3k66p4dcmnwwpcdsm8smnvdeexwuenw3mx5mtx8a38ymmpv33kzum58468yat9qy28wumn8ghj7un9d3shjtnyv9kh2uewd9hsv67rrj)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-02 at 00 31 15 Medium](https://github.com/user-attachments/assets/e9ea76c7-c29d-482f-ac93-bee524128a1f)

[nevent1qqs8f47tv4mdjkj78a96vg4sh8d2q0nvpwkzggjw7gz4flmhfk6vy4spzpmhxue69uhkummnw3ezuamfdejsz9thwden5te0v4jx2m3wdehhxarj9ekxzmnyqyxhwumn8ghj7mn0wvhxcmmvqy28wumn8ghj7un9d3shjtnyv9kh2uewd9hs8rusn4
](https://damus.io/nevent1qqs8f47tv4mdjkj78a96vg4sh8d2q0nvpwkzggjw7gz4flmhfk6vy4spzpmhxue69uhkummnw3ezuamfdejsz9thwden5te0v4jx2m3wdehhxarj9ekxzmnyqyxhwumn8ghj7mn0wvhxcmmvqy28wumn8ghj7un9d3shjtnyv9kh2uewd9hs8rusn4)

https://github.com/user-attachments/assets/411816cf-5892-481d-adf7-b4f1b77b8f99

My test account [npub14rehyx5flkme5lnudeaczdx8yzjq3dkzf06zvfqeea2tzcx9y7nqpvuw74](https://damus.io/npub14rehyx5flkme5lnudeaczdx8yzjq3dkzf06zvfqeea2tzcx9y7nqpvuw74) has a bunch of notes that test different combinations of previewable items.

**Results:**
- [x] PASS