### PR TITLE
Add privacy-based redaction to wallet view

### DIFF
--- a/damus/Models/UserSettingsStore.swift
+++ b/damus/Models/UserSettingsStore.swift
@@ -115,7 +115,10 @@ class UserSettingsStore: ObservableObject {
     
     @Setting(key: "dismiss_wallet_high_balance_warning", default_value: false)
     var dismiss_wallet_high_balance_warning: Bool
-    
+
+    @Setting(key: "hide_wallet_balance", default_value: false)
+    var hide_wallet_balance: Bool
+
     @Setting(key: "left_handed", default_value: false)
     var left_handed: Bool
     

--- a/damus/Views/Onboarding/SuggestedUserView.swift
+++ b/damus/Views/Onboarding/SuggestedUserView.swift
@@ -35,7 +35,6 @@ struct SuggestedUserView: View {
             let target = FollowTarget.pubkey(user.pubkey)
             InnerProfilePicView(url: user.pfp,
                                 fallbackUrl: nil,
-                                pubkey: target.pubkey,
                                 size: 50,
                                 highlight: .none,
                                 disable_animation: false)

--- a/damus/Views/Settings/ZapSettingsView.swift
+++ b/damus/Views/Settings/ZapSettingsView.swift
@@ -67,6 +67,8 @@ struct ZapSettingsView: View {
             Section(NSLocalizedString("NWC wallet", comment: "Title for section in zap settings that controls general NWC wallet settings.")) {
                 Toggle(NSLocalizedString("Disable high balance warning", comment: "Setting to disable high balance warnings on the user's wallet"), isOn: $settings.dismiss_wallet_high_balance_warning)
                     .toggleStyle(.switch)
+                Toggle(NSLocalizedString("Hide balance", comment: "Setting to hide wallet balance."), isOn: $settings.hide_wallet_balance)
+                    .toggleStyle(.switch)
             }
         }
         .navigationTitle(NSLocalizedString("Zaps", comment: "Navigation title for zap settings."))

--- a/damus/Views/Wallet/BalanceView.swift
+++ b/damus/Views/Wallet/BalanceView.swift
@@ -9,7 +9,9 @@ import SwiftUI
 
 struct BalanceView: View {
     var balance: Int64?
-    
+
+    @Binding var hide_balance: Bool
+
     var body: some View {
         VStack(spacing: 5) {
             Text("Current balance", comment: "Label for displaying current wallet balance")
@@ -28,29 +30,46 @@ struct BalanceView: View {
     }
     
     func numericalBalanceView(text: String) -> some View {
-        HStack {
-            Text(verbatim: text)
-                .lineLimit(1)
-                .minimumScaleFactor(0.70)
-                .font(.veryVeryLargeTitle)
-                .fontWeight(.heavy)
-                .foregroundStyle(PinkGradient)
-            
-            HStack(alignment: .top) {
-                Text("SATS", comment: "Abbreviation for Satoshis, smallest bitcoin unit")
-                    .font(.caption)
+        Group {
+            if hide_balance {
+                Text(verbatim: "*****")
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.70)
+                    .font(.veryVeryLargeTitle)
                     .fontWeight(.heavy)
                     .foregroundStyle(PinkGradient)
+
+            } else {
+                HStack {
+                    Text(verbatim: text)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.70)
+                        .font(.veryVeryLargeTitle)
+                        .fontWeight(.heavy)
+                        .foregroundStyle(PinkGradient)
+
+                    HStack(alignment: .top) {
+                        Text("SATS", comment: "Abbreviation for Satoshis, smallest bitcoin unit")
+                            .font(.caption)
+                            .fontWeight(.heavy)
+                            .foregroundStyle(PinkGradient)
+                    }
+                }
             }
         }
+        .privacySensitive()
         .padding(.bottom)
+        .onTapGesture {
+            hide_balance.toggle()
+        }
     }
 }
 
 struct BalanceView_Previews: PreviewProvider {
+    @State private static var hide_balance: Bool = false
     static var previews: some View {
-        BalanceView(balance: 100000000)
-        BalanceView(balance: nil)
+        BalanceView(balance: 100000000, hide_balance: $hide_balance)
+        BalanceView(balance: nil, hide_balance: $hide_balance)
     }
 }
 

--- a/damus/Views/Wallet/NWCSettings.swift
+++ b/damus/Views/Wallet/NWCSettings.swift
@@ -138,7 +138,10 @@ struct NWCSettings: View {
             
             Toggle(NSLocalizedString("Disable high balance warning", comment: "Setting to disable high balance warnings on the user's wallet"), isOn: $settings.dismiss_wallet_high_balance_warning)
                 .toggleStyle(.switch)
-            
+
+            Toggle(NSLocalizedString("Hide balance", comment: "Setting to hide wallet balance."), isOn: $settings.hide_wallet_balance)
+                .toggleStyle(.switch)
+
             Button(action: {
                 self.model.disconnect()
                 dismiss()

--- a/damus/Views/Wallet/WalletView.swift
+++ b/damus/Views/Wallet/WalletView.swift
@@ -14,7 +14,8 @@ struct WalletView: View {
     @State var show_settings: Bool = false
     @ObservedObject var model: WalletModel
     @ObservedObject var settings: UserSettingsStore
-    
+    @State private var showBalance: Bool = false
+
     init(damus_state: DamusState, model: WalletModel? = nil) {
         self.damus_state = damus_state
         self._model = ObservedObject(wrappedValue: model ?? damus_state.wallet)
@@ -47,6 +48,7 @@ struct WalletView: View {
                         .bold()
                         .foregroundStyle(.damusWarningTertiary)
                     }
+                    .privacySensitive()
                     .padding()
                     .overlay(
                         RoundedRectangle(cornerRadius: 20)
@@ -56,9 +58,9 @@ struct WalletView: View {
                 
                 VStack(spacing: 5) {
                     
-                    BalanceView(balance: model.balance)
-                    
-                    TransactionsView(damus_state: damus_state, transactions: model.transactions)
+                    BalanceView(balance: model.balance, hide_balance: $settings.hide_wallet_balance)
+
+                    TransactionsView(damus_state: damus_state, transactions: model.transactions, hide_balance: $settings.hide_wallet_balance)
                 }
             }
             .navigationTitle(NSLocalizedString("Wallet", comment: "Navigation title for Wallet view"))


### PR DESCRIPTION
## Summary

Money is privacy-sensitive information. We should provide better privacy controls for our users. This PR introduces the following changes:
1. Adds a `Hide balance` toggle in Zaps settings and Wallet settings
2. Tapping on wallet balance also toggles the setting
3. Hiding the balance means replacing the actual money amounts on the wallet balance and transaction amounts with `*****` and hides the detail of whether it was an incoming or outgoing transaction.
4. Activating the iOS app switcher uses the native system privacy redactor to redact the wallet balance, transaction amounts, and pubkey display name, and replaces profile pictures with an anonymous robot picture. The high balance warning is also redacted.

Note: This PR will conflict with my other PR https://github.com/damus-io/damus/pull/3063 but it should be simple to resolve the merge conflict.

| Balance hidden | Balance hidden with high balance warning | Balance shown with incoming and outgoing txs | Redacted 1 | Redacted 2 | Wallet settings | Zaps settings |
|--|--|--|--|--|--|--|
| ![IMG_6796 Medium](https://github.com/user-attachments/assets/c85e3fc8-5702-4950-8aa1-0d3d8ebf1694) | ![IMG_6797 Medium](https://github.com/user-attachments/assets/7176788f-794b-40ee-8449-6de0b1c55752) | ![IMG_6799 Medium](https://github.com/user-attachments/assets/84140cc2-5327-4018-80ea-aaedb62d8c15) | ![IMG_6798 Medium](https://github.com/user-attachments/assets/410ad1b8-fbcd-44a6-9bef-bc0bf8e6f876) | ![IMG_6800 Medium](https://github.com/user-attachments/assets/87611232-c8bd-4e01-a1e7-1a43fd0e053d) | ![IMG_6803 Medium](https://github.com/user-attachments/assets/2c2e6a59-4791-4d11-ae7e-5e6e614d69cb) | ![IMG_6804 Medium](https://github.com/user-attachments/assets/3fc49f66-0d0f-4ae0-8613-a84d5b6eb2fe) |

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 14 Pro

**iOS:** 18.5

**Damus:** b9198d6bd7a2bd30ef7166f00990c0a76168a698

**Setup:** Set up a NWC wallet with several incoming and outgoing transactions

**Steps:**
1. Open Wallet in sidebar.
2. Observe that the wallet balance and transaction amounts are shown by default.
3. Initiate the drag gesture from the bottom of the device to bring up the app switcher but leave Damus in view. Observe that the wallet balance, transaction amounts, and pubkey display name are redacted, and the profile picture is replaced with an anonymous robot picture.
4. Bringing Damus back into the foreground unredacts everything from (3).
5. Tap on the wallet balance to toggle the hide balance setting, and observe that the wallet balance and transaction amounts are replaced by `*****`.
6. Initiate the drag gesture from the bottom of the device to bring up the app switcher but leave Damus in view. Observe that the wallet balance, transaction amounts, and pubkey display name are redacted, and the profile picture is replaced with an anonymous robot picture.
7. Bringing Damus back into the foreground unredacts everything from (6).
8. Tap on the wallet balance again to show the amounts again.
9. Tap on the wallet settings gear icon and observe that the `Hide balance` toggle is on the bottom and reflects the hide/show balance state in the wallet view.
10. Navigate to the main Damus settings screen, tap the `Zaps` menu, and observe that the `Hide balance` toggle is under the `NWC Wallet` section and reflects the hide/show balance state in the wallet view.

**Results:**
- [x] PASS