### PR TITLE
Move users-section to be last in muted view

### DIFF
--- a/damus/Views/Muting/MutelistView.swift
+++ b/damus/Views/Muting/MutelistView.swift
@@ -47,20 +47,6 @@ struct MutelistView: View {
 
     var body: some View {
         List {
-            Section(NSLocalizedString("Users", comment: "Section header title for a list of muted users.")) {
-                ForEach(users, id: \.self) { user in
-                    if case let MuteItem.user(pubkey, _) = user {
-                        UserViewRow(damus_state: damus_state, pubkey: pubkey)
-                         .id(pubkey)
-                         .swipeActions {
-                             RemoveAction(item: .user(pubkey, nil))
-                         }
-                         .onTapGesture {
-                             damus_state.nav.push(route: Route.ProfileByKey(pubkey: pubkey))
-                         }
-                    }
-                }
-            }
             Section(NSLocalizedString("Hashtags", comment: "Section header title for a list of hashtags that are muted.")) {
                 ForEach(hashtags, id: \.self) { item in
                     if case let MuteItem.hashtag(hashtag, _) = item {
@@ -86,10 +72,7 @@ struct MutelistView: View {
                     }
                 }
             }
-            Section(
-                header: Text(NSLocalizedString("Threads", comment: "Section header title for a list of threads that are muted.")),
-                footer: Text("").padding(.bottom, 10 + tabHeight + getSafeAreaBottom())
-            ) {
+            Section(NSLocalizedString("Threads", comment: "Section header title for a list of threads that are muted.")) {
                 ForEach(threads, id: \.self) { item in
                     if case let MuteItem.thread(note_id, _) = item {
                         if let event = damus_state.events.lookup(note_id) {
@@ -101,6 +84,23 @@ struct MutelistView: View {
                         } else {
                             Text("Error retrieving muted event", comment: "Text for an item that application failed to retrieve the muted event for.")
                         }
+                    }
+                }
+            }
+            Section(
+                header: Text(NSLocalizedString("Users", comment: "Section header title for a list of muted users.")),
+                footer: Text("").padding(.bottom, 10 + tabHeight + getSafeAreaBottom())
+            ) {
+                ForEach(users, id: \.self) { user in
+                    if case let MuteItem.user(pubkey, _) = user {
+                        UserViewRow(damus_state: damus_state, pubkey: pubkey)
+                            .id(pubkey)
+                            .swipeActions {
+                                RemoveAction(item: .user(pubkey, nil))
+                            }
+                            .onTapGesture {
+                                damus_state.nav.push(route: Route.ProfileByKey(pubkey: pubkey))
+                            }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Move users-section to be last in muted view

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16

**iOS:** 18.2

**Damus:** 1.15 (1) 94571ede

**Setup:** simulator and SwiftUI previews

**Results:**
- [x] PASS
