### PR TITLE
Add Unicode 16 emoji reactions for iOS 18.4+ by upgrading EmojiPicker

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -6768,7 +6768,7 @@
 			repositoryURL = "https://github.com/tyiu/EmojiPicker.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.1;
+				minimumVersion = 0.2.0;
 			};
 		};
 		4C06670228FC7EC500038D2A /* XCRemoteSwiftPackageReference "Kingfisher" */ = {

--- a/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "085cf0f645323bf77edb52886489bf77b309a0a2d2b78a54beaf8520b540d596",
+  "originHash" : "06318d35ee2e6bd681b95591e67da33a9461b48a3c652e58bd9d1a6f0d82bdac",
   "pins" : [
     {
       "identity" : "codescanner",
@@ -22,8 +22,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tyiu/EmojiKit",
       "state" : {
-        "revision" : "05805f72d63a6d6a2d7dc7fe14abd37c1317b11a",
-        "version" : "0.1.2"
+        "revision" : "47a4b1402de26be0299dcb4d667c1faaf21a7874",
+        "version" : "0.2.0"
       }
     },
     {
@@ -31,8 +31,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tyiu/EmojiPicker.git",
       "state" : {
-        "revision" : "0c28b4a1a6b8840cf2580bda59517f6d0a733dc8",
-        "version" : "0.1.1"
+        "revision" : "3f48903721eae223238ff0af17c22d6373d33813",
+        "version" : "0.2.0"
       }
     },
     {


### PR DESCRIPTION
## Summary

Closes: https://github.com/damus-io/damus/issues/2915

iOS 18.4 beta 2 adds support for [Unicode 16 emojis](https://www.unicode.org/emoji/charts-16.0/emoji-released.html). I made an update on my [EmojiKit](https://github.com/tyiu/EmojiKit/commit/47a4b1402de26be0299dcb4d667c1faaf21a7874) / [EmojiPicker](https://github.com/tyiu/EmojiPicker/commit/3f48903721eae223238ff0af17c22d6373d33813) libraries to include them in the emoji picker UI. This PR upgrades the EmojiPicker library version used by Damus to pick them up.

The emojis in the frequently used top row of the screenshot are the new emojis.

![Simulator Screenshot - iPhone 16 Pro - 2025-03-13 at 17 06 58 Medium](https://github.com/user-attachments/assets/4e97f171-5cbf-4d3a-a32c-2e97797ab819)

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.4 beta 2 (22E5216h)

**Damus:** ﻿d26804d665826378f965c5eb808f6ad506f835ed

**Setup:** Download Xcode Version 16.3 beta 2 (16E5121h) or above. Install the iOS 18.4 simulator runtime.

**Steps:**
1. Build and run Damus on iOS 18.3 or below.
2. Long-press the reaction button on a note to bring up the emoji picker.
3. Search: `fatigued`, `fingerprint`, `leafless`, `radish`, `harp`, `shovel`, and `splatter`. Observe that no emojis are returned for any of these search results because the OS does not support Unicode 16 emojis.
4. Build and run Damus on iOS 18.4 beta 2 or above.
5. Long-press the reaction button on a note to bring up the emoji picker.
6. Search: `fatigued`, `fingerprint`, `leafless`, `radish`, `harp`, `shovel`, and `splatter`. Observe that an emoji is returned for each search result because the OS supports Unicode 16 emojis.

**Results:**
- [x] PASS