### PR TITLE
Update Kingfisher to 8.3.1

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -6862,7 +6862,7 @@
 			repositoryURL = "https://github.com/onevcat/Kingfisher";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 7.0.0;
+				minimumVersion = 8.3.1;
 			};
 		};
 		4C27C9302A64766F007DBC75 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {

--- a/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/damus.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -49,8 +49,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Kingfisher",
       "state" : {
-        "revision" : "415b1d97fb38bda1e5a6b2dde63354720832110b",
-        "version" : "7.6.1"
+        "revision" : "4c6b067f96953ee19526e49e4189403a2be21fb3",
+        "version" : "8.3.1"
       }
     },
     {

--- a/damus/Util/EventCache.swift
+++ b/damus/Util/EventCache.swift
@@ -354,7 +354,7 @@ func preload_image(url: URL) {
     
     //print("Preloading image \(url.absoluteString)")
 
-    KingfisherManager.shared.retrieveImage(with: Kingfisher.ImageResource(downloadURL: url)) { val in
+    KingfisherManager.shared.retrieveImage(with: Kingfisher.KF.ImageResource(downloadURL: url)) { val in
         //print("Preloaded image \(url.absoluteString)")
     }
 }


### PR DESCRIPTION
## Summary

This updates Kingfisher to 8.3.1, which might fix https://github.com/damus-io/damus/issues/2858 and others.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device + iOS combos:**
- iPhone SE simulator on iOS 18.2
- iPhone 13 mini (real physical device) on iOS 18.3.2

**Damus:** b2fa6a3f33040b1847fee2fb2903b289e3969391

**Steps:**
1. I read the guide at https://github.com/onevcat/Kingfisher/blob/master/Sources/Documentation.docc/MigrationGuide/Migration-To-8.md and followed it where applicable.
2. Briefly glanced at the code diff between Kingfisher 7.0.0 and 8.3.1 to see if I spot any obvious red flags _(I did not check its own downstream dependencies, there would be way too much code to feasibly check)_.
3. Double-checked compiler warnings around code that interacts with Kingfisher.
4. Ran the app navigated through some images, opening them, closing them, clearing the image cache — to see if there are any crashes, Kingfisher-related error logs or otherwise any unexpected behaviour.
5. Checked that clearing image cache will clear up storage space _(clearing cache made storage usage go from 9.07 GB to 7.17 GB)_
6. Checked that loading more images will fill up the cache again _(Loading about 10 other images made the cache go up from 7.17GB to 7.21GB)_
7. Restarted the app and went to the same images, making sure they load faster this time than on step 6.



**Results:**
- [x] PASS
