### PR TITLE
Re-enable note zaps ⚡️

### DIFF
--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -174,8 +174,12 @@ class UserSettingsStore: ObservableObject {
     var truncate_timeline_text: Bool
     
     /// Nozaps mode gimps note zapping to fit into apple's content-tipping guidelines. It can not be configurable to end-users on the app store
-    @Setting(key: "nozaps", default_value: true)
-    var nozaps: Bool
+    ///
+    /// Update 2025-05-12: This can be re-enabled 🥳. See https://github.com/damus-io/damus/issues/3016
+    // @Setting(key: "nozaps", default_value: true)
+    var nozaps: Bool {
+        return false
+    }
     
     @Setting(key: "truncate_mention_text", default_value: true)
     var truncate_mention_text: Bool


### PR DESCRIPTION
## Summary

The much awaited PR. Let's go!

Changelog-Changed: Re-enabled note zaps as permitted by the new App Store guidelines
Closes: https://github.com/damus-io/damus/issues/3016

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone SE simulator

**iOS:** 18.2

**Damus:** 80e55031a088e7acfca240da18a28248ee3bd5d9

**Steps:**
1. Run the app before the change. Check that the note zap icons do not appear.
2. Upgrade to this new version. Check that the note zap icons do appear.

**Results:**
- [x] PASS

## Other notes
