### PR TITLE
Remove incorrect Thai translation for notes_from_three_and_others

### DIFF
--- a/damus/th.lproj/Localizable.stringsdict
+++ b/damus/th.lproj/Localizable.stringsdict
@@ -86,20 +86,6 @@
 			<string>นำเข้า</string>
 		</dict>
 	</dict>
-	<key>notes_from_three_and_others</key>
-	<dict>
-		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@OTHERS@</string>
-		<key>OTHERS</key>
-		<dict>
-			<key>NSStringFormatSpecTypeKey</key>
-			<string>NSStringPluralRuleType</string>
-			<key>NSStringFormatValueTypeKey</key>
-			<string>d</string>
-			<key>other</key>
-			<string>โน้ตจาก %2@, %4d คนในเครือข่ายที่เชื่อถือของคุณ</string>
-		</dict>
-	</dict>
 	<key>people_reposted_count</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>


### PR DESCRIPTION
## Summary

There was an incorrect Thai translation for the `notes_from_three_and_others` key which broke a localization test in CI. It didn't have all the required parameters, which would likely result in an error at runtime if shipped.

Closes: https://github.com/damus-io/damus/issues/3093

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [x] I do not need to add a changelog entry. Reason: It's a minor enough fix.
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

Ran `NIP05DomainTimelineHeaderViewTests` and the entire test suite in Xcode and it passed.

**Device:** iPhone SE (3rd generation)

**iOS:** 18.4

**Damus:** 77abeceabaa3a3f3a87f2f7ee686c3521f64bcf2

**Steps:**
1. In Xcode, go to Product > Test in the menu bar.
2. Wait for the tests to run.
3. All tests should pass.

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_