### PR TITLE
Clean up code in ProfileName.name_choice

### DIFF
--- a/damus/Views/Profile/ProfileName.swift
+++ b/damus/Views/Profile/ProfileName.swift
@@ -67,7 +67,9 @@ struct ProfileName: View {
     }
     
     func name_choice(profile: Profile?) -> String {
-        return prefix == "@" ? current_display_name(profile: profile).username.truncate(maxLength: 50) : current_display_name(profile: profile).displayName.truncate(maxLength: 50)
+        let displayName = current_display_name(profile: profile)
+        let untruncatedName = prefix == "@" ? displayName.username : displayName.displayName
+        return untruncatedName.truncate(maxLength: 50)
     }
     
     func onlyzapper(profile: Profile?) -> Bool {


### PR DESCRIPTION
## Summary

I noticed some ugly code so I decided to clean it up. There is no behavioral change.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [ ] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [x] I do not need to add a changelog entry. Reason: It's not a user-facing change.
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.4

**Damus:** 0b85b53eda32b47c1e11c4147c1c042b147caacf

**Steps:**
1. Build and run Damus.
2. Search for `npub14rehyx5flkme5lnudeaczdx8yzjq3dkzf06zvfqeea2tzcx9y7nqpvuw74` and observe that the name in the search results is still truncated to 50 characters, which means the behavior is unchanged.

**Results:**
- [x] PASS