### PR TITLE
Rename "Universe" to "Search"

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -1086,7 +1086,7 @@ func timeline_name(_ timeline: Timeline?) -> String {
     case .notifications:
         return NSLocalizedString("Notifications", comment: "Toolbar label for Notifications view.")
     case .search:
-        return NSLocalizedString("Universe 🛸", comment: "Toolbar label for the universal view where notes from all connected relay servers appear.")
+        return NSLocalizedString("Search 🛸", comment: "Toolbar label for the universal view where notes from all connected relay servers appear.")
     case .dms:
         return NSLocalizedString("DMs", comment: "Toolbar label for DMs view, where DM is the English abbreviation for Direct Message.")
     }


### PR DESCRIPTION
Changelog-Changed: Renamed "Universe" to "Search" in UI screen
Signed-off-by: SanjaySiddharth <mjsanjaysiddharth1999@gmail.com>
Closes : https://github.com/damus-io/damus/issues/2991
## Summary

Renamed the title "Universe" to "Search"

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

**Results:**

- Tested on iPhone 16 Simulator
- [x] PASS


