### PR TITLE
2x speed playback when you hold the screen while playing a video

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # damus
 
-A twitter-like [nostr][nostr] client for iPhone, iPad and MacOS. 
+A twitter-like [nostr][nostr] client for iPhone, iPad and MacOS. Y
 
 <img src="./ss.png" width="50%" height="50%" />
 


### PR DESCRIPTION
Long-pressing videos on Damus while they play should perform a 2x speedup. Would like to see something like what has become commonplace on other platforms like X/Twitter and YouTube, as it's a huge time saver and has become expectation for many users these days.