### PR TITLE
Hide future notes from timeline

### DIFF
--- a/damus/Models/ContentFilters.swift
+++ b/damus/Models/ContentFilters.swift
@@ -40,6 +40,12 @@ func get_repost_of_muted_user_filter(damus_state: DamusState) -> ((_ ev: NostrEv
     }
 }
 
+func timestamp_filter(ev: NostrEvent) -> Bool {
+    // Allow notes that are created no more than 3 seconds in the future
+    // to account for natural clock skew between sender and receiver.
+    ev.age >= -3
+}
+
 /// Generic filter with various tweakable settings
 struct ContentFilters {
     var filters: [(NostrEvent) -> Bool]
@@ -66,6 +72,7 @@ extension ContentFilters {
             filters.append(nsfw_tag_filter)
         }
         filters.append(get_repost_of_muted_user_filter(damus_state: damus_state))
+        filters.append(timestamp_filter)
         return filters
     }
 }

--- a/damus/Models/NotificationsManager.swift
+++ b/damus/Models/NotificationsManager.swift
@@ -54,7 +54,14 @@ func should_display_notification(state: HeadlessDamusState, event ev: NostrEvent
     guard ev.age < EVENT_MAX_AGE_FOR_NOTIFICATION else {
         return false
     }
-    
+
+    // Don't show notifications for future events.
+    // Allow notes that are created no more than 3 seconds in the future
+    // to account for natural clock skew between sender and receiver.
+    guard ev.age >= -3 else {
+        return false
+    }
+
     return true
 }
 

--- a/damus/Views/Notifications/NotificationsView.swift
+++ b/damus/Views/Notifications/NotificationsView.swift
@@ -41,7 +41,10 @@ class NotificationFilter: ObservableObject, Equatable {
 
             if let item = item.filter({ ev in
                 self.friend_filter.filter(contacts: contacts, pubkey: ev.pubkey) &&
-                (!hellthread_notifications_disabled || !ev.is_hellthread(max_pubkeys: hellthread_notification_max_pubkeys))
+                (!hellthread_notifications_disabled || !ev.is_hellthread(max_pubkeys: hellthread_notification_max_pubkeys)) &&
+                // Allow notes that are created no more than 3 seconds in the future
+                // to account for natural clock skew between sender and receiver.
+                ev.age >= -3
             }) {
                 acc.append(item)
             }


### PR DESCRIPTION
## Summary

The `created_at` timestamp can be any value in the future as it can not be verified to be correct / the actual time the author posted. If someone does this, this note gets pinned at the top of the timeline in perpetuity until the system clock surpasses that timestamp and other notes get pulled in. This could be considered a malicious attack (or other users have a clock skew problem).

This change defensively filters out future notes from the timeline until the system clock has actually surpassed the `created_at` timestamp.

Closes: https://github.com/damus-io/damus/issues/2949
Related: https://github.com/damus-io/notepush/pull/17

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.4

**Damus:** 2f875abe118a9bc70336aa4fc79eebc50c24393f

**Setup:** Settings > General > Date & Time > Toggle off `Set Automatically` > Set current time to 2 or more minutes into the future (or whatever amount of time you need to run through the test steps)

**Steps:**
1. Build and run Damus on the `master` branch.
2. Follow the setup steps above to change the system clock.
3. Switch to Damus and post a note.
4. Reverse the setup steps to change the system clock back to be set automatically.
5. Switch to Damus and observe that the note is pinned at the top of the timeline (home, profile, etc)
6. Observe that the note is pinned at the top of the timeline.
7. Tap on the note to verify that the timestamp is indeed the future.
8. Checkout the HEAD of this branch, and build and run Damus.
9. Observe that the note from (3) is no longer shown on the timeline.
10. Wait until the system clock naturally passes that timestamp.
11. When a new note comes in or if you refresh the timeline (by switching away and coming back), the note from (3) will appear.

**Results:**
- [x] PASS