### PR TITLE
Fix thread parent event loading regression

### DIFF
--- a/damus/Models/ThreadModel.swift
+++ b/damus/Models/ThreadModel.swift
@@ -136,6 +136,16 @@ class ThreadModel: ObservableObject {
 
         event_map.add(event: ev)
         
+        // Add all parent events that we have on EventCache (and subsequently on NostrDB)
+        // This helps ensure we include as many locally-stored notes as possible — even on poor networking conditions
+        damus_state.events.parent_events(event: ev, keypair: damus_state.keypair).forEach {
+            // Note: Nostr threads are cryptographically guaranteeed to be acyclic graphs, which means there is no risk of infinite recursion in this call
+            add_event(
+                $0,  // The `lookup` function in `parent_events` turns the event into an "owned" object, so we do not need to clone here
+                keypair: damus_state.keypair
+            )
+        }
+
         // Publish changes
         objectWillChange.send()
     }

--- a/damus/Models/ThreadModel.swift
+++ b/damus/Models/ThreadModel.swift
@@ -29,7 +29,18 @@ class ThreadModel: ObservableObject {
     ///
     /// This is a computed property because we then don't need to worry about keeping things in sync
     var parent_events: [NostrEvent] {
-        return event_map.parent_events(of: selected_event)
+        // This block of code helps ensure `ThreadEventMap` stays in sync with `EventCache`
+        let parent_events_from_cache = damus_state.events.parent_events(event: selected_event, keypair: damus_state.keypair)
+        for parent_event in parent_events_from_cache {
+            add_event(
+                parent_event,
+                keypair: damus_state.keypair,
+                look_for_parent_events: false,   // We have all parents we need for now
+                publish_changes: false           // Publishing changes during a view render is problematic
+            )
+        }
+        
+        return parent_events_from_cache
     }
     /// All of the direct and indirect replies of `selected_event` in the thread. sorted chronologically
     ///
@@ -125,7 +136,13 @@ class ThreadModel: ObservableObject {
     /// Adds an event to this thread.
     /// Normally this does not need to be called externally because it is the responsibility of this class to load the events, not the view's.
     /// However, this can be called externally for testing purposes (e.g. injecting events for testing)
-    func add_event(_ ev: NostrEvent, keypair: Keypair) {
+    /// 
+    /// - Parameters:
+    ///   - ev: The event to add into the thread event map
+    ///   - keypair: The user's keypair
+    ///   - look_for_parent_events: Whether to search for parent events of the input event in NostrDB
+    ///   - publish_changes: Whether to publish changes at the end
+    func add_event(_ ev: NostrEvent, keypair: Keypair, look_for_parent_events: Bool = true, publish_changes: Bool = true) {
         if event_map.contains(id: ev.id) {
             return
         }
@@ -136,18 +153,22 @@ class ThreadModel: ObservableObject {
 
         event_map.add(event: ev)
         
-        // Add all parent events that we have on EventCache (and subsequently on NostrDB)
-        // This helps ensure we include as many locally-stored notes as possible — even on poor networking conditions
-        damus_state.events.parent_events(event: ev, keypair: damus_state.keypair).forEach {
-            // Note: Nostr threads are cryptographically guaranteeed to be acyclic graphs, which means there is no risk of infinite recursion in this call
-            add_event(
-                $0,  // The `lookup` function in `parent_events` turns the event into an "owned" object, so we do not need to clone here
-                keypair: damus_state.keypair
-            )
+        if look_for_parent_events {
+            // Add all parent events that we have on EventCache (and subsequently on NostrDB)
+            // This helps ensure we include as many locally-stored notes as possible — even on poor networking conditions
+            damus_state.events.parent_events(event: ev, keypair: damus_state.keypair).forEach {
+                add_event(
+                    $0,  // The `lookup` function in `parent_events` turns the event into an "owned" object, so we do not need to clone here
+                    keypair: damus_state.keypair,
+                    look_for_parent_events: false,   // We do not need deep recursion
+                    publish_changes: false           // Do not publish changes multiple times
+                )
+            }
         }
-
-        // Publish changes
-        objectWillChange.send()
+        
+        if publish_changes {
+            objectWillChange.send()
+        }
     }
     
     /// Handles an incoming event from a relay pool


### PR DESCRIPTION
## Summary

This fixes a regression where ThreadModel would no longer look at NostrDB saved notes for parent events, causing some instability on thread loading — especially in poor networking conditions.

This was fixed by adding a call that searches for parent events in EventCache/NostrDB each time an event is added to the ThreadModel.

That `add_event` function is the ideal spot to place the call because it is the only interface used for all information updates incoming to the ThreadModel, including:
- anytime an event is loaded from the network into the thread model.
- when the ThreadModel is first initialized, with an initial event.

Fixes: 74d5bee1f6c4c3807fbdd41458a36dd059c896ad
Changelog-Fixed: Fixed an issue where threads would not load properly

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone SE simulator
**iOS:** 18.2
**Steps:**
1. Navigate through the app (Notes & Replies tab or Notifications tab) and find a reply in a thread that had been loaded before.
2. Turn off the internet connection
3. Navigate to the thread
4. Check if parent events are loaded
    - They should load. If not, the issue is present.

**Results:**
- Damus version 1.13 (0c148c8a1fc55cd7b598e38306d697f30f3eb96b): Parent notes do not load, **ISSUE REPRODUCED**
- Damus version 3bd048d71f9233b7648684a8184bb169d9da1266: Parent notes load, **TEST PASS**
