### PR TITLE
Display wallet response error if available

### DIFF
--- a/damus/Views/Wallet/SendPaymentView.swift
+++ b/damus/Views/Wallet/SendPaymentView.swift
@@ -217,6 +217,10 @@ struct SendPaymentView: View {
                                     ))
                                 }
                             }
+                            else if let error = error as? WalletConnect.WalletResponseErr,
+                                    let humanReadableError = error.humanReadableError  {
+                                sendState = .failed(error: humanReadableError)
+                            }
                             else {
                                 sendState = .failed(error: .init(
                                     user_visible_description: NSLocalizedString("An unexpected error occurred.", comment: "A human-readable error message"),


### PR DESCRIPTION
## Summary

This commit improves error handling in the wallet's "send" feature, by displaying more specific wallet response error messages when available.

Closes: https://github.com/damus-io/damus/issues/3095
Changelog-Fixed: Improve error handling on wallet send feature

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone SE simulator

**iOS:** 18.2

**Damus:** 919508732fde2db5e7405fac09da06cfec0adc6c (A local build where I am working on the wallet budget setting)

**Setup:** Coinos one-click wallet

**Steps:**
1. Reduce quota to 10 sats/week
2. Try to send 21 sats
3. Ensure error message is specific

**Results:**
- [x] PASS
- [ ] Partial PASS

![Simulator Screenshot - iPhone SE (3rd generation) - 2025-06-20 at 19 00 06](https://github.com/user-attachments/assets/711b0369-46ae-4b91-ae3a-2b223158bca9)

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_
