### PR TITLE
Change spaces to newlines in new posts to provide cleaner separation between text, uploaded media, and quoted notes

### DIFF
--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -865,33 +865,29 @@ func build_post(state: DamusState, post: NSAttributedString, action: PostAction,
 
 
     var content = post.string
-        .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
 
-    let imagesString = uploadedMedias.map { $0.uploadedURL.absoluteString }.joined(separator: " ")
+    let imagesString = uploadedMedias.map { $0.uploadedURL.absoluteString }.joined(separator: "\n")
 
     if !imagesString.isEmpty {
-        content.append(" " + imagesString + " ")
+        content.append("\n\n" + imagesString)
     }
 
     var tags: [[String]] = []
 
     switch action {
-        case .replying_to(let replying_to):
-            // start off with the reply tags
-            tags = nip10_reply_tags(replying_to: replying_to, keypair: state.keypair)
+    case .replying_to(let replying_to):
+        // start off with the reply tags
+        tags = nip10_reply_tags(replying_to: replying_to, keypair: state.keypair)
 
-        case .quoting(let ev):
-            content.append(" nostr:" + bech32_note_id(ev.id))
+    case .quoting(let ev):
+        content.append("\n\nnostr:" + bech32_note_id(ev.id))
 
-            if let quoted_ev = state.events.lookup(ev.id) {
-                tags.append(["p", quoted_ev.pubkey.hex()])
-            }
-        case .posting(let postTarget):
-            break
-        case .highlighting(let draft):
-            break
-        case .sharing(_):
-            break
+        if let quoted_ev = state.events.lookup(ev.id) {
+            tags.append(["p", quoted_ev.pubkey.hex()])
+        }
+    case .posting, .highlighting, .sharing:
+        break
     }
 
     // append additional tags
@@ -913,7 +909,7 @@ func build_post(state: DamusState, post: NSAttributedString, action: PostAction,
             }
     }
 
-    return NostrPost(content: content, kind: .text, tags: tags)
+    return NostrPost(content: content.trimmingCharacters(in: .whitespacesAndNewlines), kind: .text, tags: tags)
 }
 
 func isSupportedVideo(url: URL?) -> Bool {


### PR DESCRIPTION
## Summary

When you create a new post in Damus, spaces are added between the text content, uploaded media (if they exist), and quoted note (if it exists). This causes rendering in other clients to look strange because it all becomes one line.

It's no problem for clients that do rich rendering and have special rules that format it to look nice. For clients or people who just want to look at unrendered text or want to render images and notes as they are positioned in the string (i.e. on the same line), it's hard to read because it's a jumbled mess.

This PR adds cleaner logical separation (two newlines) between those three types of data in the kind 1 note by using newlines.


Previously, it used to look like this:

```
(text) (media1) (media2) (media3) (quoted note)
```

Now, It looks like this:

```
(text)

(media1)
(media2)
(media3)

(quoted note)
```

Here's an example of a note that I created that follows this new format:
[nevent1qqsya3arj9twja8g27t9cmwh0vjy69sx3627ywn25jl97agm2366hhspzemhxue69uhhyetvv9ujumn0wd68ytnzv9hxgqgkwaehxw309aex2mrp0yh8qunfd4skctnwv46qz9rhwden5te0wfjkccte9ejxzmt4wvhxjmcpg3mhxue69uhkgc35v4nx7cn4wvexjmr5w3mn2em0dd3hwcmtxdhkkcmjxsmnv6r3ddkhjutyw4hhj7tyd3hny63hd95kwetgddukgtnvda3kzmq7lagnk](https://damus.io/nevent1qqsya3arj9twja8g27t9cmwh0vjy69sx3627ywn25jl97agm2366hhspzemhxue69uhhyetvv9ujumn0wd68ytnzv9hxgqgkwaehxw309aex2mrp0yh8qunfd4skctnwv46qz9rhwden5te0wfjkccte9ejxzmt4wvhxjmcpg3mhxue69uhkgc35v4nx7cn4wvexjmr5w3mn2em0dd3hwcmtxdhkkcmjxsmnv6r3ddkhjutyw4hhj7tyd3hny63hd95kwetgddukgtnvda3kzmq7lagnk)

This is the resulting note content:
```
Testing a Damus change. Ignore me.

https://i.nostr.build/lBlfjugOzi2NbARz.jpg
https://i.nostr.build/ZSc0XzDgyc4zGKQl.jpg

nostr:note1dzzm34a9vmw6f6pz9hvlfuketskcytnl65pnu8y3nm9r228zwj7srlteaj
```

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro

**iOS:** 18.3.1

**Damus:** adba831c1fc63b19e4bd61fb87bb59dd897a4604

**Steps:**
1. Build and run Damus.
2. Quote repost a note, write some text, and upload at least 2 images and/or videos.

Observe that the "content" field of the raw JSON note separates the three different types of data with two newlines.

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_