### PR TITLE
Added safety reminder to wallets with higher balance

### DIFF
--- a/damus/Views/Wallet/WalletView.swift
+++ b/damus/Views/Wallet/WalletView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+let WALLET_WARNING_THRESHOLD: UInt64 = 100000
+
 struct WalletView: View {
     let damus_state: DamusState
     @State var show_settings: Bool = false
@@ -22,6 +24,27 @@ struct WalletView: View {
     func MainWalletView(nwc: WalletConnectURL) -> some View {
         ScrollView {
             VStack(spacing: 35) {
+                if let balance = model.balance, balance > WALLET_WARNING_THRESHOLD {
+                    VStack(spacing: 10) {
+                        HStack {
+                            Image(systemName: "exclamationmark.circle")
+                            Text("Safety Reminder", comment: "Heading for a safety reminder that appears when the user has too many funds, recommending them to learn about safeguarding their funds.")
+                                .font(.title3)
+                                .bold()
+                        }
+                        .foregroundStyle(.damusWarningTertiary)
+                        
+                        Text("If your wallet balance is getting high, it's important to understand how to keep your funds secure. Please consider learning the best practices to ensure your assets remain safe. [Click here](https://damus.io/docs/wallet/high-balance-safety-reminder/) to learn more.", comment: "Text reminding the user has a high balance, recommending them to learn about self-custody")
+                            .foregroundStyle(.damusWarningSecondary)
+                            .opacity(0.8)
+                    }
+                    .padding()
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 20)
+                            .stroke(.damusWarningBorder, lineWidth: 1)
+                    )
+                }
+                
                 VStack(spacing: 5) {
                     
                     BalanceView(balance: model.balance)


### PR DESCRIPTION
## Summary

This commit will display a safety reminder for users with more than 100K sats balance on their NWC wallet.

This is how it looks like:
| Light mode | Dark mode |
|--------|--------|
| ![Image](https://github.com/user-attachments/assets/0e266c1d-91fc-4ee0-837a-ce06cfc62fcf) | ![Image](https://github.com/user-attachments/assets/e965a30d-c2c5-45f6-85ab-243556cf6020) |

Once they click "learn more", they can be taken to the following page:

![Image](https://github.com/user-attachments/assets/25dc8d2b-4ba0-4a23-bc8a-f97c8f9c25a6)

_(Code for the documentation website was posted on a new repo at https://github.com/damus-io/damus-docs, currently a private repo until we decide whether or not to go with it)_

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report


**Device:** iPhone SE simulator

**iOS:** 18.2

**Damus:** Equivalent to b7666e2bd1f3d1e123a066310bef0d9edbf2ce24

**Setup:**
- Manually changed the threshold in the code while testing to test different conditions
- Wallet with 1 sat balance

**Steps:**
1. Change threshold to 0 sats and check wallet balance. Reminder should appear
2. Change threshold to 100,000 sats and check wallet balance. Reminder should not appear
3. Check light mode and dark mode and ensure it looks good

**Results:**
- [x] PASS
- [ ] Partial PASS

## Other notes

- PR depends on deploying https://github.com/damus-io/damus-docs (to avoid broken links).
- Copywriting is tentative, I did not want to spend too much time on it.
