### PR TITLE
Fix display issues with pasted or uploaded images

### DIFF
--- a/damus/Features/Posting/Views/PostView.swift
+++ b/damus/Features/Posting/Views/PostView.swift
@@ -630,44 +630,50 @@ struct PVImageCarouselView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
                 ForEach(media.indices, id: \.self) { index in
-                    ZStack(alignment: .topLeading) {
-                        if isSupportedVideo(url: media[index].uploadedURL) {
-                            VideoPlayer(player: configurePlayer(with: media[index].localURL))
-                                .frame(width: media.count == 1 ? deviceWidth * 0.8 : 250, height: media.count == 1 ? 400 : 250)
-                                .cornerRadius(10)
-                                .padding()
-                                .contextMenu { contextMenuContent(for: media[index]) }
-                        } else {
-                            KFAnimatedImage(media[index].uploadedURL)
-                                .imageContext(.note, disable_animation: false)
-                                .configure { view in
-                                    view.framePreloadCount = 3
+                    if isSupportedVideo(url: media[index].uploadedURL) {
+                        VideoPlayer(player: configurePlayer(with: media[index].localURL))
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: media.count == 1 ? deviceWidth * 0.8 : 250, alignment: .topLeading)
+                            .cornerRadius(10)
+                            .contextMenu { contextMenuContent(for: media[index]) }
+                            .overlay(
+                                Button(action: {
+                                    media.remove(at: index)
+                                }) {
+                                    closeImageView
                                 }
-                                .frame(width: media.count == 1 ? deviceWidth * 0.8 : 250, height: media.count == 1 ? 400 : 250)
-                                .cornerRadius(10)
-                                .padding()
-                                .contextMenu { contextMenuContent(for: media[index]) }
-                        }
-                        
-                        VStack {  // Set spacing to 0 to remove the gap between items
-                            Image("close-circle")
-                                .foregroundColor(.white)
-                                .padding(20)
-                                .shadow(radius: 5)
-                                .onTapGesture {
-                                    media.remove(at: index) // Direct removal using index
+                                    .padding([.top, .leading], 8),
+                                alignment: .topLeading
+                            )
+                            .overlay(
+                                Image(systemName: "video")
+                                    .foregroundColor(.white)
+                                    .padding(10)
+                                    .background(Color.black.opacity(0.5))
+                                    .clipShape(Circle())
+                                    .shadow(radius: 5)
+                                    .opacity(0.6),
+                                alignment: .bottomLeading
+                            )
+                    } else {
+                        KFAnimatedImage(media[index].uploadedURL)
+                            .imageContext(.note, disable_animation: false)
+                            .configure { view in
+                                view.framePreloadCount = 3
+                            }
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: media.count == 1 ? deviceWidth * 0.8 : 250, alignment: .topLeading)
+                            .cornerRadius(10)
+                            .contextMenu { contextMenuContent(for: media[index]) }
+                            .overlay(
+                                Button(action: {
+                                    media.remove(at: index)
+                                }) {
+                                    closeImageView
                                 }
-                            
-                            if isSupportedVideo(url: media[index].uploadedURL) {
-                                Spacer()
-                                    Image(systemName: "video")
-                                        .foregroundColor(.white)
-                                        .padding(10)
-                                        .shadow(radius: 5)
-                                        .opacity(0.6)
-                                }
-                        }
-                        .padding(.bottom, 35)
+                                    .padding([.top, .leading], 8),
+                                alignment: .topLeading
+                            )
                     }
                 }
                 if let mediaUP = mediaUnderProgress, let progress = imageUploadModel.progress {
@@ -675,8 +681,8 @@ struct PVImageCarouselView: View {
                         // Media under upload-progress
                         Image(uiImage: getImage(media: mediaUP))
                             .resizable()
-                            .aspectRatio(contentMode: .fill)
-                            .frame(width: media.count == 0 ? deviceWidth * 0.8 : 250, height: media.count == 0 ? 400 : 250)
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: media.count == 1 ? deviceWidth * 0.8 : 250, alignment: .topLeading)
                             .cornerRadius(10)
                             .opacity(0.3)
                             .padding()
@@ -712,6 +718,14 @@ struct PVImageCarouselView: View {
         player.allowsExternalPlayback = false
         player.usesExternalPlaybackWhileExternalScreenIsActive = false
         return player
+    }
+
+    private var closeImageView: some View {
+        Image("close-circle")
+            .foregroundColor(.white)
+            .background(Color.black.opacity(0.5))
+            .clipShape(Circle())
+            .shadow(radius: 5)
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix aspect ratio, use `fit` 
- Remove fixed height on image frame to align close button on image
- Use overlay instead of ZStack to reduce complexity
- Add background to close button to get better contrast in light mode
- Change close-image to be a button for better accessibility

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 15, iPhone 13

**iOS:** 18.5, 17.6.1

**Damus:** 1.12 (682) 4cf8097, 1.15 (1) ce19e12d

**Steps:** uploaded and pasted image and videos, tried both single image/video and multiple

**Results:**
- [x] PASS

before multiple:
![before-multiple](https://github.com/user-attachments/assets/155e308c-85a7-49d1-a2f0-c2dd573f875a)

after multiple:
![multi](https://github.com/user-attachments/assets/1e458c50-7958-432f-9670-78f46bbc5315)


before single:
![before-single](https://github.com/user-attachments/assets/7400ed91-3a67-4779-b716-63c12d868fb8)

after single: 
![sing](https://github.com/user-attachments/assets/03637c0e-f6b8-4926-b9b4-94e3c2f52102)

