### PR TITLE
Add relay hints to tags and identifiers

### DIFF
--- a/damus/Models/Mentions.swift
+++ b/damus/Models/Mentions.swift
@@ -64,10 +64,35 @@ enum MentionRef: TagKeys, TagConvertible, Equatable, Hashable {
         switch self {
         case .pubkey(let pubkey): return ["p", pubkey.hex()]
         case .note(let noteId):   return ["e", noteId.hex()]
-        case .nevent(let nevent): return ["e", nevent.noteid.hex()]
-        case .nprofile(let nprofile): return ["p", nprofile.author.hex()]
+        case .nevent(let nevent):
+            var tagBuilder = ["e", nevent.noteid.hex()]
+
+            let relay = nevent.relays.first
+            if let author = nevent.author?.hex() {
+                tagBuilder.append(relay ?? "")
+                tagBuilder.append(author)
+            } else if let relay {
+                tagBuilder.append(relay)
+            }
+
+            return tagBuilder
+        case .nprofile(let nprofile):
+            var tagBuilder = ["p", nprofile.author.hex()]
+
+            if let relay = nprofile.relays.first {
+                tagBuilder.append(relay)
+            }
+
+            return tagBuilder
         case .nrelay(let url): return ["r", url]
-        case .naddr(let naddr): return ["a", naddr.kind.description + ":" + naddr.author.hex() + ":" + naddr.identifier.string()]
+        case .naddr(let naddr):
+            var tagBuilder = ["a", "\(naddr.kind.description):\(naddr.author.hex()):\(naddr.identifier.string())"]
+
+            if let relay = naddr.relays.first {
+                tagBuilder.append(relay)
+            }
+
+            return tagBuilder
         }
     }
 

--- a/damus/Models/NostrNetworkManager/NostrNetworkManager.swift
+++ b/damus/Models/NostrNetworkManager/NostrNetworkManager.swift
@@ -51,6 +51,16 @@ class NostrNetworkManager {
     func connect() {
         self.userRelayList.connect()
     }
+
+    func relaysForEvent(event: NostrEvent) -> [RelayURL] {
+        // TODO(tyiu) Ideally this list would be sorted by the event author's outbox relay preferences
+        // and reliability of relays to maximize chances of others finding this event.
+        if let relays = pool.seen[event.id] {
+            return Array(relays)
+        }
+
+        return []
+    }
 }
 
 

--- a/damus/Models/ProfileModel.swift
+++ b/damus/Models/ProfileModel.swift
@@ -22,8 +22,6 @@ class ProfileModel: ObservableObject, Equatable {
         }
         return nil
     }
-
-    private let MAX_SHARE_RELAYS = 4
     
     var events: EventHolder
     let pubkey: Pubkey
@@ -222,7 +220,7 @@ class ProfileModel: ObservableObject, Equatable {
     }
 
     func getCappedRelayStrings() -> [String] {
-        return self.relay_urls?.prefix(MAX_SHARE_RELAYS).map { $0.absoluteString } ?? []
+        return self.relay_urls?.prefix(Constants.MAX_SHARE_RELAYS).map { $0.absoluteString } ?? []
     }
 }
 

--- a/damus/Util/Bech32Object.swift
+++ b/damus/Util/Bech32Object.swift
@@ -47,6 +47,10 @@ struct NEvent : Equatable, Hashable {
         self.author = author
         self.kind = kind
     }
+
+    init(event: NostrEvent, relays: [String]) {
+        self.init(noteid: event.id, relays: relays, author: event.pubkey, kind: event.kind)
+    }
 }
 
 struct NProfile : Equatable, Hashable {

--- a/damus/Util/Constants.swift
+++ b/damus/Util/Constants.swift
@@ -45,4 +45,5 @@ class Constants {
     
     // MARK: General constants
     static let GIF_IMAGE_TYPE: String = "com.compuserve.gif"
+    static let MAX_SHARE_RELAYS = 4
 }

--- a/damus/Views/ActionBar/RepostAction.swift
+++ b/damus/Views/ActionBar/RepostAction.swift
@@ -21,7 +21,7 @@ struct RepostAction: View {
                 dismiss()
                             
                 guard let keypair = self.damus_state.keypair.to_full(),
-                      let boost = make_boost_event(keypair: keypair, boosted: self.event) else {
+                      let boost = make_boost_event(keypair: keypair, boosted: self.event, relayURL: damus_state.nostrNetwork.relaysForEvent(event: self.event).first) else {
                     return
                 }
 

--- a/damus/Views/ActionBar/ShareAction.swift
+++ b/damus/Views/ActionBar/ShareAction.swift
@@ -26,7 +26,16 @@ struct ShareAction: View {
         self.userProfile = userProfile
         self._show_share = show_share
     }
-    
+
+    var event_relay_url_strings: [String] {
+        let relays = userProfile.damus.nostrNetwork.relaysForEvent(event: event)
+        if !relays.isEmpty {
+            return relays.prefix(Constants.MAX_SHARE_RELAYS).map { $0.absoluteString }
+        }
+
+        return userProfile.getCappedRelayStrings()
+    }
+
     var body: some View {
         
         VStack {
@@ -40,7 +49,7 @@ struct ShareAction: View {
                 
                 ShareActionButton(img: "link", text: NSLocalizedString("Copy Link", comment: "Button to copy link to note")) {
                     dismiss()
-                    UIPasteboard.general.string = "https://damus.io/" + Bech32Object.encode(.nevent(NEvent(noteid: event.id, relays: userProfile.getCappedRelayStrings())))
+                    UIPasteboard.general.string = "https://damus.io/" + Bech32Object.encode(.nevent(NEvent(event: event, relays: event_relay_url_strings)))
                 }
                 
                 let bookmarkImg = isBookmarked ? "bookmark.fill" : "bookmark"

--- a/damus/Views/Chat/ChatEventView.swift
+++ b/damus/Views/Chat/ChatEventView.swift
@@ -235,7 +235,7 @@ struct ChatEventView: View {
     
     func send_like(emoji: String) {
         guard let keypair = damus_state.keypair.to_full(),
-              let like_ev = make_like_event(keypair: keypair, liked: event, content: emoji) else {
+              let like_ev = make_like_event(keypair: keypair, liked: event, content: emoji, relayURL: damus_state.nostrNetwork.relaysForEvent(event: event).first) else {
             return
         }
 

--- a/damus/Views/Events/EventMenu.swift
+++ b/damus/Views/Events/EventMenu.swift
@@ -63,7 +63,16 @@ struct MenuItems: View {
         self.target_pubkey = target_pubkey
         self.profileModel = profileModel
     }
-    
+
+    var event_relay_url_strings: [String] {
+        let relays = damus_state.nostrNetwork.relaysForEvent(event: event)
+        if !relays.isEmpty {
+            return relays.prefix(Constants.MAX_SHARE_RELAYS).map { $0.absoluteString }
+        }
+
+        return profileModel.getCappedRelayStrings()
+    }
+
     var body: some View {
         Group {
             Button {
@@ -79,7 +88,7 @@ struct MenuItems: View {
             }
 
             Button {
-                UIPasteboard.general.string = event.id.bech32
+                UIPasteboard.general.string = Bech32Object.encode(.nevent(NEvent(event: event, relays: event_relay_url_strings)))
             } label: {
                 Label(NSLocalizedString("Copy note ID", comment: "Context menu option for copying the ID of the note."), image: "note-book")
             }

--- a/damusTests/Bech32ObjectTests.swift
+++ b/damusTests/Bech32ObjectTests.swift
@@ -167,7 +167,23 @@ class Bech32ObjectTests: XCTestCase {
         
         XCTAssertEqual(expectedEncoding, actualEncoding)
     }
-    
+
+    func testTLVEncoding_NeventFromNostrEvent_ValidContent() throws {
+        let relays = ["wss://relay.damus.io", "wss://relay.nostr.band"]
+        let nevent = NEvent(event: test_note, relays: relays)
+
+        XCTAssertEqual(nevent.noteid, test_note.id)
+        XCTAssertEqual(nevent.relays, relays)
+        XCTAssertEqual(nevent.author, test_note.pubkey)
+        XCTAssertEqual(nevent.kind, test_note.kind)
+
+        let expectedEncoding = "nevent1qqsqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqpz3mhxue69uhhyetvv9ujuerpd46hxtnfduq3vamnwvaz7tmjv4kxz7fwdehhxarj9e3xzmnyqgsgydql3q4ka27d9wnlrmus4tvkrnc8ftc4h8h5fgyln54gl0a7dgsrqsqqqqqpppe7n6"
+
+        let actualEncoding = Bech32Object.encode(.nevent(NEvent(event: test_note, relays: relays)))
+
+        XCTAssertEqual(expectedEncoding, actualEncoding)
+    }
+
     func testTLVEncoding_NProfileExample_ValidContent() throws {
         guard let author = try bech32_decode("npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6") else {
             XCTFail()

--- a/damusTests/LikeTests.swift
+++ b/damusTests/LikeTests.swift
@@ -25,7 +25,7 @@ class LikeTests: XCTestCase {
                                keypair: test_keypair,
                                tags: [cindy.tag, bob.tag])!
         let id = liked.id
-        let like_ev = make_like_event(keypair: test_keypair_full, liked: liked)!
+        let like_ev = make_like_event(keypair: test_keypair_full, liked: liked, relayURL: nil)!
 
         XCTAssertTrue(like_ev.referenced_pubkeys.contains(test_keypair.pubkey))
         XCTAssertTrue(like_ev.referenced_pubkeys.contains(cindy))
@@ -36,12 +36,12 @@ class LikeTests: XCTestCase {
     func testToReactionEmoji() {
         let liked = NostrEvent(content: "awesome #[0] post", keypair: test_keypair, tags: [["p", "cindy"], ["e", "bob"]])!
 
-        let emptyReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "")!
-        let plusReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "+")!
-        let minusReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "-")!
-        let heartReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "❤️")!
-        let thumbsUpReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "👍")!
-        let shakaReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "🤙")!
+        let emptyReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "", relayURL: nil)!
+        let plusReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "+", relayURL: nil)!
+        let minusReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "-", relayURL: nil)!
+        let heartReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "❤️", relayURL: nil)!
+        let thumbsUpReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "👍", relayURL: nil)!
+        let shakaReaction = make_like_event(keypair: test_keypair_full, liked: liked, content: "🤙", relayURL: nil)!
 
         XCTAssertEqual(to_reaction_emoji(ev: emptyReaction), "❤️")
         XCTAssertEqual(to_reaction_emoji(ev: plusReaction), "❤️")

--- a/damusTests/PostViewTests.swift
+++ b/damusTests/PostViewTests.swift
@@ -174,7 +174,7 @@ final class PostViewTests: XCTestCase {
     func testQuoteRepost() {
         let post = build_post(state: test_damus_state, post: .init(), action: .quoting(test_note), uploadedMedias: [], pubkeys: [])
 
-        XCTAssertEqual(post.tags, [["q", test_note.id.hex()]])
+        XCTAssertEqual(post.tags, [["q", test_note.id.hex(), "", jack_keypair.pubkey.hex()], ["p", jack_keypair.pubkey.hex()]])
     }
 
     func testBuildPostRecognizesStringsAsNpubs() throws {


### PR DESCRIPTION
## Summary

This PR adds relay hints to tags and identifiers to improve content discovery on the network. Previously, we were referencing identifiers without them, so other clients would need to guess where to look for that content, leading to a broken user experience.

This PR does not take care of all the places that could have relay hints added. It only adds the ones where it's convenient. To fully tackle the rest, we would need a fundamental change in some of the core code.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.5

**Damus:** 96cd6dc79800e7857af461085d912ea5bf2ebdd7

**Steps:**
1. Go to any note and tap on the `...` menu, and tap `Copy note ID`.
2. Observe that the clipboard has an `nevent` instead of a `note1` identifier now.
3. Paste that `nevent` identifier into search and observe that note appear.
4. Also paste it into https://njump.me/nevent... and observe that it appears there as well.
5. Tap the share button on any note and `Copy Link`. 
6. Observe that the clipboard has an `nevent`. This has not changed, but the selection of relays now prefers actual relays that we found the event from first.
7. Repeat step 5-6 but use `Share Link` instead.
8. Try replying to threads, reposting, quote reposting, reacting. You should observe that we now provide relay hints in the e and p tags.
9. For quote reposting, observe that there is a nostr:nevent... appended to the end of the note content instead of a nostr:note1...

**Results:**
- [x] PASS