### PR TITLE
Fixes bug: UI feedback upon copying npub in side menu

### DIFF
--- a/damus/Views/SideMenuView.swift
+++ b/damus/Views/SideMenuView.swift
@@ -162,6 +162,9 @@ struct SideMenuView: View {
                 
                 PubkeyView(pubkey: damus_state.pubkey, sidemenu: true)
                     .pubkey_context_menu(pubkey: damus_state.pubkey)
+                    .simultaneousGesture(TapGesture().onEnded{
+                        isSidebarVisible = true
+                    })
             }
         }
     }


### PR DESCRIPTION
Closes : https://github.com/damus-io/damus/issues/2748
Signed-off-by: SanjaySiddharth <mjsanjaysiddharth1999@gmail.com>

## Summary

Fixes the issue where tapping the copy button next to the npub in the side menu causes the menu to close without providing user feedback.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** iPhone 16 iOS simulator 

**iOS:** 18.2

**Damus:** 0c148c8a1fc55cd7b598e38306d697f30f3eb96b

**Steps:** 
1. Open Damus App
2. Click on the profile icon on top left corner.
3. Click on the 3d box icon next to the npub identifier above the "Profile" menu.

**Results:**
- [x] PASS

