### PR TITLE
Fix for note block rendering issue in the `nostrdb-update` branch

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -1486,6 +1486,12 @@
 		D74AAFD22B155E78006CF0F4 /* WalletConnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7D09612A098D0E00943473 /* WalletConnect.swift */; };
 		D74AAFD42B155ECB006CF0F4 /* Zaps+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74AAFD32B155ECB006CF0F4 /* Zaps+.swift */; };
 		D74AAFD62B155F0C006CF0F4 /* WalletConnect+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74AAFD52B155F0C006CF0F4 /* WalletConnect+.swift */; };
+		D74DEC8A2DA0A19B00E69FA6 /* Ndb+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74DEC892DA0A19800E69FA6 /* Ndb+.swift */; };
+		D74DEC8B2DA0A19B00E69FA6 /* Ndb+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74DEC892DA0A19800E69FA6 /* Ndb+.swift */; };
+		D74DEC8C2DA0A19B00E69FA6 /* Ndb+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74DEC892DA0A19800E69FA6 /* Ndb+.swift */; };
+		D74DEC8F2DA0C65F00E69FA6 /* Ndb+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74DEC892DA0A19800E69FA6 /* Ndb+.swift */; };
+		D74DEC902DA0C6B500E69FA6 /* NostrFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C75EFAE28049D340006080F /* NostrFilter.swift */; };
+		D74DEC912DA0CA2400E69FA6 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72E12772BEED22400F4F781 /* Array.swift */; };
 		D74EA08A2D2BF2A7002290DD /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767066E2C8BB3CE00F09726 /* URLHandler.swift */; };
 		D74EA08E2D2E271E002290DD /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74EA08D2D2E271E002290DD /* ErrorView.swift */; };
 		D74EA08F2D2E271E002290DD /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74EA08D2D2E271E002290DD /* ErrorView.swift */; };
@@ -1668,6 +1674,10 @@
 		D7F360262CEBBD8B009D34DA /* PresentFullScreenItemNotify.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EB00AF2CD59C8300660C07 /* PresentFullScreenItemNotify.swift */; };
 		D7F360272CEBBDC0009D34DA /* DamusVideoControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EFBA362CC322F300F45588 /* DamusVideoControlsView.swift */; };
 		D7F360292CEBBE34009D34DA /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = D7F360282CEBBE34009D34DA /* CodeScanner */; };
+		D7F563102DEE71C0008509DE /* NdbFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F5630F2DEE71BB008509DE /* NdbFilter.swift */; };
+		D7F563112DEE71C0008509DE /* NdbFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F5630F2DEE71BB008509DE /* NdbFilter.swift */; };
+		D7F563122DEE71C0008509DE /* NdbFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F5630F2DEE71BB008509DE /* NdbFilter.swift */; };
+		D7F563132DEE71C0008509DE /* NdbFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7F5630F2DEE71BB008509DE /* NdbFilter.swift */; };
 		D7FB10A72B0C371A00FA8D42 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2B10272A7B0F5C008AA43E /* Log.swift */; };
 		D7FB14222BE5970000398331 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D7FB14212BE5970000398331 /* PrivacyInfo.xcprivacy */; };
 		D7FB14252BE5A9A800398331 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D7FB14242BE5A9A800398331 /* PrivacyInfo.xcprivacy */; };
@@ -2483,6 +2493,7 @@
 		D74AAFCE2B155D8C006CF0F4 /* ZapDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZapDataModel.swift; sourceTree = "<group>"; };
 		D74AAFD32B155ECB006CF0F4 /* Zaps+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Zaps+.swift"; sourceTree = "<group>"; };
 		D74AAFD52B155F0C006CF0F4 /* WalletConnect+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletConnect+.swift"; sourceTree = "<group>"; };
+		D74DEC892DA0A19800E69FA6 /* Ndb+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Ndb+.swift"; sourceTree = "<group>"; };
 		D74EA08D2D2E271E002290DD /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		D74EA0922D2E77B9002290DD /* LoadableThreadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableThreadView.swift; sourceTree = "<group>"; };
 		D74F43092B23F0BE00425B75 /* DamusPurple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DamusPurple.swift; sourceTree = "<group>"; };
@@ -2537,6 +2548,7 @@
 		D7EDED2D2B128E8A0018B19C /* CollectionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionExtension.swift; sourceTree = "<group>"; };
 		D7EDED322B12ACAE0018B19C /* DamusUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DamusUserDefaults.swift; sourceTree = "<group>"; };
 		D7EFBA362CC322F300F45588 /* DamusVideoControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DamusVideoControlsView.swift; sourceTree = "<group>"; };
+		D7F5630F2DEE71BB008509DE /* NdbFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NdbFilter.swift; sourceTree = "<group>"; };
 		D7FB14212BE5970000398331 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D7FB14242BE5A9A800398331 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D7FD12252BD345A700CF195B /* FirstAidSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstAidSettingsView.swift; sourceTree = "<group>"; };
@@ -3240,6 +3252,8 @@
 		4C9054862A6AEB4500811EEC /* nostrdb */ = {
 			isa = PBXGroup;
 			children = (
+				D7F5630F2DEE71BB008509DE /* NdbFilter.swift */,
+				D74DEC892DA0A19800E69FA6 /* Ndb+.swift */,
 				4CC6A9F92CAB688500989CEF /* ccan */,
 				4C15224A2B8D499F007CDC17 /* parser.h */,
 				4CF47FDC2B631C0100F2B2C0 /* src */,
@@ -4651,6 +4665,7 @@
 				4CDD1AE22A6B3074001CD4DF /* NdbTagsIterator.swift in Sources */,
 				4C216F34286F5ACD00040376 /* DMView.swift in Sources */,
 				D7CB5D512B1174D100AD4105 /* FriendFilter.swift in Sources */,
+				D74DEC8C2DA0A19B00E69FA6 /* Ndb+.swift in Sources */,
 				D7CBD1D42B8D21DC00BFD889 /* DamusPurpleNotificationManagement.swift in Sources */,
 				4C32B9572A9AD44700DC3548 /* Root.swift in Sources */,
 				504323A72A34915F006AE6DC /* RelayModel.swift in Sources */,
@@ -4930,6 +4945,7 @@
 				4C5E54032A9522F600FF6E60 /* UserStatus.swift in Sources */,
 				4C7D095F2A098C5D00943473 /* ConnectWalletView.swift in Sources */,
 				3AA24802297E3DC20090C62D /* RepostView.swift in Sources */,
+				D7F563122DEE71C0008509DE /* NdbFilter.swift in Sources */,
 				5C6E1DAF2A194075008FC15A /* PinkGradient.swift in Sources */,
 				4CD7641B28A1641400B6928F /* EndBlock.swift in Sources */,
 				4C198DEF29F88C6B004C165C /* BlurHashEncode.swift in Sources */,
@@ -5405,6 +5421,7 @@
 				82D6FB7E2CD99F7900C925F4 /* Mentions.swift in Sources */,
 				82D6FB7F2CD99F7900C925F4 /* ProfileUpdate.swift in Sources */,
 				82D6FB802CD99F7900C925F4 /* Post.swift in Sources */,
+				D7F563132DEE71C0008509DE /* NdbFilter.swift in Sources */,
 				82D6FB812CD99F7900C925F4 /* PostBlock.swift in Sources */,
 				82D6FB822CD99F7900C925F4 /* Reply.swift in Sources */,
 				82D6FB832CD99F7900C925F4 /* SearchModel.swift in Sources */,
@@ -5516,6 +5533,7 @@
 				82D6FBEF2CD99F7900C925F4 /* MarketingContentView.swift in Sources */,
 				82D6FBF02CD99F7900C925F4 /* LogoView.swift in Sources */,
 				82D6FBF12CD99F7900C925F4 /* IAPProductStateView.swift in Sources */,
+				D74DEC8B2DA0A19B00E69FA6 /* Ndb+.swift in Sources */,
 				82D6FBF22CD99F7900C925F4 /* PurpleBackdrop.swift in Sources */,
 				82D6FBF32CD99F7900C925F4 /* DamusPurpleView.swift in Sources */,
 				82D6FBF42CD99F7900C925F4 /* DamusPurpleWelcomeView.swift in Sources */,
@@ -5800,6 +5818,7 @@
 				D73E5E952C6A97F4007EB227 /* ThreadModel.swift in Sources */,
 				D73E5E962C6A97F4007EB227 /* ReplyMap.swift in Sources */,
 				D73E5E972C6A97F4007EB227 /* ProfileModel.swift in Sources */,
+				D74DEC8A2DA0A19B00E69FA6 /* Ndb+.swift in Sources */,
 				D73E5E982C6A97F4007EB227 /* ActionBarModel.swift in Sources */,
 				D73E5E992C6A97F4007EB227 /* Liked.swift in Sources */,
 				D73E5E9A2C6A97F4007EB227 /* ProfileUpdate.swift in Sources */,
@@ -5822,6 +5841,7 @@
 				4CC6A9FA2CAB688500989CEF /* str.c in Sources */,
 				4CC6A9FB2CAB688500989CEF /* tal.c in Sources */,
 				4CC6A9FD2CAB688500989CEF /* mem.c in Sources */,
+				D7F563102DEE71C0008509DE /* NdbFilter.swift in Sources */,
 				4CC6A9FE2CAB688500989CEF /* sha256.c in Sources */,
 				4CC6AA002CAB688500989CEF /* likely.c in Sources */,
 				4CC6AA042CAB688500989CEF /* htable.c in Sources */,
@@ -6170,6 +6190,7 @@
 				4CBB6F682B72B5F0000477A4 /* NdbProfile.swift in Sources */,
 				4CBB6F672B72B5E8000477A4 /* NdbBlock.swift in Sources */,
 				4CBB6F662B72B5DD000477A4 /* NdbBlocksIterator.swift in Sources */,
+				D74DEC8F2DA0C65F00E69FA6 /* Ndb+.swift in Sources */,
 				D798D21F2B0858D600234419 /* MigratedTypes.swift in Sources */,
 				D7CE1B472B0BE719002EDAD4 /* NativeObject.swift in Sources */,
 				D71AD9002CEC176A002E2C3C /* AppAccessibilityIdentifiers.swift in Sources */,
@@ -6194,6 +6215,7 @@
 				D7B76C902C825042003A16CB /* PushNotificationClient.swift in Sources */,
 				D7CE1B432B0BE719002EDAD4 /* String+extension.swift in Sources */,
 				D7CB5D3F2B116DAD00AD4105 /* NotificationsManager.swift in Sources */,
+				D74DEC912DA0CA2400E69FA6 /* Array.swift in Sources */,
 				D7CB5D602B11770C00AD4105 /* FollowState.swift in Sources */,
 				D7CB5D402B116E8A00AD4105 /* UserSettingsStore.swift in Sources */,
 				D7CE1B1C2B0BE147002EDAD4 /* refmap.c in Sources */,
@@ -6213,6 +6235,7 @@
 				D7CB5D522B1174D100AD4105 /* FriendFilter.swift in Sources */,
 				D7CE1B362B0BE702002EDAD4 /* FbConstants.swift in Sources */,
 				D74AAFD12B155DA4006CF0F4 /* RelayURL.swift in Sources */,
+				D74DEC902DA0C6B500E69FA6 /* NostrFilter.swift in Sources */,
 				D7EDED272B117FF10018B19C /* CompatibleAttribute.swift in Sources */,
 				D74AAFCD2B155D07006CF0F4 /* MakeZapRequest.swift in Sources */,
 				D7CCFC072B05833200323D86 /* NdbNote.swift in Sources */,
@@ -6222,6 +6245,7 @@
 				D7EDED222B117DCA0018B19C /* SequenceUtils.swift in Sources */,
 				D7CE1B422B0BE719002EDAD4 /* Offset.swift in Sources */,
 				D7FB10A72B0C371A00FA8D42 /* Log.swift in Sources */,
+				D7F563112DEE71C0008509DE /* NdbFilter.swift in Sources */,
 				D7CE1B182B0BDFDD002EDAD4 /* mdb.c in Sources */,
 				D7CCFC162B05894300323D86 /* Pubkey.swift in Sources */,
 				D7EDED2C2B128CFA0018B19C /* DamusColors.swift in Sources */,

--- a/damus.xcodeproj/xcshareddata/xcschemes/damus.xcscheme
+++ b/damus.xcodeproj/xcshareddata/xcschemes/damus.xcscheme
@@ -55,6 +55,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/damus/Models/NoteContent.swift
+++ b/damus/Models/NoteContent.swift
@@ -66,7 +66,7 @@ func note_artifact_is_separated(kind: NostrKind?) -> Bool {
     return kind != .longform
 }
 
-func render_note_content(ndb: Ndb, ev: NostrEvent, profiles: Profiles, keypair: Keypair) -> NoteArtifacts {
+func render_immediately_available_note_content(ndb: Ndb, ev: NostrEvent, profiles: Profiles, keypair: Keypair) -> NoteArtifacts {
     guard let blocks = ev.blocks(ndb: ndb) else {
         return .separated(.just_content(ev.get_content(keypair)))
     }
@@ -76,6 +76,15 @@ func render_note_content(ndb: Ndb, ev: NostrEvent, profiles: Profiles, keypair: 
     }
     
     return .separated(render_blocks(blocks: blocks.unsafeUnownedValue, profiles: profiles, note: ev))
+}
+
+actor ContentRenderer {
+    func render_note_content(ndb: Ndb, ev: NostrEvent, profiles: Profiles, keypair: Keypair) async -> NoteArtifacts {
+        guard let result = try? await ndb.waitFor(noteId: ev.id, timeout: 10) else {
+            return .separated(.just_content(ev.get_content(keypair)))
+        }
+        return render_immediately_available_note_content(ndb: ndb, ev: ev, profiles: profiles, keypair: keypair)
+    }
 }
 
 func render_blocks(blocks: NdbBlocks, profiles: Profiles, note: NdbNote) -> NoteArtifactsSeparated {

--- a/damus/Models/NotificationsManager.swift
+++ b/damus/Models/NotificationsManager.swift
@@ -138,7 +138,7 @@ func create_local_notification(profiles: Profiles, notify: LocalNotification) {
 func render_notification_content_preview(ndb: Ndb, ev: NostrEvent, profiles: Profiles, keypair: Keypair) -> String {
 
     let prefix_len = 300
-    let artifacts = render_note_content(ndb: ndb, ev: ev, profiles: profiles, keypair: keypair)
+    let artifacts = render_immediately_available_note_content(ndb: ndb, ev: ev, profiles: profiles, keypair: keypair)
 
     // special case for longform events
     if ev.known_kind == .longform {

--- a/damus/Types/Ids/NoteId.swift
+++ b/damus/Types/Ids/NoteId.swift
@@ -51,4 +51,15 @@ struct NoteId: IdType, TagKey, TagConvertible {
 
         return note_id
     }
+    
+    func withUnsafePointer<T>(_ body: (UnsafePointer<UInt8>) throws -> T) rethrows -> T {
+        return try self.id.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+            guard let baseAddress = bytes.baseAddress else {
+                fatalError("Cannot get base address")
+            }
+            return try baseAddress.withMemoryRebound(to: UInt8.self, capacity: bytes.count) { ptr in
+                return try body(ptr)
+            }
+        }
+    }
 }

--- a/damus/Types/Ids/Pubkey.swift
+++ b/damus/Types/Ids/Pubkey.swift
@@ -44,5 +44,15 @@ struct Pubkey: IdType, TagKey, TagConvertible, Identifiable {
         return pubkey
     }
     
+    func withUnsafePointer<T>(_ body: (UnsafePointer<UInt8>) throws -> T) rethrows -> T {
+        return try self.id.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) in
+            guard let baseAddress = bytes.baseAddress else {
+                fatalError("Cannot get base address")
+            }
+            return try baseAddress.withMemoryRebound(to: UInt8.self, capacity: bytes.count) { ptr in
+                return try body(ptr)
+            }
+        }
+    }
 }
 

--- a/damus/Util/EventCache.swift
+++ b/damus/Util/EventCache.swift
@@ -376,7 +376,7 @@ func preload_event(plan: PreloadPlan, state: DamusState) async {
     //print("Preloading event \(plan.event.content)")
 
     if artifacts == nil && plan.load_artifacts {
-        let arts = render_note_content(ndb: state.ndb, ev: plan.event, profiles: profiles, keypair: our_keypair)
+        let arts = await ContentRenderer().render_note_content(ndb: state.ndb, ev: plan.event, profiles: profiles, keypair: our_keypair)
         artifacts = arts
         
         // we need these asap
@@ -397,7 +397,13 @@ func preload_event(plan: PreloadPlan, state: DamusState) async {
     }
     
     if plan.load_preview, note_artifact_is_separated(kind: plan.event.known_kind) {
-        let arts = artifacts ?? render_note_content(ndb: state.ndb, ev: plan.event, profiles: profiles, keypair: our_keypair)
+        let arts: NoteArtifacts
+        if let artifacts {
+            arts = artifacts
+        }
+        else {
+            arts = await ContentRenderer().render_note_content(ndb: state.ndb, ev: plan.event, profiles: profiles, keypair: our_keypair)
+        }
 
         // only separated artifacts have previews
         if case .separated(let sep) = arts {

--- a/damus/Util/Log.swift
+++ b/damus/Util/Log.swift
@@ -19,6 +19,7 @@ enum LogCategory: String {
     case damus_purple
     case image_uploading
     case video_coordination
+    case ndb
 }
 
 /// Damus structured logger

--- a/damus/Views/Events/Longform/LongformView.swift
+++ b/damus/Views/Events/Longform/LongformView.swift
@@ -48,7 +48,7 @@ let test_longform_event = LongformEvent.parse(from: NostrEvent(
 struct LongformView_Previews: PreviewProvider {
     static var previews: some View {
         let st = test_damus_state
-        let artifacts = render_note_content(ndb: st.ndb, ev: test_longform_event.event, profiles: st.profiles, keypair: Keypair(pubkey: .empty, privkey: nil))
+        let artifacts = render_immediately_available_note_content(ndb: st.ndb, ev: test_longform_event.event, profiles: st.profiles, keypair: Keypair(pubkey: .empty, privkey: nil))
 
         let model = NoteArtifactsModel(state: .loaded(artifacts))
         ScrollView {

--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -270,7 +270,7 @@ struct NoteContentView: View {
                 }
                 await preload_event(plan: plan, state: damus_state)
             } else if force_artifacts {
-                let arts = render_note_content(ndb: damus_state.ndb, ev: event, profiles: damus_state.profiles, keypair: damus_state.keypair)
+                let arts = await ContentRenderer().render_note_content(ndb: damus_state.ndb, ev: event, profiles: damus_state.profiles, keypair: damus_state.keypair)
                 self.artifacts_model.state = .loaded(arts)
             }
         }

--- a/nostrdb/Ndb+.swift
+++ b/nostrdb/Ndb+.swift
@@ -1,0 +1,30 @@
+//
+//  Ndb+.swift
+//  damus
+//
+//  Created by Daniel D’Aquino on 2025-04-04.
+//
+
+/// ## Implementation notes
+///
+/// 1. This was created as a separate file because it contains dependencies to damus-specific structures such as `NostrFilter`, which is not yet available inside the NostrDB codebase.
+
+import Foundation
+
+extension Ndb {
+    /// Subscribe to events matching the provided NostrFilters
+    /// - Parameters:
+    ///   - filters: Array of NostrFilter objects
+    ///   - maxSimultaneousResults: Maximum number of initial results to return
+    /// - Returns: AsyncStream of StreamItem events
+    /// - Throws: NdbStreamError if subscription fails
+    func subscribe(filters: [NostrFilter], maxSimultaneousResults: Int = 1000) throws(NdbStreamError) -> AsyncStream<StreamItem> {
+        let ndbFilters: [NdbFilter]
+        do {
+            ndbFilters = try filters.toNdbFilters()
+        } catch {
+            throw .cannotConvertFilter(error)
+        }
+        return try self.subscribe(filters: ndbFilters, maxSimultaneousResults: maxSimultaneousResults)
+    }
+}

--- a/nostrdb/NdbFilter.swift
+++ b/nostrdb/NdbFilter.swift
@@ -1,0 +1,356 @@
+//
+//  NdbFilter.swift
+//  damus
+//
+//  Created by Daniel D'Aquino on 2025-06-02.
+//
+
+import Foundation
+
+/// A safe Swift wrapper around `UnsafeMutablePointer<ndb_filter>` that manages memory automatically.
+///
+/// This class provides a safe interface to the underlying C `ndb_filter` structure, handling
+/// memory allocation and deallocation automatically. It eliminates the need for manual memory
+/// management when working with NostrDB filters.
+///
+/// ## Usage
+/// ```swift
+/// let nostrFilter = NostrFilter(kinds: [.text_note])
+/// let ndbFilter = try NdbFilter(from: nostrFilter)
+/// // Use ndbFilter.ndbFilter or ndbFilter.unsafePointer as needed
+/// // Memory is automatically cleaned up when ndbFilter goes out of scope
+/// ```
+class NdbFilter {
+    private let filterPointer: UnsafeMutablePointer<ndb_filter>
+    
+    /// Creates a new NdbFilter from a NostrFilter.
+    /// - Parameter nostrFilter: The NostrFilter to convert
+    /// - Throws: `NdbFilterError.conversionFailed` if the underlying conversion fails
+    init(from nostrFilter: NostrFilter) throws {
+        do {
+            self.filterPointer = try Self.from(nostrFilter: nostrFilter)
+        } catch {
+            throw NdbFilterError.conversionFailed(error)
+        }
+    }
+    
+    /// Provides access to the underlying `ndb_filter` structure.
+    /// - Returns: The underlying `ndb_filter` value (not a pointer)
+    var ndbFilter: ndb_filter {
+        return filterPointer.pointee
+    }
+    
+    /// Provides access to the underlying unsafe pointer when needed for C interop.
+    /// - Warning: The caller must not deallocate this pointer. It will be automatically 
+    ///           deallocated when this NdbFilter is destroyed.
+    /// - Returns: The unsafe mutable pointer to the underlying ndb_filter
+    var unsafePointer: UnsafeMutablePointer<ndb_filter> {
+        return filterPointer
+    }
+    
+    /// Creates multiple NdbFilter instances from an array of NostrFilters.
+    /// - Parameter nostrFilters: Array of NostrFilter instances to convert
+    /// - Returns: Array of NdbFilter instances
+    /// - Throws: `NdbFilterError.conversionFailed` if any conversion fails
+    static func create(from nostrFilters: [NostrFilter]) throws -> [NdbFilter] {
+        return try nostrFilters.map { try NdbFilter(from: $0) }
+    }
+    
+    // MARK: - Conversion to/from ndb_filter
+    
+    // TODO: This function is long and repetitive, refactor it into something cleaner.
+    private static func from(nostrFilter: NostrFilter) throws(NdbFilterConversionError) -> UnsafeMutablePointer<ndb_filter> {
+        let filterPointer = UnsafeMutablePointer<ndb_filter>.allocate(capacity: 1)
+
+        guard ndb_filter_init(filterPointer) == 1 else {
+            filterPointer.deallocate()
+            throw NdbFilterConversionError.failedToInitialize
+        }
+        
+        // Handle `ids` field
+        if let ids = nostrFilter.ids {
+            guard ndb_filter_start_field(filterPointer, NDB_FILTER_IDS) == 1 else {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToStartField
+            }
+            
+            for noteId in ids {
+                do {
+                    try noteId.withUnsafePointer({ idPointer in
+                        if ndb_filter_add_id_element(filterPointer, idPointer) != 1 {
+                            ndb_filter_destroy(filterPointer)
+                            filterPointer.deallocate()
+                            throw NdbFilterConversionError.failedToAddElement
+                        }
+                    })
+                }
+                catch {
+                    ndb_filter_destroy(filterPointer)
+                    filterPointer.deallocate()
+                    throw NdbFilterConversionError.failedToAddElement
+                }
+            }
+            
+            ndb_filter_end_field(filterPointer)
+        }
+        
+        // Handle `kinds` field
+        if let kinds = nostrFilter.kinds {
+            guard ndb_filter_start_field(filterPointer, NDB_FILTER_KINDS) == 1 else {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToStartField
+            }
+            
+            for kind in kinds {
+                if ndb_filter_add_int_element(filterPointer, UInt64(kind.rawValue)) != 1 {
+                    ndb_filter_destroy(filterPointer)
+                    filterPointer.deallocate()
+                    throw NdbFilterConversionError.failedToAddElement
+                }
+            }
+            
+            ndb_filter_end_field(filterPointer)
+        }
+        
+        // Handle `referenced_ids` field
+        if let referencedIds = nostrFilter.referenced_ids {
+            guard ndb_filter_start_tag_field(filterPointer, CChar(UnicodeScalar("e").value)) == 1 else {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToStartField
+            }
+            
+            for refId in referencedIds {
+                do {
+                    try refId.withUnsafePointer({ refPointer in
+                        if ndb_filter_add_id_element(filterPointer, refPointer) != 1 {
+                            ndb_filter_destroy(filterPointer)
+                            filterPointer.deallocate()
+                            throw NdbFilterConversionError.failedToAddElement
+                        }
+                    })
+                }
+                catch {
+                    ndb_filter_destroy(filterPointer)
+                    filterPointer.deallocate()
+                    throw NdbFilterConversionError.failedToAddElement
+                }
+            }
+            
+            ndb_filter_end_field(filterPointer)
+        }
+
+        // Handle `pubkeys`
+        if let pubkeys = nostrFilter.pubkeys {
+            guard ndb_filter_start_tag_field(filterPointer, CChar(UnicodeScalar("p").value)) == 1 else {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToStartField
+            }
+
+            for pubkey in pubkeys {
+                do {
+                    try pubkey.withUnsafePointer({ pubkeyPointer in
+                        if ndb_filter_add_id_element(filterPointer, pubkeyPointer) != 1 {
+                            ndb_filter_destroy(filterPointer)
+                            filterPointer.deallocate()
+                            throw NdbFilterConversionError.failedToAddElement
+                        }
+                    })
+                }
+                catch {
+                    ndb_filter_destroy(filterPointer)
+                    filterPointer.deallocate()
+                    throw NdbFilterConversionError.failedToAddElement
+                }
+            }
+            
+            ndb_filter_end_field(filterPointer)
+        }
+        
+        // Handle `since`
+        if let since = nostrFilter.since {
+            if ndb_filter_start_field(filterPointer, NDB_FILTER_SINCE) != 1 {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToAddElement
+            }
+            
+            if ndb_filter_add_int_element(filterPointer, UInt64(since)) != 1 {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToAddElement
+            }
+            
+            ndb_filter_end_field(filterPointer)
+        }
+
+        // Handle `until`
+        if let until = nostrFilter.until {
+            if ndb_filter_start_field(filterPointer, NDB_FILTER_UNTIL) != 1 {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToAddElement
+            }
+            
+            if ndb_filter_add_int_element(filterPointer, UInt64(until)) != 1 {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToAddElement
+            }
+            
+            ndb_filter_end_field(filterPointer)
+        }
+
+        // Handle `limit`
+        if let limit = nostrFilter.limit {
+            if ndb_filter_start_field(filterPointer, NDB_FILTER_LIMIT) != 1 {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToAddElement
+            }
+            
+            if ndb_filter_add_int_element(filterPointer, UInt64(limit)) != 1 {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToAddElement
+            }
+            
+            ndb_filter_end_field(filterPointer)
+        }
+        
+        // Handle `authors`
+        if let authors = nostrFilter.authors {
+            guard ndb_filter_start_field(filterPointer, NDB_FILTER_AUTHORS) == 1 else {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToStartField
+            }
+
+            for author in authors {
+                do {
+                    try author.withUnsafePointer({ authorPointer in
+                        if ndb_filter_add_id_element(filterPointer, authorPointer) != 1 {
+                            ndb_filter_destroy(filterPointer)
+                            filterPointer.deallocate()
+                            throw NdbFilterConversionError.failedToAddElement
+                        }
+                    })
+                }
+                catch {
+                    ndb_filter_destroy(filterPointer)
+                    filterPointer.deallocate()
+                    throw NdbFilterConversionError.failedToAddElement
+                }
+                
+            }
+            
+            ndb_filter_end_field(filterPointer)
+        }
+        
+        // Handle `hashtag`
+        if let hashtags = nostrFilter.hashtag {
+            guard ndb_filter_start_tag_field(filterPointer, CChar(UnicodeScalar("t").value)) == 1 else {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToStartField
+            }
+
+            for tag in hashtags {
+                if ndb_filter_add_str_element(filterPointer, tag.cString(using: .utf8)) != 1 {
+                    ndb_filter_destroy(filterPointer)
+                    filterPointer.deallocate()
+                    throw NdbFilterConversionError.failedToAddElement
+                }
+            }
+            ndb_filter_end_field(filterPointer)
+        }
+        
+        // Handle `parameter`
+        if let parameters = nostrFilter.parameter {
+            guard ndb_filter_start_tag_field(filterPointer, CChar(UnicodeScalar("d").value)) == 1 else {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToStartField
+            }
+
+            for parameter in parameters {
+                if ndb_filter_add_str_element(filterPointer, parameter.cString(using: .utf8)) != 1 {
+                    ndb_filter_destroy(filterPointer)
+                    filterPointer.deallocate()
+                    throw NdbFilterConversionError.failedToAddElement
+                }
+            }
+            ndb_filter_end_field(filterPointer)
+        }
+
+        // Handle `quotes`
+        if let quotes = nostrFilter.quotes {
+            guard ndb_filter_start_tag_field(filterPointer, CChar(UnicodeScalar("q").value)) == 1 else {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToStartField
+            }
+            
+            for quote in quotes {
+                do {
+                    try quote.withUnsafePointer({ quotePointer in
+                        if ndb_filter_add_id_element(filterPointer, quotePointer) != 1 {
+                            ndb_filter_destroy(filterPointer)
+                            filterPointer.deallocate()
+                            throw NdbFilterConversionError.failedToAddElement
+                        }
+                    })
+                }
+                catch {
+                    ndb_filter_destroy(filterPointer)
+                    filterPointer.deallocate()
+                    throw NdbFilterConversionError.failedToAddElement
+                }
+                
+            }
+            
+            ndb_filter_end_field(filterPointer)
+        }
+
+        // Finalize the filter
+        guard ndb_filter_end(filterPointer) == 1 else {
+            ndb_filter_destroy(filterPointer)
+            filterPointer.deallocate()
+            throw NdbFilterConversionError.failedToFinalize
+        }
+
+        return filterPointer
+    }
+
+    enum NdbFilterConversionError: Error {
+        case failedToInitialize
+        case failedToStartField
+        case failedToAddElement
+        case failedToFinalize
+    }
+    
+    deinit {
+        ndb_filter_destroy(filterPointer)
+        filterPointer.deallocate()
+    }
+}
+
+/// Errors that can occur when working with NdbFilter.
+enum NdbFilterError: Error {
+    /// Thrown when conversion from NostrFilter to NdbFilter fails.
+    /// - Parameter Error: The underlying error that caused the conversion to fail
+    case conversionFailed(Error)
+}
+
+/// Extension to create multiple NdbFilters safely from an array of NostrFilters.
+extension Array where Element == NostrFilter {
+    /// Converts an array of NostrFilters to NdbFilters.
+    /// - Returns: Array of NdbFilter instances
+    /// - Throws: `NdbFilterError.conversionFailed` if any conversion fails
+    func toNdbFilters() throws -> [NdbFilter] {
+        return try self.map { try NdbFilter(from: $0) }
+    }
+}

--- a/nostrdb/src/nostrdb.c
+++ b/nostrdb/src/nostrdb.c
@@ -7095,7 +7095,7 @@ static struct ndb_blocks *ndb_note_to_blocks(struct ndb_note *note)
 	if (content_len >= INT32_MAX)
 		return NULL;
 
-	unsigned char *buffer = malloc(content_len);
+    unsigned char *buffer = malloc(2<<18);  // Not carefully calculated, but ok because we will not need this once we switch to the local relay model
 	if (!buffer)
 		return NULL;
 


### PR DESCRIPTION
## Summary

On the new nostrdb update branch, the note blocks are sometimes not immediately available, causing issues with content rendering — since we have not switched to the local relay model yet.

This PR implements a mechanism that attempts to wait for ndb block parsing to "hydrate" content properly.

To make this possible, mechanisms for querying and subscribing to NostrDB notes using `NostrFilters` were created. This also advances the local relay model support.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

### Functional test

**Device:** iPhone SE simulator

**iOS:** 18.2

**Damus:** 54e044ad1b6b96a0a272276332c9dde4f02f830e

**Setup:** Running the on the `damus` configuration with address sanitizer enabled

**Steps:**
1. Scroll down the home timeline for at least 5 minutes
2. Go to different threads, notification tabs, DM tabs, etc
3. Ensure notes render as expected, and that there are no crashes.

**Results:**
- [x] PASS

**Test notes:**
- The DMs are failing to decrypt for some reason (I already ensured to be logged in using an nsec). However, this also happens on the commit before these changes, so the issue is not caused by these changes.

### Performance test

**Device:** iPhone 13 Mini

**iOS:** 18.5

**Damus:** 54e044ad1b6b96a0a272276332c9dde4f02f830e

**Setup:** Running the on the `release` configuration without debugger attached

**Baseline comparison:** Damus 1.14 (959)

**Steps:**
1. Scroll down the home timeline for a bit
2. Try to feel hangs on the app's performance

**Results:** **PASS**
- Performance feels the same as the baseline 1.14 (959). There are a few hiccups in the first second after cold-initializing the app, and then scrolling feels mostly smooth with some occasional minor hiccups.

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_
