### PR TITLE
Add privacy-based redaction to nsec in key settings view

### DIFF
--- a/damus/Views/Settings/KeySettingsView.swift
+++ b/damus/Views/Settings/KeySettingsView.swift
@@ -89,6 +89,7 @@ struct KeySettingsView: View {
                                 .disabled(true)
                         } else {
                             Text(sec)
+                                .privacySensitive()
                                 .clipShape(RoundedRectangle(cornerRadius: 5))
                         }
                         


### PR DESCRIPTION
## Summary

Private keys are sensitive information. This PR marks it as privacy sensitive so that it is redacted in the key settings view when the app switcher is active.

![Simulator Screenshot - iPhone 16 Pro - 2025-06-01 at 19 55 51 Medium](https://github.com/user-attachments/assets/7b6b1cad-c212-44ba-8d23-63d2a099dc6b)

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.5

**Damus:** 947e24864e8f44bb076ddfee95a4f371139c447e

**Steps:**
1. Open Settings from Damus sidebar.
2. Tap on Keys.
3. Toggle `Show` under the `Secret Account Login Key` section.
4. If in simulator, add an arbitrary passcode to authenticate.
5. Observe that the private key is revealed in plaintext.
6. Initiate the drag gesture from the bottom of the device to bring up the app switcher but leave Damus in view. Observe that the private key is redacted.
7. Bringing Damus back into the foreground unredacts the private key.

**Results:**
- [x] PASS