### PR TITLE
Fix quotes view header alignment

### DIFF
--- a/damus/Views/Reposts/QuoteRepostsView.swift
+++ b/damus/Views/Reposts/QuoteRepostsView.swift
@@ -12,9 +12,19 @@ struct QuoteRepostsView: View {
     @ObservedObject var model: EventsModel
 
     var body: some View {
-        TimelineView<AnyView>(events: model.events, loading: $model.loading, damus: damus_state, show_friend_icon: true, filter: ContentFilters.default_filters(damus_state: damus_state).filter(ev:))
+        TimelineView(events: model.events, loading: $model.loading, damus: damus_state, show_friend_icon: true, filter: ContentFilters.default_filters(damus_state: damus_state).filter(ev:)) {
+            ZStack(alignment: .leading) {
+                DamusBackground(maxHeight: 250)
+                    .mask(LinearGradient(gradient: Gradient(colors: [.black, .black, .black, .clear]), startPoint: .top, endPoint: .bottom))
+                Text("Quotes", comment: "Navigation bar title for Quote Reposts view.")
+                    .foregroundStyle(DamusLogoGradient.gradient)
+                    .font(.title.bold())
+                    .padding(.leading, 30)
+                    .padding(.top, 30)
+            }
+        }
+        .ignoresSafeArea()
         .padding(.bottom, tabHeight)
-        .navigationBarTitle(NSLocalizedString("Quotes", comment: "Navigation bar title for Quote Reposts view."))
         .onAppear {
             model.subscribe()
         }


### PR DESCRIPTION
## Summary

The first note in the quotes timeline view is always overlapped by the header. This PR fixes that issue and adds a gradient to make it look consistent with the hashtag timeline view (and soon NIP-05 timeline view).

| Before | After |
|--------|-------|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-05-27 at 17 37 57 Medium](https://github.com/user-attachments/assets/61f04fe7-bda7-4873-8ea0-401cef84225f) | ![Simulator Screenshot - iPhone 16 Pro - 2025-05-27 at 17 39 11 Medium](https://github.com/user-attachments/assets/618955f4-4b23-4031-986f-2e988c08cf0d) |

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.4

**Damus:** 612abfd86268f6f181e6d0ce20f007c97930f1ee

**Steps:**
1. Build and run Damus.
2. Navigate to a note that has been quote reposted, such as https://damus.io/nevent1qqszsqvlrm69y5u3ctgwpuh4lnpj3d79rqpzf8traze2nf6hyhy8j0gpxdmhxue69uhkuamr9ec8y6tdv9kzumn9wshkz7tkdfkx26tvd4urqctvxa4ryur3wsergut9vsch5dmp8pesz9nhwden5te0wfjkccte9ehx7uewwdhkx6tpdsq3gamnwvaz7tmjv4kxz7fwv3sk6atn9e5k7qgdwaehxw309ahx7uewd3hkcek565z
3. Tap on `Quotes` in the event counter bar.
4. Observe that there is a gradient header that says `Quotes` and does not obstruct the notes in the timeline.

**Results:**
- [x] PASS