### PR TITLE
Fix and cleanup note rendering link previews

### DIFF
--- a/damus/Views/NoteContentView.swift
+++ b/damus/Views/NoteContentView.swift
@@ -87,6 +87,12 @@ struct NoteContentView: View {
             return linkPreviewWithNoMedia(cached)
         }
 
+        // If media is already being shown, do not show media in the link preview
+        // to avoid taking up additional screen space.
+        if case let .separated(separated) = note_artifacts, !separated.media.isEmpty && !self.options.contains(.no_media) {
+            return linkPreviewWithNoMedia(cached)
+        }
+
         return LinkViewRepresentable(meta: .linkmeta(cached))
     }
 


### PR DESCRIPTION
## Summary

This PR introduces two changes:
1. Fix note rendering to include non-media link previews with image, video, and icon removed when media previews are disabled. Previously, the URL string AND its preview card were both hidden when media previews were disabled (only the former should have been hidden).
2. Remove image, video, and icon from non-media link previews if media links are present to reduce screen clutter.

Closes: https://github.com/damus-io/damus/issues/3099

| Media previews off | Media previews on | Image and Non-Media Link Together | 
|--|--|--|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-06-22 at 22 31 54 Medium](https://github.com/user-attachments/assets/d9115805-cfd2-488d-91e1-d2352ebc7161) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-22 at 22 31 39 Medium](https://github.com/user-attachments/assets/8ed6d049-2b02-40ec-8751-db792ddcaa28) | ![Simulator Screenshot - iPhone 16 Pro - 2025-06-22 at 22 26 28 Medium](https://github.com/user-attachments/assets/aca2abe8-1285-422d-a76a-83890c5abf39) |


## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** iOS 18.5

**Damus:** a8b6b5f10e736a780bbca26de6d1ad62178a2ba6

**Steps:**
1. Open the left sidebar and tap `Settings`.
2. Tap `Appearance and filters`.
3. Turn on `Media previews`.
4. Navigate to `nevent1qqsrv8l8vx0pstf00hp8hhwg7nvtu07fk7qgnq66xruwsfqafwc3ddgpz4mhxue69uhkummnw3ezumtfd3hh2tnvdakqz9rhwden5te0dehhxarj9ehhsarj9ejx2aspzdmhxue69uhkummnw3ezuenv0yhxgetkqyv8wumn8ghj7mn0wd68ytnsd3jkytnwv468wmmjdv6hk6y4` which has a note with a non-media link in it.
5. Observe that there is a link preview with the title and domain name showing on the bottom bar, with the rendered open graph preview card on top.
6. Navigate to `nevent1qqsp5pncw5hkwlvrf7652flumj3gv00s4q7vhwt0a645q0yp8gv56wskz4c38`.
7. Observe that there is a link preview with the title and domain name showing, but without a rendered open graph preview card because there is both an image link and a non-media link in the note content.
8. Open the left bar and tap `Settings`.
9. Tap `Appearance and filters`.
10. Turn off `Media previews`.
11. Navigate to `nevent1qqsrv8l8vx0pstf00hp8hhwg7nvtu07fk7qgnq66xruwsfqafwc3ddgpz4mhxue69uhkummnw3ezumtfd3hh2tnvdakqz9rhwden5te0dehhxarj9ehhsarj9ejx2aspzdmhxue69uhkummnw3ezuenv0yhxgetkqyv8wumn8ghj7mn0wd68ytnsd3jkytnwv468wmmjdv6hk6y4` which has a note with just a URL in the content.
12. Observe that there is a link preview with the title and domain name showing, but without a rendered open graph preview card.

**Results:**
- [x] PASS
- [ ] Partial PASS