### PR TITLE
NWC wallet support improvements

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -1479,6 +1479,9 @@
 		D74AAFD22B155E78006CF0F4 /* WalletConnect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7D09612A098D0E00943473 /* WalletConnect.swift */; };
 		D74AAFD42B155ECB006CF0F4 /* Zaps+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74AAFD32B155ECB006CF0F4 /* Zaps+.swift */; };
 		D74AAFD62B155F0C006CF0F4 /* WalletConnect+.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74AAFD52B155F0C006CF0F4 /* WalletConnect+.swift */; };
+		D74E64132DC95CC7004C7892 /* HumanReadableErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74E64112DC95CBE004C7892 /* HumanReadableErrors.swift */; };
+		D74E64142DC95CC7004C7892 /* HumanReadableErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74E64112DC95CBE004C7892 /* HumanReadableErrors.swift */; };
+		D74E64152DC95CC7004C7892 /* HumanReadableErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74E64112DC95CBE004C7892 /* HumanReadableErrors.swift */; };
 		D74EA08A2D2BF2A7002290DD /* URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D767066E2C8BB3CE00F09726 /* URLHandler.swift */; };
 		D74EA08E2D2E271E002290DD /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74EA08D2D2E271E002290DD /* ErrorView.swift */; };
 		D74EA08F2D2E271E002290DD /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74EA08D2D2E271E002290DD /* ErrorView.swift */; };
@@ -2514,6 +2517,7 @@
 		D74AAFCE2B155D8C006CF0F4 /* ZapDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZapDataModel.swift; sourceTree = "<group>"; };
 		D74AAFD32B155ECB006CF0F4 /* Zaps+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Zaps+.swift"; sourceTree = "<group>"; };
 		D74AAFD52B155F0C006CF0F4 /* WalletConnect+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletConnect+.swift"; sourceTree = "<group>"; };
+		D74E64112DC95CBE004C7892 /* HumanReadableErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HumanReadableErrors.swift; sourceTree = "<group>"; };
 		D74EA08D2D2E271E002290DD /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		D74EA0922D2E77B9002290DD /* LoadableNostrEventView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableNostrEventView.swift; sourceTree = "<group>"; };
 		D74F43092B23F0BE00425B75 /* DamusPurple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DamusPurple.swift; sourceTree = "<group>"; };
@@ -4035,6 +4039,7 @@
 		D78F080A2D7F78B000FC6C75 /* WalletConnect */ = {
 			isa = PBXGroup;
 			children = (
+				D74E64112DC95CBE004C7892 /* HumanReadableErrors.swift */,
 				D78F08102D7F78F600FC6C75 /* Response.swift */,
 				D78F080B2D7F78EB00FC6C75 /* Request.swift */,
 				4C7D09612A098D0E00943473 /* WalletConnect.swift */,
@@ -4688,6 +4693,7 @@
 				D7315A2A2ACDF3B70036E30A /* DamusCacheManager.swift in Sources */,
 				D7373BA82B68974500F7783D /* DamusPurpleNewUserOnboardingView.swift in Sources */,
 				4C7D09682A0AE9B200943473 /* NWCScannerView.swift in Sources */,
+				D74E64152DC95CC7004C7892 /* HumanReadableErrors.swift in Sources */,
 				D7CB5D452B116FE800AD4105 /* Contacts+.swift in Sources */,
 				4CA352A42A76AFF3003BB08B /* UpdateStatsNotify.swift in Sources */,
 				D798D21E2B0858BB00234419 /* MigratedTypes.swift in Sources */,
@@ -5125,6 +5131,7 @@
 				82D6FAED2CD99F7900C925F4 /* PostNotify.swift in Sources */,
 				82D6FAEE2CD99F7900C925F4 /* PresentSheetNotify.swift in Sources */,
 				D74EA0932D2E77B9002290DD /* LoadableNostrEventView.swift in Sources */,
+				D74E64142DC95CC7004C7892 /* HumanReadableErrors.swift in Sources */,
 				82D6FAEF2CD99F7900C925F4 /* ProfileUpdatedNotify.swift in Sources */,
 				82D6FAF02CD99F7900C925F4 /* ReportNotify.swift in Sources */,
 				82D6FAF12CD99F7900C925F4 /* ScrollToTopNotify.swift in Sources */,
@@ -5731,6 +5738,7 @@
 				D73E5ECC2C6A97F4007EB227 /* SuggestedUsersViewModel.swift in Sources */,
 				D73E5ED22C6A97F4007EB227 /* WalletView.swift in Sources */,
 				D73E5ED32C6A97F4007EB227 /* NWCScannerView.swift in Sources */,
+				D74E64132DC95CC7004C7892 /* HumanReadableErrors.swift in Sources */,
 				D73E5ED42C6A97F4007EB227 /* FriendsButton.swift in Sources */,
 				D73E5ED52C6A97F4007EB227 /* GradientFollowButton.swift in Sources */,
 				D73E5ED62C6A97F4007EB227 /* AlbyButton.swift in Sources */,

--- a/damus/Components/NoteZapButton.swift
+++ b/damus/Components/NoteZapButton.swift
@@ -240,7 +240,7 @@ func send_zap(damus_state: DamusState, target: ZapTarget, lnurl: String, is_cust
             // we don't have a delay on one-tap nozaps (since this will be from customize zap view)
             let delay = damus_state.settings.nozaps ? nil : 5.0
 
-            let nwc_req = WalletConnect.pay(url: nwc_state.url, pool: damus_state.nostrNetwork.pool, post: damus_state.nostrNetwork.postbox, invoice: inv, delay: delay, on_flush: flusher)
+            let nwc_req = WalletConnect.pay(url: nwc_state.url, pool: damus_state.nostrNetwork.pool, post: damus_state.nostrNetwork.postbox, invoice: inv, zap_request: zapreq, delay: delay, on_flush: flusher)
 
             guard let nwc_req, case .nwc(let pzap_state) = pending_zap_state else {
                 print("nwc: failed to send nwc request for zapreq \(reqid.reqid)")

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -263,6 +263,7 @@ class HomeModel: ContactsDelegate {
             guard let nwc_str = damus_state.settings.nostr_wallet_connect,
                   let nwc = WalletConnectURL(str: nwc_str),
                   let resp = await WalletConnect.FullWalletResponse(from: ev, nwc: nwc) else {
+                Log.error("HomeModel: Received NWC response I do not understand", for: .nwc)
                 return
             }
 

--- a/damus/Models/HomeModel.swift
+++ b/damus/Models/HomeModel.swift
@@ -265,6 +265,11 @@ class HomeModel: ContactsDelegate {
                 return
             }
             
+            guard nwc.relay == relay else { return }    // Don't process NWC responses coming from relays other than our designated one
+            guard ev.referenced_pubkeys.first == nwc.keypair.pubkey else {
+                return      // This message is not for us. Ignore it.
+            }
+            
             var resp: WalletConnect.FullWalletResponse? = nil
             do {
                 resp = try await WalletConnect.FullWalletResponse(from: ev, nwc: nwc)

--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -113,6 +113,9 @@ class UserSettingsStore: ObservableObject {
     @Setting(key: "show_wallet_selector", default_value: false)
     var show_wallet_selector: Bool
     
+    @Setting(key: "dismiss_wallet_high_balance_warning", default_value: false)
+    var dismiss_wallet_high_balance_warning: Bool
+    
     @Setting(key: "left_handed", default_value: false)
     var left_handed: Bool
     

--- a/damus/Nostr/Id.swift
+++ b/damus/Nostr/Id.swift
@@ -143,8 +143,16 @@ struct ReplaceableParam: TagConvertible {
     var keychar: AsciiCharacter { "d" }
 }
 
-struct Signature: Hashable, Equatable {
+struct Signature: Codable, Hashable, Equatable {
     let data: Data
+    
+    init(from decoder: Decoder) throws {
+        self.init(try hex_decoder(decoder, expected_len: 64))
+    }
+
+    func encode(to encoder: Encoder) throws {
+        try hex_encoder(to: encoder, data: self.data)
+    }
 
     init(_ p: Data) {
         self.data = p

--- a/damus/Nostr/NostrEvent.swift
+++ b/damus/Nostr/NostrEvent.swift
@@ -379,6 +379,10 @@ func decode_json<T: Decodable>(_ val: String) -> T? {
     return try? JSONDecoder().decode(T.self, from: Data(val.utf8))
 }
 
+func decode_json_throwing<T: Decodable>(_ val: String) throws -> T {
+    return try JSONDecoder().decode(T.self, from: Data(val.utf8))
+}
+
 func decode_data<T: Decodable>(_ data: Data) -> T? {
     let decoder = JSONDecoder()
     do {
@@ -539,6 +543,7 @@ func event_to_json(ev: NostrEvent) -> String {
     return str
 }
 
+@available(*, deprecated, renamed: "NIP04.decryptContent", message: "Deprecated, please use NIP04.decryptContent instead")
 func decrypt_dm(_ privkey: Privkey?, pubkey: Pubkey, content: String, encoding: EncEncoding) -> String? {
     guard let privkey = privkey else {
         return nil

--- a/damus/Util/WalletConnect/HumanReadableErrors.swift
+++ b/damus/Util/WalletConnect/HumanReadableErrors.swift
@@ -1,0 +1,97 @@
+//
+//  HumanReadableErrors.swift
+//  damus
+//
+//  Created by Daniel D’Aquino on 2025-05-05.
+//
+
+import Foundation
+
+extension WalletConnect.FullWalletResponse.InitializationError {
+    var humanReadableError: ErrorView.UserPresentableError? {
+        switch self {
+        case .incorrectAuthorPubkey:
+            nil    // Anyone can send a response event with an incorrect author pubkey, it is not really an "error". We should silently ignore it.
+        case .missingRequestIdReference:
+            .init(
+                user_visible_description: NSLocalizedString("Wallet provider returned an invalid response.", comment: "Error description shown to the user when a response from the wallet provider is invalid"),
+                tip: NSLocalizedString("Please copy the technical info and send it to our support team.", comment: "Tip on how to resolve issue when wallet returns an invalid response"),
+                technical_info: "Wallet response does not make a reference to any request; No request ID `e` tag was found."
+            )
+        case .failedToDecodeJSON(let error):
+            .init(
+                user_visible_description: NSLocalizedString("Wallet provider returned a response that we do not understand.", comment: "Error description shown to the user when a response from the wallet provider contains data the app does not understand"),
+                tip: NSLocalizedString("Please copy the technical info and send it to our support team.", comment: "Tip on how to resolve issue when wallet returns an invalid response"),
+                technical_info: "Failed to decode NWC Wallet response JSON. Error: \(error)"
+            )
+        case .failedToDecrypt(let error):
+            .init(
+                user_visible_description: NSLocalizedString("Wallet provider returned a response that we could not decrypt.", comment: "Error description shown to the user when a response from the wallet provider contains data the app could not decrypt."),
+                tip: NSLocalizedString("Please copy the technical info and send it to our support team.", comment: "Tip on how to resolve issue when wallet returns an invalid response"),
+                technical_info: "Failed to decrypt NWC Wallet response. Error: \(error)"
+            )
+        }
+    }
+}
+
+extension WalletConnect.WalletResponseErr {
+    var humanReadableError: ErrorView.UserPresentableError? {
+        guard let code = self.code else {
+            return .init(
+                user_visible_description: String(format: NSLocalizedString("Your connected wallet raised an unknown error. Message: %s", comment: "Human readable error description for unknown error"), self.message ?? NSLocalizedString("Empty error message", comment: "A human readable placeholder to indicate that the error message is empty")),
+                tip: NSLocalizedString("Please contact the developer of your wallet provider for help.", comment: "Human readable error description for an unknown error raised by a wallet provider."),
+                technical_info: "NWC wallet provider returned an error response without a valid reason code. Message: \(self.message ?? "Empty error message")"
+            )
+        }
+        switch code {
+        case .rateLimited:
+            return .init(
+                user_visible_description: NSLocalizedString("Your wallet is temporarily being rate limited.", comment: "Error description for rate limit error"),
+                tip: NSLocalizedString("Wait a few moments, and then try again.", comment: "Tip for rate limit error"),
+                technical_info: "Wallet returned a rate limit error with message: \(self.message ?? "No further details provided")"
+            )
+        case .notImplemented:
+            return .init(
+                user_visible_description: NSLocalizedString("This feature is not implemented by your wallet.", comment: "Error description for not implemented feature"),
+                tip: NSLocalizedString("Please check for updates or contact your wallet provider.", comment: "Tip for not implemented error"),
+                technical_info: "Wallet reported a not implemented error. Message: \(self.message ?? "No further details provided")"
+            )
+        case .insufficientBalance:
+            return .init(
+                user_visible_description: NSLocalizedString("Your wallet does not have sufficient balance for this transaction.", comment: "Error description for insufficient balance"),
+                tip: NSLocalizedString("Please deposit more funds and try again.", comment: "Tip for insufficient balance errors"),
+                technical_info: "Wallet returned an insufficient balance error. Message: \(self.message ?? "No further details provided")"
+            )
+        case .quotaExceeded:
+            return .init(
+                user_visible_description: NSLocalizedString("Your transaction quota has been exceeded.", comment: "Error description for quota exceeded"),
+                tip: NSLocalizedString("Wait for the quota to reset, or configure your wallet provider to allow a higher limit.", comment: "Tip for quota exceeded"),
+                technical_info: "Wallet reported a quota exceeded error. Message: \(self.message ?? "No further details provided")"
+            )
+        case .restricted:
+            return .init(
+                user_visible_description: NSLocalizedString("This operation is restricted by your wallet.", comment: "Error description for restricted operation"),
+                tip: NSLocalizedString("Check your account permissions or contact support.", comment: "Tip for restricted operation"),
+                technical_info: "Wallet returned a restricted error. Message: \(self.message ?? "No further details provided")"
+            )
+        case .unauthorized:
+            return .init(
+                user_visible_description: NSLocalizedString("You are not authorized to perform this action with your wallet.", comment: "Error description for unauthorized access"),
+                tip: NSLocalizedString("Please verify your credentials or permissions.", comment: "Tip for unauthorized access"),
+                technical_info: "Wallet returned an unauthorized error. Message: \(self.message ?? "No further details provided")"
+            )
+        case .internalError:
+            return .init(
+                user_visible_description: NSLocalizedString("An internal error occurred in your wallet.", comment: "Error description for an internal error"),
+                tip: NSLocalizedString("Try restarting your wallet or contacting support if the problem persists.", comment: "Tip for internal error"),
+                technical_info: "Wallet reported an internal error. Message: \(self.message ?? "No further details provided")"
+            )
+        case .other:
+            return .init(
+                user_visible_description: NSLocalizedString("An unspecified error occurred in your wallet.", comment: "Error description for an unspecified error"),
+                tip: NSLocalizedString("Please try again or contact your wallet provider for further assistance.", comment: "Tip for unspecified error"),
+                technical_info: "Wallet returned an error: \(self.message ?? "No further details provided")"
+            )
+        }
+    }
+}

--- a/damus/Util/WalletConnect/WalletConnect+.swift
+++ b/damus/Util/WalletConnect/WalletConnect+.swift
@@ -20,6 +20,7 @@ extension WalletConnect {
     static func subscribe(url: WalletConnectURL, pool: RelayPool) {
         var filter = NostrFilter(kinds: [.nwc_response])
         filter.authors = [url.pubkey]
+        filter.pubkeys = [url.keypair.pubkey]
         filter.limit = 0
         let sub = NostrSubscribe(filters: [filter], sub_id: "nwc")
 

--- a/damus/Util/WalletConnect/WalletConnect+.swift
+++ b/damus/Util/WalletConnect/WalletConnect+.swift
@@ -40,8 +40,9 @@ extension WalletConnect {
     ///   - on_flush: A callback to call after the event has been flushed to the network
     /// - Returns: The Nostr Event that was sent to the network, representing the request that was made
     @discardableResult
-    static func pay(url: WalletConnectURL, pool: RelayPool, post: PostBox, invoice: String, delay: TimeInterval? = 5.0, on_flush: OnFlush? = nil) -> NostrEvent? {
-        let req = WalletConnect.Request.payInvoice(invoice: invoice)
+    static func pay(url: WalletConnectURL, pool: RelayPool, post: PostBox, invoice: String, zap_request: NostrEvent?, delay: TimeInterval? = 5.0, on_flush: OnFlush? = nil) -> NostrEvent? {
+        
+        let req = WalletConnect.Request.payZapRequest(invoice: invoice, zapRequest: zap_request)
         guard let ev = req.to_nostr_event(to_pk: url.pubkey, keypair: url.keypair) else {
             return nil
         }
@@ -142,7 +143,7 @@ extension WalletConnect {
         }
         
         print("damus-donation donating...")
-        WalletConnect.pay(url: nwc, pool: pool, post: postbox, invoice: invoice, delay: nil)
+        WalletConnect.pay(url: nwc, pool: pool, post: postbox, invoice: invoice, zap_request: nil, delay: nil)
     }
 
     /// Handles a received Nostr Wallet Connect error

--- a/damus/Util/WalletConnect/WalletConnect.swift
+++ b/damus/Util/WalletConnect/WalletConnect.swift
@@ -86,7 +86,7 @@ extension WalletConnect {
         let created_at: UInt64 // unixtimestamp, // invoice/payment creation time
         let expires_at: UInt64?  // unixtimestamp, // invoice expiration time, optional if not applicable
         let settled_at: UInt64? // unixtimestamp, // invoice/payment settlement time, optional if unpaid
-        //"metadata": {} // generic metadata that can be used to add things like zap/boostagram details for a payer name/comment/etc.
+        let metadata: WalletConnect.Request.Metadata?    // generic metadata that can be used to add things like zap/boostagram details for a payer name/comment/etc.
     }
 }
 

--- a/damus/Views/ErrorHandling/ErrorView.swift
+++ b/damus/Views/ErrorHandling/ErrorView.swift
@@ -50,6 +50,10 @@ struct ErrorView: View {
             .cornerRadius(10)
             .padding(.vertical, 30)
             
+            if let technical_info = error.technical_info {
+                ErrorTechInfoCopyButton(errorInfo: technical_info)
+            }
+            
             Spacer()
             
             if let damus_state, damus_state.is_privkey_user {
@@ -67,6 +71,39 @@ struct ErrorView: View {
         }
         .padding(20)
         .padding(.top, 20)
+    }
+    
+    struct ErrorTechInfoCopyButton: View {
+        let errorInfo: String
+        @State var copied: Bool = false
+        
+        var body: some View {
+            VStack {
+                if !copied {
+                    Button(action: {
+                        UIPasteboard.general.string = errorInfo
+                        copied = true
+                        
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            copied = false
+                        }
+                    }, label: {
+                        HStack {
+                            Image(systemName: "square.on.square.dashed")
+                            Text("Copy technical information", comment: "Button label to allow user to copy technical information from an error screen (usually to provide our support team for further troubleshooting)")
+                        }
+                    })
+                }
+                else {
+                    HStack {
+                        Image(systemName: "checkmark.circle")
+                        Text("Copied!", comment: "Label indicating that the error technical information was successfully copied to the clipboard, which shows up as soon as the user clicks the copy button.")
+                    }
+                    .foregroundStyle(.damusGreen)
+                }
+            }
+            .padding(.vertical, 20)
+        }
     }
     
     /// An error that is displayed to the user, and can be sent to the Developers as well.
@@ -113,7 +150,7 @@ struct ErrorView: View {
         error: .init(
             user_visible_description: "We are still too early",
             tip: "Stay humble, keep building, stack sats",
-            technical_info: nil
+            technical_info: "UTXOs too small, must stack more sats"
         )
     )
 }

--- a/damus/Views/Relays/RelayView.swift
+++ b/damus/Views/Relays/RelayView.swift
@@ -11,12 +11,14 @@ struct RelayView: View {
     let state: DamusState
     let relay: RelayURL
     let recommended: Bool
+    /// Disables navigation link
+    let disableNavLink: Bool
     @ObservedObject private var model_cache: RelayModelCache
 
     @State var relay_state: Bool
     @Binding var showActionButtons: Bool
 
-    init(state: DamusState, relay: RelayURL, showActionButtons: Binding<Bool>, recommended: Bool) {
+    init(state: DamusState, relay: RelayURL, showActionButtons: Binding<Bool>, recommended: Bool, disableNavLink: Bool = false) {
         self.state = state
         self.relay = relay
         self.recommended = recommended
@@ -24,6 +26,7 @@ struct RelayView: View {
         _showActionButtons = showActionButtons
         let relay_state = RelayView.get_relay_state(pool: state.nostrNetwork.pool, relay: relay)
         self._relay_state = State(initialValue: relay_state)
+        self.disableNavLink = disableNavLink
     }
 
     static func get_relay_state(pool: RelayPool, relay: RelayURL) -> Bool {
@@ -96,10 +99,12 @@ struct RelayView: View {
                         RelayStatusView(connection: relay_connection)
                     }
                     
-                    Image("chevron-large-right")
-                        .resizable()
-                        .frame(width: 15, height: 15)
-                        .foregroundColor(.gray)
+                    if !disableNavLink {
+                        Image("chevron-large-right")
+                            .resizable()
+                            .frame(width: 15, height: 15)
+                            .foregroundColor(.gray)
+                    }
                 }
             }
             .contentShape(Rectangle())
@@ -108,7 +113,9 @@ struct RelayView: View {
             self.relay_state = RelayView.get_relay_state(pool: state.nostrNetwork.pool, relay: self.relay)
         }
         .onTapGesture {
-            state.nav.push(route: Route.RelayDetail(relay: relay, metadata: model_cache.model(with_relay_id: relay)?.metadata))
+            if !disableNavLink {
+                state.nav.push(route: Route.RelayDetail(relay: relay, metadata: model_cache.model(with_relay_id: relay)?.metadata))
+            }
         }
     }
     

--- a/damus/Views/Settings/ZapSettingsView.swift
+++ b/damus/Views/Settings/ZapSettingsView.swift
@@ -63,6 +63,11 @@ struct ZapSettingsView: View {
                         }
                     }
             }
+            
+            Section(NSLocalizedString("NWC wallet", comment: "Title for section in zap settings that controls general NWC wallet settings.")) {
+                Toggle(NSLocalizedString("Disable high balance warning", comment: "Setting to disable high balance warnings on the user's wallet"), isOn: $settings.dismiss_wallet_high_balance_warning)
+                    .toggleStyle(.switch)
+            }
         }
         .navigationTitle(NSLocalizedString("Zaps", comment: "Navigation title for zap settings."))
         .onReceive(handle_notify(.switched_timeline)) { _ in

--- a/damus/Views/Wallet/ConnectWalletView.swift
+++ b/damus/Views/Wallet/ConnectWalletView.swift
@@ -152,7 +152,7 @@ struct ConnectWalletView: View {
                 CoinosButton() {
                     self.show_coinos_options = true
                 }
-                Text("Coinos is a service operated by a third-party. We have no access to your Coinos wallet.", comment: "Small caption with a disclaimer that Damus does not own or have access to Coinos wallets, Coinos is a third-party service.")
+                Text("Coinos is a service operated by a third-party. The Damus team has no access to your wallet.", comment: "Small caption with a disclaimer that Damus does not own or have access to Coinos wallets, Coinos is a third-party service.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)

--- a/damus/Views/Wallet/ConnectWalletView.swift
+++ b/damus/Views/Wallet/ConnectWalletView.swift
@@ -70,7 +70,7 @@ struct ConnectWalletView: View {
                     
                     Spacer()
                     
-                    NWCSettings.AccountDetailsView(nwc: nwc)
+                    NWCSettings.AccountDetailsView(nwc: nwc, damus_state: nil)
                     
                     Spacer()
                     

--- a/damus/Views/Wallet/NWCSettings.swift
+++ b/damus/Views/Wallet/NWCSettings.swift
@@ -134,7 +134,7 @@ struct NWCSettings: View {
             SupportDamus
                 .padding(.bottom)
             
-            AccountDetailsView(nwc: nwc)
+            AccountDetailsView(nwc: nwc, damus_state: damus_state)
             
             Toggle(NSLocalizedString("Disable high balance warning", comment: "Setting to disable high balance warnings on the user's wallet"), isOn: $settings.dismiss_wallet_high_balance_warning)
                 .toggleStyle(.switch)
@@ -185,6 +185,7 @@ struct NWCSettings: View {
     
     struct AccountDetailsView: View {
         let nwc: WalletConnect.ConnectURL
+        let damus_state: DamusState?
         
         var body: some View {
             VStack(alignment: .leading) {
@@ -198,11 +199,17 @@ struct NWCSettings: View {
                 Text("Routing", comment: "Label indicating the routing address for Nostr Wallet Connect payments. In other words, the relay used by the NWC wallet provider")
                     .font(.headline)
                 
-                Text(nwc.relay.absoluteString)
-                    .font(.body)
-                    .fontWeight(.bold)
-                    .foregroundColor(.gray)
-                    .padding(.bottom)
+                if let damus_state {
+                    RelayView(state: damus_state, relay: nwc.relay, showActionButtons: .constant(false), recommended: false, disableNavLink: true)
+                        .padding(.bottom)
+                }
+                else {
+                    Text(nwc.relay.absoluteString)
+                        .font(.body)
+                        .fontWeight(.bold)
+                        .foregroundColor(.gray)
+                        .padding(.bottom)
+                }
                 
                 if let lud16 = nwc.lud16 {
                     Text("Account", comment: "Label for the user account information with the Nostr Wallet Connect wallet provider.")

--- a/damus/Views/Wallet/NWCSettings.swift
+++ b/damus/Views/Wallet/NWCSettings.swift
@@ -136,6 +136,9 @@ struct NWCSettings: View {
             
             AccountDetailsView(nwc: nwc)
             
+            Toggle(NSLocalizedString("Disable high balance warning", comment: "Setting to disable high balance warnings on the user's wallet"), isOn: $settings.dismiss_wallet_high_balance_warning)
+                .toggleStyle(.switch)
+            
             Button(action: {
                 self.model.disconnect()
                 dismiss()

--- a/damus/Views/Wallet/TransactionsView.swift
+++ b/damus/Views/Wallet/TransactionsView.swift
@@ -20,8 +20,8 @@ struct TransactionView: View {
         let created_at = Date.init(timeIntervalSince1970: TimeInterval(transaction.created_at))
         let formatter = RelativeDateTimeFormatter()
         let relativeDate = formatter.localizedString(for: created_at, relativeTo: Date.now)
-        let event = decode_nostr_event_json(transaction.description ?? "")
-        let pubkey = (event?.pubkey ?? ANON_PUBKEY)
+        let event = decode_nostr_event_json(transaction.description ?? "") ?? transaction.metadata?.nostr
+        let pubkey = self.pubkeyToDisplay(for: event, isIncomingTransaction: isIncomingTransaction) ?? ANON_PUBKEY
         
         VStack(alignment: .leading) {
             HStack(alignment: .center) {
@@ -71,6 +71,16 @@ struct TransactionView: View {
                 RoundedRectangle(cornerRadius: 10)
                     .stroke(DamusColors.neutral3, lineWidth: 1)
             )
+        }
+    }
+    
+    func pubkeyToDisplay(for zapRequest: NostrEvent?, isIncomingTransaction: Bool) -> Pubkey? {
+        guard let zapRequest else { return nil }
+        if isIncomingTransaction {
+            return zapRequest.pubkey    // We want to know who sent it to us
+        }
+        else {
+            return zapRequest.referenced_pubkeys.first  // We want to know who we sent it to
         }
     }
     
@@ -139,10 +149,10 @@ struct TransactionsView: View {
 
 struct TransactionsView_Previews: PreviewProvider {
     static let tds = test_damus_state
-    static let transaction1: WalletConnect.Transaction = WalletConnect.Transaction(type: "incoming", invoice: "", description: "{\"id\":\"7c0999a5870ca3ba0186a29a8650152b555cee29b53b5b8747d8a3798042d01c\",\"pubkey\":\"b8851a06dfd79d48fc325234a15e9a46a32a0982a823b54cdf82514b9b120ba1\",\"created_at\":1736383715,\"kind\":9734,\"tags\":[[\"p\",\"520830c334a3f79f88cac934580d26f91a7832c6b21fb9625690ea2ed81b5626\"],[\"amount\",\"21000\"],[\"e\",\"a25e152a4cd1b3bbc3d22e8e9315d8ea1f35c227b2f212c7cff18abff36fa208\"],[\"relays\",\"wss://nos.lol\",\"wss://nostr.wine\",\"wss://premium.primal.net\",\"wss://relay.damus.io\",\"wss://relay.nostr.band\",\"wss://relay.nostrarabia.com\"]],\"content\":\"🫡 Onward!\",\"sig\":\"e77d16822fa21b9c2e6b580b51c470588052c14aeb222f08f0e735027e366157c8742a6d5cb850780c2bf44ac63d89b048e5cc56dd47a1bfc740a3173e578f4e\"}", description_hash: "", preimage: "", payment_hash: "1234567890", amount: 21000, fees_paid: 0, created_at: 1737736866, expires_at: 0, settled_at: 0)
-    static let transaction2: WalletConnect.Transaction = WalletConnect.Transaction(type: "incoming", invoice: "", description: "", description_hash: "", preimage: "", payment_hash: "123456789033", amount: 100000000, fees_paid: 0, created_at: 1737690090, expires_at: 0, settled_at: 0)
-    static let transaction3: WalletConnect.Transaction = WalletConnect.Transaction(type: "outgoing", invoice: "", description: "", description_hash: "", preimage: "", payment_hash: "123456789042", amount: 303000, fees_paid: 0, created_at: 1737590101, expires_at: 0, settled_at: 0)
-    static let transaction4: WalletConnect.Transaction = WalletConnect.Transaction(type: "incoming", invoice: "", description: "", description_hash: "", preimage: "", payment_hash: "1234567890662", amount: 720000, fees_paid: 0, created_at: 1737090300, expires_at: 0, settled_at: 0)
+    static let transaction1: WalletConnect.Transaction = WalletConnect.Transaction(type: "incoming", invoice: "", description: "{\"id\":\"7c0999a5870ca3ba0186a29a8650152b555cee29b53b5b8747d8a3798042d01c\",\"pubkey\":\"b8851a06dfd79d48fc325234a15e9a46a32a0982a823b54cdf82514b9b120ba1\",\"created_at\":1736383715,\"kind\":9734,\"tags\":[[\"p\",\"520830c334a3f79f88cac934580d26f91a7832c6b21fb9625690ea2ed81b5626\"],[\"amount\",\"21000\"],[\"e\",\"a25e152a4cd1b3bbc3d22e8e9315d8ea1f35c227b2f212c7cff18abff36fa208\"],[\"relays\",\"wss://nos.lol\",\"wss://nostr.wine\",\"wss://premium.primal.net\",\"wss://relay.damus.io\",\"wss://relay.nostr.band\",\"wss://relay.nostrarabia.com\"]],\"content\":\"🫡 Onward!\",\"sig\":\"e77d16822fa21b9c2e6b580b51c470588052c14aeb222f08f0e735027e366157c8742a6d5cb850780c2bf44ac63d89b048e5cc56dd47a1bfc740a3173e578f4e\"}", description_hash: "", preimage: "", payment_hash: "1234567890", amount: 21000, fees_paid: 0, created_at: 1737736866, expires_at: 0, settled_at: 0, metadata: nil)
+    static let transaction2: WalletConnect.Transaction = WalletConnect.Transaction(type: "incoming", invoice: "", description: "", description_hash: "", preimage: "", payment_hash: "123456789033", amount: 100000000, fees_paid: 0, created_at: 1737690090, expires_at: 0, settled_at: 0, metadata: nil)
+    static let transaction3: WalletConnect.Transaction = WalletConnect.Transaction(type: "outgoing", invoice: "", description: "", description_hash: "", preimage: "", payment_hash: "123456789042", amount: 303000, fees_paid: 0, created_at: 1737590101, expires_at: 0, settled_at: 0, metadata: nil)
+    static let transaction4: WalletConnect.Transaction = WalletConnect.Transaction(type: "incoming", invoice: "", description: "", description_hash: "", preimage: "", payment_hash: "1234567890662", amount: 720000, fees_paid: 0, created_at: 1737090300, expires_at: 0, settled_at: 0, metadata: nil)
     static var test_transactions: [WalletConnect.Transaction] = [transaction1, transaction2, transaction3, transaction4]
     
     static var previews: some View {

--- a/damus/Views/Wallet/WalletView.swift
+++ b/damus/Views/Wallet/WalletView.swift
@@ -24,7 +24,7 @@ struct WalletView: View {
     func MainWalletView(nwc: WalletConnectURL) -> some View {
         ScrollView {
             VStack(spacing: 35) {
-                if let balance = model.balance, balance > WALLET_WARNING_THRESHOLD {
+                if let balance = model.balance, balance > WALLET_WARNING_THRESHOLD && !settings.dismiss_wallet_high_balance_warning {
                     VStack(spacing: 10) {
                         HStack {
                             Image(systemName: "exclamationmark.circle")
@@ -36,7 +36,16 @@ struct WalletView: View {
                         
                         Text("If your wallet balance is getting high, it's important to understand how to keep your funds secure. Please consider learning the best practices to ensure your assets remain safe. [Click here](https://damus.io/docs/wallet/high-balance-safety-reminder/) to learn more.", comment: "Text reminding the user has a high balance, recommending them to learn about self-custody")
                             .foregroundStyle(.damusWarningSecondary)
+                            .accentColor(.damusWarningTertiary)
                             .opacity(0.8)
+                        
+                        Button(action: {
+                            settings.dismiss_wallet_high_balance_warning = true
+                        }, label: {
+                            Text("Dismiss", comment: "Button label to dismiss the safety reminder that the user's wallet has a high balance")
+                        })
+                        .bold()
+                        .foregroundStyle(.damusWarningTertiary)
                     }
                     .padding()
                     .overlay(


### PR DESCRIPTION
## Summary

This PR adds several improvements related to NWC wallet support.

### Zap request information to `pay_invoice`

This PR adds zap-request information to the `pay_invoice` NWC command, in order for the NWC wallet to get the recipient information, which will help us get real people's names on the wallet transaction view.

For an understanding on why this is necessary to fix most of the "Unknown" entries on the wallet transactions view, please reference this diagram:

```mermaid
sequenceDiagram
    participant NWC Provider
    participant Client
    participant Recipient LNURL server
    participant Relays listed on zap request
    Client->>Recipient LNURL server: Verify support and recipient info
    Recipient LNURL server->>Client: Support and recipient info
    Client->>Recipient LNURL server: NIP-57 `kind:9734` zap request
    Recipient LNURL server->>Client: Lightning Invoice (description hash only)
    Client->>NWC Provider: NIP-47 `pay_invoice` command (Invoice with description hash only)
    NWC Provider->>Recipient LNURL server: Pay invoice
    Recipient LNURL server->>Relays listed on zap request: NIP-57 `kind:9735` zap receipt (w/ embedded zap request)
    Relays listed on zap request->>Client: NIP-57 `kind:9735` zap receipt (w/ embedded zap request)
```

Please see https://github.com/nostr-protocol/nips/issues/1843 or https://github.com/damus-io/damus/issues/2927 for more details.

### Other improvements

1. Better disclaimer message on the Coinos button (https://github.com/damus-io/damus/issues/3000)
2. Better error handling for possible NWC-related issues (https://github.com/damus-io/damus/issues/3010), avoiding silent failures.
3. Added the option for users to easily copy error technical info and send them to us.
4. More lenient parsing of wallet responses that avoids at least one instance of this issue https://github.com/damus-io/damus/issues/2999 (maybe not all, though, hard to know with the info we currently have)
5. Full `Codable` support for `NdbNote`, which helps us embed `NostrEvent` in other JSON payloads
6. Added the option for users to dismiss the high balance warning (https://github.com/damus-io/damus/issues/2994)
7. Fixed a previously invisible issue where the app would try to decrypt every NWC response on the wire even if not ours
8. Recovered the relay connectivity indicator on NWC settings, that has been lost during the new feature development
9. Added some unit testing coverage around NWC request/response encoding/decoding


## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone SE simulator

**iOS:** 18.2

**Damus:** 6c8a238788b4b983bb9e634e28609cc0ca4ae7b7

**Wallets:**
- One-click setup Coinos
- Test AlbyHub wallet

**Coverage:**
1. Ran unit tests and ensured they are passing.
2. Connected to an AlbyHub wallet, sent some zaps, and looked at the transaction history. Verified that the zap recipient now shows up on the transaction history.
3. Connected to both Coinos and AlbyHub wallets, verified that balance and TX history show up, and zaps work.
4. Verified new Coinos disclaimer message appears.
5. Locally modified high balance threshold to 1 sat, verified that the warning shows up, but it can be dismissed. User can undo the dismissal by going to zap settings or NWC settings.
6. Sent a zap on a wallet without enough funds. A user-friendly error sheet appears indicating that there are not enough funds.
    i. Also verified that error technical info can be copied from that view.
    ii. During development, also saw the user-viewable error for decryption issues (Which was an issue on our end that I have fixed in this PR, but worth mentioning to show that this error mechanism is working).
    ii. Note: Other wallet-related errors follow a similar logic, but not every case was tested as some of those are very hard to test.
7. Checked that the relay information in NWC settings now shows relay connection information.

**Results:**
- [x] PARTIAL PASS.
    - **Note:** Coinos currently does not seem to be ingesting zap request information from the `pay_invoice` NWC command, and therefore we still show "Unknown" profile for sent zaps. But at least this is working with AlbyHub, so it is only a matter of time and coordination before we get this working with Coinos as well.


## Other notes

- @jb55, I added a function to the nostrdb C codebase. If this PR gets approved, we should add that upstream as well to avoid losing it during the NostrDB update work.
- I recommend reviewing this commit by commit — might make it easier.

