### PR TITLE
Npub tag in draft-posts fixed

### DIFF
--- a/damus/Views/PostView.swift
+++ b/damus/Views/PostView.swift
@@ -863,7 +863,9 @@ func build_post(state: DamusState, post: NSAttributedString, action: PostAction,
 func build_post(state: DamusState, post: NSAttributedString, action: PostAction, uploadedMedias: [UploadedMedia], pubkeys: [Pubkey]) -> NostrPost {
     let post = NSMutableAttributedString(attributedString: post)
     post.enumerateAttributes(in: NSRange(location: 0, length: post.length), options: []) { attributes, range, stop in
-        if let link = attributes[.link] as? String {
+        let linkValue = attributes[.link]
+        let link = (linkValue as? String) ?? (linkValue as? URL)?.absoluteString
+        if let link {
             let nextCharIndex = range.upperBound
             if nextCharIndex < post.length,
                let nextChar = post.attributedSubstring(from: NSRange(location: nextCharIndex, length: 1)).string.first,

--- a/damusTests/PostViewTests.swift
+++ b/damusTests/PostViewTests.swift
@@ -176,6 +176,48 @@ final class PostViewTests: XCTestCase {
 
         XCTAssertEqual(post.tags, [["q", test_note.id.hex()]])
     }
+
+    func testBuildPostRecognizesStringsAsNpubs() throws {
+        // given
+        let expectedLink = "nostr:\(test_pubkey.npub)"
+        let content = NSMutableAttributedString(string: "@test", attributes: [
+            NSAttributedString.Key.link: "damus:\(expectedLink)"
+        ])
+
+        // when
+        let post = build_post(
+            state: test_damus_state,
+            post: content,
+            action: .posting(.user(test_pubkey)),
+            uploadedMedias: [],
+            pubkeys: []
+        )
+
+        // then
+        XCTAssertEqual(post.content, expectedLink)
+    }
+
+    func testBuildPostRecognizesUrlsAsNpubs() throws {
+        // given
+        guard let npubUrl = URL(string: "damus:nostr:\(test_pubkey.npub)") else {
+            return XCTFail("Could not create URL")
+        }
+        let content = NSMutableAttributedString(string: "@test", attributes: [
+            NSAttributedString.Key.link: npubUrl
+        ])
+
+        // when
+        let post = build_post(
+            state: test_damus_state,
+            post: content,
+            action: .posting(.user(test_pubkey)),
+            uploadedMedias: [],
+            pubkeys: []
+        )
+
+        // then
+        XCTAssertEqual(post.content, "nostr:\(test_pubkey.npub)")
+    }
 }
 
 func checkMentionLinkEditorHandling(


### PR DESCRIPTION

## Summary
Npub tag in draft-posts should be stored and retrieved. Damus stores both Strings and URLs in `NSAttributedString.Key.link`. Make Damus handle both.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report
**Device:** iPhone 16

**iOS:** 18.2

**Damus:** 1.15 (1) 94571ede

**Setup:** simulator and added unit tests

**Results:**
- [x] PASS

## Other notes

Has Damus considered using MVVM architecture pattern? For example `PostView` could use a `PostViewModel` for handling logic that is specific to its view which is now available for everyone in the global function `build_post()` to adress separation of concerns?
