### PR TITLE
Fix quote notes to include missing q tag

### DIFF
--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -883,6 +883,8 @@ func build_post(state: DamusState, post: NSAttributedString, action: PostAction,
     case .quoting(let ev):
         content.append("\n\nnostr:" + bech32_note_id(ev.id))
 
+        tags.append(["q", ev.id.hex()]);
+
         if let quoted_ev = state.events.lookup(ev.id) {
             tags.append(["p", quoted_ev.pubkey.hex()])
         }

--- a/damusTests/PostViewTests.swift
+++ b/damusTests/PostViewTests.swift
@@ -170,6 +170,12 @@ final class PostViewTests: XCTestCase {
         
         nonAlphaNumerics.forEach { testAddingStringAfterLink(str: $0)}
     }
+
+    func testQuoteRepost() {
+        let post = build_post(state: test_damus_state, post: .init(), action: .quoting(test_note), uploadedMedias: [], pubkeys: [])
+
+        XCTAssertEqual(post.tags, [["q", test_note.id.hex()]])
+    }
 }
 
 func checkMentionLinkEditorHandling(


### PR DESCRIPTION
Closes: https://github.com/damus-io/damus/issues/2615

## Summary

q tag is expected per [NIP-18](https://github.com/nostr-protocol/nips/blob/611b6351863e128f470576586f0e2b9a75f19039/18.md#quote-reposts). Damus was not including it when posting quote notes.

This is why the event action bar counter wasn't showing quotes created by Damus.

Here is an example quote note created with the fix:
https://damus.io/nevent1qqsf2lad8xecucafccjurykhlf24rshznwzkfawkkjsuz7flwcswddgpz4mhxue69uhk2er9dchxummnw3ezumrpdejqzrthwden5te0dehhxtnvdakqzyrhwden5te0dehhxarj9emkjmn9qy28wumn8ghj7un9d3shjtnyv9kh2uewd9hshn0jam

which corresponds to this json:
```json
{
  "sig": "40a08ad84e5406b29e4d87ef1dc17517e389c6918fb22f627dad6f64d26802357ad655cca5250e5c3def6122f40699d3db9526b5f6fd7bfc43dd38cce48bd392",
  "id": "957fad39b38e63a9c625c192d7fa5551c2e29b8564f5d6b4a1c1793f7620e6b5",
  "tags":
  [
    [
      "q",
      "526812e9ab0784c59c22bf3d21c5912a22c2fd0ed5a8266dc3732e3c76c171c0"
    ],
    [
      "p",
      "2779f3d9f42c7dee17f0e6bcdcf89a8f9d592d19e3b1bbd27ef1cffd1a7f98d1"
    ],
    [
      "p",
      "2779f3d9f42c7dee17f0e6bcdcf89a8f9d592d19e3b1bbd27ef1cffd1a7f98d1"
    ]
  ],
  "kind": 1,
  "content": "Test quote note.\n\nnostr:note12f5p96dtq7zvt8pzhu7jr3v39g3v9lgw6k5zvmwrwvhrcakpw8qqhlda28",
  "pubkey": "a8f3721a89fdb79a7e7c6e7b8134c720a408b6c24bf4262419cf54b160c527a6",
  "created_at": 1744583975
}
```

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16e

**iOS:** iOS 18.4

**Damus:** fab0e5de29a2dfc3d6ce31249ab356915f80f1a8

**Steps:**
1. Build and run Damus.
2. Quote a note and publish it.
3. Observe the quote note JSON to ensure that the q tag is included which references the original note hex id.

**Results:**
- [x] PASS