### PR TITLE
Fix bug where profile view was showing more than just the notes and replies on the notes / notes & replies tabs

### DIFF
--- a/damus/Views/Profile/ProfileView.swift
+++ b/damus/Views/Profile/ProfileView.swift
@@ -122,7 +122,10 @@ struct ProfileView: View {
     func content_filter(_ fstate: FilterState) -> ((NostrEvent) -> Bool) {
         var filters = ContentFilters.defaults(damus_state: damus_state)
         filters.append(fstate.filter)
-        if fstate == .conversations {
+        switch fstate {
+        case .posts, .posts_and_replies:
+            filters.append({ profile.pubkey == $0.pubkey })
+        case .conversations:
             filters.append({ profile.conversation_events.contains($0.id) } )
         }
         return ContentFilters(filters: filters).filter


### PR DESCRIPTION
## Summary

I introduced a bug in https://github.com/damus-io/damus/pull/2875 where Conversation events from yourself would show up in the Notes / Notes & Replies tabs. My change had expanded on what the EventHolder would hold, but I didn't make a corresponding change to filter those out to match on pubkey.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** iOS 18.3.1

**Damus:** d174b03648151d7370a2204d80f7d297e81613ac

**Steps:**:
1. Build and run Damus.
2. Navigate to a profile that you have composed a note that mentions their pubkey in a p-tag.
3. Ensure that your note does not show up on that profile's Notes or Notes & Replies tabs.

**Results:**
- [x] PASS