### PR TITLE
Show additional information on top of blurred image

### DIFF
--- a/damus/Views/Events/Longform/LongformPreview.swift
+++ b/damus/Views/Events/Longform/LongformPreview.swift
@@ -122,19 +122,7 @@ struct LongformPreviewBody: View {
                 } else if blur_images || (blur_images && !state.settings.media_previews) {
                     ZStack {
                         titleImage(url: url)
-                        ZStack {
-                            Blur()
-                            
-                            VStack(alignment: .center) {
-                                Text(NSLocalizedString("Non-following user media. Tap to open", comment: "Non-following user media. Tap to open."))
-                                    .foregroundStyle(Color.white)
-                                    .font(.title2)
-                                    .padding(8)
-                            }
-                        }
-                        .onTapGesture {
-                            blur_images = false
-                        }
+                        BlurOverlayView(blur_images: $blur_images, artifacts: nil, size: nil, damus_state: nil, parentView: .longFormView)
                     }
                 }
             }

--- a/damus/Views/Events/Longform/LongformPreview.swift
+++ b/damus/Views/Events/Longform/LongformPreview.swift
@@ -122,10 +122,19 @@ struct LongformPreviewBody: View {
                 } else if blur_images || (blur_images && !state.settings.media_previews) {
                     ZStack {
                         titleImage(url: url)
-                        Blur()
-                            .onTapGesture {
-                                blur_images = false
+                        ZStack {
+                            Blur()
+                            
+                            VStack(alignment: .center) {
+                                Text(NSLocalizedString("Non-following user media. Tap to open", comment: "Non-following user media. Tap to open."))
+                                    .foregroundStyle(Color.white)
+                                    .font(.title2)
+                                    .padding(8)
                             }
+                        }
+                        .onTapGesture {
+                            blur_images = false
+                        }
                     }
                 }
             }

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -190,7 +190,7 @@ struct NoteContentView: View {
                                 switch artifacts.media[0] {
                                 case .image(let url), .video(let url):
                                     Text(abbreviateURL(url))
-                                        .font(eventviewsize_to_font(size, font_size: damus_state.settings.font_size))
+                                        .font(eventviewsize_to_font(size, font_size: damus_state.settings.font_size*0.8))
                                         .foregroundStyle(.white)
                                         .multilineTextAlignment(.center)
                                         .padding(EdgeInsets(top: 0, leading: 10, bottom: 5, trailing: 10))

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -171,10 +171,30 @@ struct NoteContentView: View {
                             Blur()
                             
                             VStack(alignment: .center) {
-                                Text(NSLocalizedString("Non-following user media. Tap to open", comment: "Non-following user media. Tap to open."))
+                                Image(systemName: "eye.slash")
+                                    .foregroundStyle(.white)
+                                    .bold()
+                                    .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
+                                Text(NSLocalizedString("Media from someone you \n dont follow", comment: "Media from someone you dont follow"))
+                                    .multilineTextAlignment(.center)
                                     .foregroundStyle(Color.white)
                                     .font(.title2)
-                                    .padding(8)
+                                    .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
+                                Button(NSLocalizedString("Tap to load", comment: "Tap to load")){
+                                    blur_images = false
+                                }
+                                .buttonStyle(.bordered)
+                                .fontWeight(.bold)
+                                .foregroundStyle(.white)
+                                .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
+                                switch artifacts.media[0] {
+                                case .image(let url), .video(let url):
+                                    Text(abbreviateURL(url))
+                                        .font(eventviewsize_to_font(size, font_size: damus_state.settings.font_size))
+                                        .foregroundStyle(.white)
+                                        .multilineTextAlignment(.center)
+                                        .padding(EdgeInsets(top: 0, leading: 10, bottom: 5, trailing: 10))
+                                }
                             }
                         }
                         .onTapGesture {

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -166,10 +166,20 @@ struct NoteContentView: View {
                         ImageCarousel(state: damus_state, evid: event.id, urls: artifacts.media) { dismiss in
                             fullscreen_preview(dismiss: dismiss)
                         }
-                        Blur()
-                            .onTapGesture {
-                                blur_images = false
+                        ZStack {
+                            
+                            Blur()
+                            
+                            VStack(alignment: .center) {
+                                Text(NSLocalizedString("Non-following user media. Tap to open", comment: "Non-following user media. Tap to open."))
+                                    .foregroundStyle(Color.white)
+                                    .font(.title2)
+                                    .padding(8)
                             }
+                        }
+                        .onTapGesture {
+                            blur_images = false
+                        }
                     }
                 }
             }
@@ -401,7 +411,7 @@ struct NoteContentView_Previews: PreviewProvider {
             .previewDisplayName("Super short note")
 
             VStack {
-                NoteContentView(damus_state: state, event: test_encoded_note_with_image!, blur_images: false, size: .normal, options: [])
+                NoteContentView(damus_state: state, event: test_encoded_note_with_image!, blur_images: true, size: .normal, options: [])
             }
             .previewDisplayName("Note with image")
 

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -189,11 +189,11 @@ struct NoteContentView: View {
                                 .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
                                 switch artifacts.media[0] {
                                 case .image(let url), .video(let url):
-                                    Text(abbreviateURL(url))
+                                    Text(abbreviateURL(url).prefix(20))
                                         .font(eventviewsize_to_font(size, font_size: damus_state.settings.font_size*0.8))
                                         .foregroundStyle(.white)
                                         .multilineTextAlignment(.center)
-                                        .padding(EdgeInsets(top: 0, leading: 10, bottom: 5, trailing: 10))
+                                        .padding(EdgeInsets(top: 20, leading: 10, bottom: 5, trailing: 10))
                                 }
                             }
                         }

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -23,6 +23,11 @@ struct Blur: UIViewRepresentable {
     }
 }
 
+enum viewType {
+    case noteContentView, longFormView
+}
+
+
 struct NoteContentView: View {
     
     let damus_state: DamusState
@@ -166,43 +171,7 @@ struct NoteContentView: View {
                         ImageCarousel(state: damus_state, evid: event.id, urls: artifacts.media) { dismiss in
                             fullscreen_preview(dismiss: dismiss)
                         }
-                        ZStack {
-                            
-                            Color.black
-                                .opacity(0.54)
-                            
-                            Blur()
-                            
-                            VStack(alignment: .center) {
-                                Image(systemName: "eye.slash")
-                                    .foregroundStyle(.white)
-                                    .bold()
-                                    .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
-                                Text(NSLocalizedString("Media from someone you \n don't follow", comment: "Label on the image blur mask"))
-                                    .multilineTextAlignment(.center)
-                                    .foregroundStyle(Color.white)
-                                    .font(.title2)
-                                    .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
-                                Button(NSLocalizedString("Tap to load", comment: "Label for button that allows user to dismiss media content warning and unblur the image")){
-                                    blur_images = false
-                                }
-                                .buttonStyle(.bordered)
-                                .fontWeight(.bold)
-                                .foregroundStyle(.white)
-                                .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
-                                switch artifacts.media[0] {
-                                case .image(let url), .video(let url):
-                                    Text(abbreviateURL(url).prefix(20))
-                                        .font(eventviewsize_to_font(size, font_size: damus_state.settings.font_size*0.8))
-                                        .foregroundStyle(.white)
-                                        .multilineTextAlignment(.center)
-                                        .padding(EdgeInsets(top: 20, leading: 10, bottom: 5, trailing: 10))
-                                }
-                            }
-                        }
-                        .onTapGesture {
-                            blur_images = false
-                        }
+                        BlurOverlayView(blur_images: $blur_images, artifacts: artifacts, size: size, damus_state: damus_state, parentView: .noteContentView)
                     }
                 }
             }
@@ -468,3 +437,56 @@ func separate_images(ev: NostrEvent, keypair: Keypair) -> [MediaUrl]? {
     return mediaUrls.isEmpty ? nil : mediaUrls
 }
 
+
+struct BlurOverlayView: View {
+    @Binding var blur_images: Bool
+    let artifacts: NoteArtifactsSeparated?
+    let size: EventViewKind?
+    let damus_state: DamusState?
+    let parentView: viewType
+    var body: some View {
+        ZStack {
+            
+            Color.black
+                .opacity(0.54)
+            
+            Blur()
+            
+            VStack(alignment: .center) {
+                Image(systemName: "eye.slash")
+                    .foregroundStyle(.white)
+                    .bold()
+                    .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
+                Text(NSLocalizedString("Media from someone you \n don't follow", comment: "Label on the image blur mask"))
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(Color.white)
+                    .font(.title2)
+                    .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
+                Button(NSLocalizedString("Tap to load", comment: "Label for button that allows user to dismiss media content warning and unblur the image")){
+                    blur_images = false
+                }
+                .buttonStyle(.bordered)
+                .fontWeight(.bold)
+                .foregroundStyle(.white)
+                .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
+                if parentView == .noteContentView,
+                   let artifacts = artifacts,
+                   let size = size,
+                   let damus_state = damus_state
+                    {
+                    switch artifacts.media[0] {
+                    case .image(let url), .video(let url):
+                        Text(abbreviateURL(url).prefix(20))
+                            .font(eventviewsize_to_font(size, font_size: damus_state.settings.font_size*0.8))
+                            .foregroundStyle(.white)
+                            .multilineTextAlignment(.center)
+                            .padding(EdgeInsets(top: 20, leading: 10, bottom: 5, trailing: 10))
+                    }
+                }
+            }
+        }
+        .onTapGesture {
+            blur_images = false
+        }
+    }
+}

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -168,6 +168,9 @@ struct NoteContentView: View {
                         }
                         ZStack {
                             
+                            Color.black
+                                .opacity(0.54)
+                            
                             Blur()
                             
                             VStack(alignment: .center) {
@@ -175,12 +178,12 @@ struct NoteContentView: View {
                                     .foregroundStyle(.white)
                                     .bold()
                                     .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
-                                Text(NSLocalizedString("Media from someone you \n dont follow", comment: "Media from someone you dont follow"))
+                                Text(NSLocalizedString("Media from someone you \n don't follow", comment: "Label on the image blur mask"))
                                     .multilineTextAlignment(.center)
                                     .foregroundStyle(Color.white)
                                     .font(.title2)
                                     .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
-                                Button(NSLocalizedString("Tap to load", comment: "Tap to load")){
+                                Button(NSLocalizedString("Tap to load", comment: "Label for button that allows user to dismiss media content warning and unblur the image")){
                                     blur_images = false
                                 }
                                 .buttonStyle(.bordered)


### PR DESCRIPTION
Changelog-Added: Shows additional information on top of a blurred image
Closes: https://github.com/damus-io/damus/issues/2854
Signed-off-by: SanjaySiddharth <mjsanjaysiddharth1999@gmail.com>

## Summary

PR adds a text overlay on blurred images stating "Non-following user media. Tap to open"
![Simulator Screenshot - iPhone 16 - 2025-03-13 at 21 32 21](https://github.com/user-attachments/assets/45a788c4-b117-4a04-b495-50c199c8766c)


## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.2

**Damus:** 0c148c8a1fc55cd7b598e38306d697f30f3eb96b

**Setup:** Xcode 16.2 from App Store . Install iOS 18.2 simulator runtime

**Steps:** 
1. Build and run Damus
2. Click on profile on top left corner -> settings -> appearance and filters -> images -> make sure the "Blur images" option is turned on.
3. Scroll through the timeline to find any posts with image.
4. Find that the image is blurred and there is a text overlay "Non-following user media. Tap to open"
5. Click on the blurred image to reveal the image.

**Results:**
- [x] PASS
