### PR TITLE
Add network connect call to extensions

### DIFF
--- a/highlighter action extension/ActionViewController.swift
+++ b/highlighter action extension/ActionViewController.swift
@@ -135,6 +135,7 @@ struct ShareExtensionView: View {
                 return
             }
             self.state = DamusState(keypair: keypair)
+            self.state?.nostrNetwork.connect()
         })
         .onChange(of: self.highlighter_state) {
             if case .cancelled = highlighter_state {

--- a/share extension/ShareViewController.swift
+++ b/share extension/ShareViewController.swift
@@ -250,6 +250,7 @@ struct ShareExtensionView: View {
             return false
         }
         state = DamusState(keypair: keypair)
+        state?.nostrNetwork.connect()
         return true
     }
     


### PR DESCRIPTION
## Summary

This commit fixes a regression on the highlighter and share extensions, which was caused by a change in the code's architecture, which required the network manager to be initialized.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [x] I do not need to add a changelog entry. Reason: _We never released a version with this bug. It was fixed before it could reach the App Store._ 
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report


**Device:** iPhone SE simulator

**iOS:** 18.2

**Damus:** 3555ac60963044b59c260cf1be90b4a572dd483c

**Steps:**

1. Share something via the highlighter extension. Make sure posting works.
2. Share something via the share extension. Make sure posting works.

**Results:**
- [x] PASS
