### PR TITLE
Move Kingfisher data to the Caches directory

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -1703,6 +1703,9 @@
 		D7F360262CEBBD8B009D34DA /* PresentFullScreenItemNotify.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EB00AF2CD59C8300660C07 /* PresentFullScreenItemNotify.swift */; };
 		D7F360272CEBBDC0009D34DA /* DamusVideoControlsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7EFBA362CC322F300F45588 /* DamusVideoControlsView.swift */; };
 		D7F360292CEBBE34009D34DA /* CodeScanner in Frameworks */ = {isa = PBXBuildFile; productRef = D7F360282CEBBE34009D34DA /* CodeScanner */; };
+		D7FA46E52DBDAA7E002C9BB0 /* ImageCacheMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7FA46E42DBDAA75002C9BB0 /* ImageCacheMigrations.swift */; };
+		D7FA46E62DBDAA7E002C9BB0 /* ImageCacheMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7FA46E42DBDAA75002C9BB0 /* ImageCacheMigrations.swift */; };
+		D7FA46E72DBDAA7E002C9BB0 /* ImageCacheMigrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7FA46E42DBDAA75002C9BB0 /* ImageCacheMigrations.swift */; };
 		D7FB10A72B0C371A00FA8D42 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2B10272A7B0F5C008AA43E /* Log.swift */; };
 		D7FB14222BE5970000398331 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D7FB14212BE5970000398331 /* PrivacyInfo.xcprivacy */; };
 		D7FB14252BE5A9A800398331 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D7FB14242BE5A9A800398331 /* PrivacyInfo.xcprivacy */; };
@@ -2574,6 +2577,7 @@
 		D7EDED2D2B128E8A0018B19C /* CollectionExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionExtension.swift; sourceTree = "<group>"; };
 		D7EDED322B12ACAE0018B19C /* DamusUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DamusUserDefaults.swift; sourceTree = "<group>"; };
 		D7EFBA362CC322F300F45588 /* DamusVideoControlsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DamusVideoControlsView.swift; sourceTree = "<group>"; };
+		D7FA46E42DBDAA75002C9BB0 /* ImageCacheMigrations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheMigrations.swift; sourceTree = "<group>"; };
 		D7FB14212BE5970000398331 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D7FB14242BE5A9A800398331 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D7FD12252BD345A700CF195B /* FirstAidSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstAidSettingsView.swift; sourceTree = "<group>"; };
@@ -3312,6 +3316,7 @@
 		4C7FF7D628233637009601DB /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				D7FA46E42DBDAA75002C9BB0 /* ImageCacheMigrations.swift */,
 				D73B74E02D8365B40067BDBC /* ExtraFonts.swift */,
 				D7DB93042D66A43B00DA1EE5 /* Undistractor.swift */,
 				D73E5F7E2C6AA066007EB227 /* DamusAliases.swift */,
@@ -4675,6 +4680,7 @@
 				4CCEB7AE29B53D260078AA28 /* SearchingEventView.swift in Sources */,
 				4CF0ABE929844AF100D66079 /* AnyCodable.swift in Sources */,
 				BA3759932ABCCEBA0018D73B /* CameraModel.swift in Sources */,
+				D7FA46E72DBDAA7E002C9BB0 /* ImageCacheMigrations.swift in Sources */,
 				D7100C5A2B76FD5100C59298 /* LogoView.swift in Sources */,
 				4C0A3F8F280F640A000448DE /* ThreadModel.swift in Sources */,
 				4C3AC79F2833115300E1F516 /* FollowButtonView.swift in Sources */,
@@ -5217,6 +5223,7 @@
 				82D6FB432CD99F7900C925F4 /* KeychainStorage.swift in Sources */,
 				82D6FB442CD99F7900C925F4 /* Bech32.swift in Sources */,
 				82D6FB452CD99F7900C925F4 /* InputDismissKeyboard.swift in Sources */,
+				D7FA46E62DBDAA7E002C9BB0 /* ImageCacheMigrations.swift in Sources */,
 				82D6FB462CD99F7900C925F4 /* Constants.swift in Sources */,
 				82D6FB472CD99F7900C925F4 /* LinkView.swift in Sources */,
 				D7DB1FDF2D5A78CE00CF06DA /* NIP44.swift in Sources */,
@@ -5681,6 +5688,7 @@
 				D73E5E9F2C6A97F4007EB227 /* CreateAccountModel.swift in Sources */,
 				D73E5EA12C6A97F4007EB227 /* SignalModel.swift in Sources */,
 				5CB017272D42C5C400A9ED05 /* TransactionsView.swift in Sources */,
+				D7FA46E52DBDAA7E002C9BB0 /* ImageCacheMigrations.swift in Sources */,
 				D73E5EA22C6A97F4007EB227 /* FollowTarget.swift in Sources */,
 				D73E5EA32C6A97F4007EB227 /* BookmarksManager.swift in Sources */,
 				D73E5EA42C6A97F4007EB227 /* EventsModel.swift in Sources */,

--- a/damus/Util/ImageCacheMigrations.swift
+++ b/damus/Util/ImageCacheMigrations.swift
@@ -1,0 +1,79 @@
+//
+//  ImageCacheMigrations.swift
+//  damus
+//
+//  Created by Daniel D’Aquino on 2025-04-26.
+//
+
+import Foundation
+import Kingfisher
+
+struct ImageCacheMigrations {
+    static func migrateKingfisherCacheIfNeeded() {
+        let fileManager = FileManager.default
+        let defaults = UserDefaults.standard
+        let migration1Key = "KingfisherCacheMigrated"   // Never ever changes
+        let migration2Key = "KingfisherCacheMigratedV2" // Never ever changes
+        
+        let migration1Done = defaults.bool(forKey: migration1Key)
+        let migration2Done = defaults.bool(forKey: migration2Key)
+
+        guard !migration1Done || !migration2Done else {
+            // All migrations are already done. Skip.
+            return
+        }
+
+        let oldCachePath = migration1Done ? migration1KingfisherCachePath() : migration0KingfisherCachePath()
+
+        // New shared cache location
+        let newCachePath = kingfisherCachePath().path
+
+        if fileManager.fileExists(atPath: oldCachePath) {
+            do {
+                // Move the old cache to the new location
+                try fileManager.moveItem(atPath: oldCachePath, toPath: newCachePath)
+                Log.info("Successfully migrated Kingfisher cache to %s", for: .storage, newCachePath)
+            } catch {
+                do {
+                    // Cache data is not essential, fallback to deleting the cache and starting all over
+                    // It's better than leaving significant garbage data stuck indefinitely on the user's phone
+                    try fileManager.removeItem(atPath: newCachePath)
+                    try fileManager.removeItem(atPath: oldCachePath)
+                }
+                catch {
+                    Log.error("Failed to migrate cache: %s", for: .storage, error.localizedDescription)
+                    return  // Do not mark them as complete, we can try again next time the user reloads the app
+                }
+            }
+        }
+        
+        // Mark migrations as complete
+        defaults.set(true, forKey: migration1Key)
+        defaults.set(true, forKey: migration2Key)
+    }
+    
+    static private func migration0KingfisherCachePath() -> String {
+        // Implementation note: These are old, so they should not be changed
+        let defaultCache = ImageCache.default
+        return defaultCache.diskStorage.directoryURL.path
+    }
+    
+    static private func migration1KingfisherCachePath() -> String {
+        // Implementation note: These are old, so they are hard-coded on purpose, because we can't change these values from the past.
+        let groupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.com.damus")!
+        return groupURL.appendingPathComponent("ImageCache").path
+    }
+    
+    /// The latest path for kingfisher to store cached images on.
+    ///
+    /// Documentation references:
+    /// - https://developer.apple.com/documentation/foundation/filemanager/containerurl(forsecurityapplicationgroupidentifier:)#:~:text=The%20system%20creates%20only%20the%20Library/Caches%20subdirectory%20automatically
+    /// - https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#:~:text=Put%20data%20cache,files%20as%20needed.
+    static func kingfisherCachePath() -> URL {
+        let groupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: Constants.DAMUS_APP_GROUP_IDENTIFIER)!
+        return groupURL
+            .appendingPathComponent("Library")
+            .appendingPathComponent("Caches")
+            .appendingPathComponent(Constants.IMAGE_CACHE_DIRNAME)
+    }
+}


### PR DESCRIPTION
## Summary

This commit moves Kingfisher data to Apple's designated caches folder to avoid it from being backed up to iCloud.

Reasoning for the fix can be found here: https://github.com/damus-io/damus/issues/2993#issuecomment-2832750054

Closes: https://github.com/damus-io/damus/issues/2993
Changelog-Fixed: Fixed issue where cached images would be backed up to iCloud

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone SE simulator

**iOS:** 18.2

**Damus:**  4bee4a44c5d94814d9e5a6b89a2c145548116f64

**Setup:**
- Damus group container root folder known and opened on a terminal
- Debugger attached, and logs filtered with the keyword "migrat" to capture migration logs

**Steps:**
1. Delete Damus on the device
2. Install older version of Damus before the change: bcb59896dbb7449cb89190c829322914959271e6
3. Run the app, view some images
4. Upgrade damus to the version under test
5. Ensure the "migration successful logs" appear
6. View the group container on the terminal, ensure the previous folder location has been deleted
7. Delete Damus and install version v1.9 (An even older version with a different cache location)
8. Run the app, see an image or two
9. Upgrade to the new version under test
10. Ensure successful migration log appears


**Results:**
- [x] PASS

## Other notes

Apple does not seem to provide any tools for simulating backups or low-storage file evictions, so for this part of the issue we are relying solely on Apple's documentation. I recommend us to test this on the next TestFlight — by following up with the users who reported the issue and checking if it was resolved.
