### PR TITLE
Hide end previewables when hashtags are present

### DIFF
--- a/damus/Models/NoteContent.swift
+++ b/damus/Models/NoteContent.swift
@@ -117,6 +117,10 @@ func render_blocks(blocks bs: Blocks, profiles: Profiles, can_hide_last_previewa
                 }
                 hide_text_index = i
             } else if case .text(let txt) = block, txt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                // We should hide whitespace at the end sequence.
+                hide_text_index = i
+            } else if case .hashtag = block {
+                // We should keep hashtags at the end sequence but hide all the other previewables around it.
                 hide_text_index = i
             } else {
                 break
@@ -149,7 +153,16 @@ func render_blocks(blocks bs: Blocks, profiles: Profiles, can_hide_last_previewa
             // No need to show the text representation of the block if the only previewables are the sequence of them
             // found at the end of the content.
             // This is to save unnecessary use of screen space.
+            // The only exception is that if there are hashtags embedded in the end sequence, which is not uncommon,
+            // then we still want to show those hashtags but hide everything else that is previewable in the end sequence.
             if ind >= hide_text_index {
+                if case .text(let txt) = block, txt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    if case .hashtag = blocks[safe: ind+1] {
+                        return str + CompatibleText(stringLiteral: reduce_text_block(ind: ind, hide_text_index: -1, txt: txt))
+                    }
+                } else if case .hashtag(let htag) = block {
+                    return str + hashtag_str(htag)
+                }
                 return str
             }
         }


### PR DESCRIPTION
## Summary

It's quite common for people or clients to add hashtags at the end of a note. Sometimes those hashtags come after previewable blocks, like images. We should hide the end previewable blocks when hashtags are present to make the note more readable.

It's worth mentioning that this is only an intermediate fix. The real fix is to render media inline, but that's a much larger change.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro

**iOS:** iOS 18.4

**Damus:** 3a331f6a0563e8bd88f48061cf84d1fe2466aed0

**Steps:**
1. Build and run Damus on `master` branch.
2. Open [nevent1qqs8kjly8l9gdcht2he8r0wls4y5l9qnc8wedw8ezq7luau5uqlfk5gpp4mhxue69uhkummn9ekx7mqprfmhxue69uhhyetvv9ujumn0wd68yurvv438xtnrdaksz9nhwden5te0d9hxymmc9ehx7um5wgh8w6twv5q3jamnwvaz7tms09exzmtfvshxv6tpw34xze3wvdhk6ywnxxt](https://damus.io/nevent1qqs8kjly8l9gdcht2he8r0wls4y5l9qnc8wedw8ezq7luau5uqlfk5gpp4mhxue69uhkummn9ekx7mqprfmhxue69uhhyetvv9ujumn0wd68yurvv438xtnrdaksz9nhwden5te0d9hxymmc9ehx7um5wgh8w6twv5q3jamnwvaz7tms09exzmtfvshxv6tpw34xze3wvdhk6ywnxxt)
3. Observe that image URLs are shown in the note.
4. Build and run Damus on this branch.
5.  Open [nevent1qqs8kjly8l9gdcht2he8r0wls4y5l9qnc8wedw8ezq7luau5uqlfk5gpp4mhxue69uhkummn9ekx7mqprfmhxue69uhhyetvv9ujumn0wd68yurvv438xtnrdaksz9nhwden5te0d9hxymmc9ehx7um5wgh8w6twv5q3jamnwvaz7tms09exzmtfvshxv6tpw34xze3wvdhk6ywnxxt](https://damus.io/nevent1qqs8kjly8l9gdcht2he8r0wls4y5l9qnc8wedw8ezq7luau5uqlfk5gpp4mhxue69uhkummn9ekx7mqprfmhxue69uhhyetvv9ujumn0wd68yurvv438xtnrdaksz9nhwden5te0d9hxymmc9ehx7um5wgh8w6twv5q3jamnwvaz7tms09exzmtfvshxv6tpw34xze3wvdhk6ywnxxt) again.
6. Observe that the image URLs are hidden but hashtags remain.

**Results:**
- [x] PASS

## Other notes

| Before | After |
|-------|--------|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-05-19 at 21 52 53 Medium](https://github.com/user-attachments/assets/f65f6cab-4172-4d58-9dd2-79f0f6883c45) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-19 at 21 06 48 Medium](https://github.com/user-attachments/assets/6ec13693-2c71-4fe4-ab3f-dbe7b3b42f11) |
