### PR TITLE
Fix #nsfw tag filtering to be case insensitive

### DIFF
--- a/damus/Models/ContentFilters.swift
+++ b/damus/Models/ContentFilters.swift
@@ -31,7 +31,7 @@ enum FilterState : Int {
 
 /// Simple filter to determine whether to show posts with #nsfw tags
 func nsfw_tag_filter(ev: NostrEvent) -> Bool {
-    return ev.referenced_hashtags.first(where: { t in t.hashtag == "nsfw" }) == nil
+    return ev.referenced_hashtags.first(where: { t in t.hashtag.caseInsensitiveCompare("nsfw") == .orderedSame }) == nil
 }
 
 func get_repost_of_muted_user_filter(damus_state: DamusState) -> ((_ ev: NostrEvent) -> Bool) {


### PR DESCRIPTION
## Summary

Closes: https://github.com/damus-io/damus/issues/3131

Tags with nsfw hashtags appear on feeds even if the setting to filter them out is enabled. The issue is that the code is doing a case sensitive match on `nsfw` in all lower case. It should be a case insensitive compare instead.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.5

**Damus:** 6076aaf73893cf7624a411df4bc3096019df5d98

**Steps:**
1. In Settings > Appearance and filters. Disable `Hide notes with nsfw tags`
2. Go to kojira's profile and scroll down until you find this note: https://damus.io/nevent1qqsfdlzvdat4zm7ek4yndy0au2sw7vpp0tnlqjxek0m5s43ymj3u2ucpz4mhxue69uhhyetvv9ujucm0d9hx7uewd9hsz9rhwden5te0wahkuuewvdskcanp9ejx2asprpmhxue69uhhqun9d45h2mfwwpexjmtpdshxuet5qys8wumn8ghj7un9d3shjtnvv4uxjmn8w3hkucnfw33k76tw9ehhyec4mt9h5 posted at 2025-07-09 10:55AM Eastern Time. It should appear on the feed.
3. Go back to settings from step 1 and enable the setting.
4. Scroll on the feed from step 2 again and observe that the note with the nsfw tag does not appear even though the hashtag is in all caps.

**Results:**
- [x] PASS