### PR TITLE
Add relay count and relay view to events

### DIFF
--- a/damus/Models/ActionBarModel.swift
+++ b/damus/Models/ActionBarModel.swift
@@ -25,12 +25,13 @@ class ActionBarModel: ObservableObject {
     @Published private(set) var zaps: Int
     @Published var zap_total: Int64
     @Published var replies: Int
-    
+    @Published var relays: Int
+
     static func empty() -> ActionBarModel {
         return ActionBarModel(likes: 0, boosts: 0, zaps: 0, zap_total: 0, replies: 0, our_like: nil, our_boost: nil, our_zap: nil, our_reply: nil)
     }
     
-    init(likes: Int = 0, boosts: Int = 0, zaps: Int = 0, zap_total: Int64 = 0, replies: Int = 0, our_like: NostrEvent? = nil, our_boost: NostrEvent? = nil, our_zap: Zapping? = nil, our_reply: NostrEvent? = nil, our_quote_repost: NostrEvent? = nil, quote_reposts: Int = 0) {
+    init(likes: Int = 0, boosts: Int = 0, zaps: Int = 0, zap_total: Int64 = 0, replies: Int = 0, our_like: NostrEvent? = nil, our_boost: NostrEvent? = nil, our_zap: Zapping? = nil, our_reply: NostrEvent? = nil, our_quote_repost: NostrEvent? = nil, quote_reposts: Int = 0, relays: Int = 0) {
         self.likes = likes
         self.boosts = boosts
         self.zaps = zaps
@@ -42,6 +43,7 @@ class ActionBarModel: ObservableObject {
         self.our_reply = our_reply
         self.our_quote_repost = our_quote_repost
         self.quote_reposts = quote_reposts
+        self.relays = relays
     }
     
     func update(damus: DamusState, evid: NoteId) {
@@ -56,11 +58,12 @@ class ActionBarModel: ObservableObject {
         self.our_zap = damus.zaps.our_zaps[evid]?.first
         self.our_reply = damus.replies.our_reply(evid)
         self.our_quote_repost = damus.quote_reposts.our_events[evid]
+        self.relays = (damus.nostrNetwork.pool.seen[evid] ?? []).count
         self.objectWillChange.send()
     }
     
     var is_empty: Bool {
-        return likes == 0 && boosts == 0 && zaps == 0
+        return likes == 0 && boosts == 0 && zaps == 0 && quote_reposts == 0 && relays == 0
     }
     
     var liked: Bool {

--- a/damus/Nostr/RelayPool.swift
+++ b/damus/Nostr/RelayPool.swift
@@ -357,6 +357,7 @@ class RelayPool {
                 }
                 seen[nev.id, default: Set()].insert(relay_id)
                 counts[relay_id, default: 0] += 1
+                notify(.update_stats(note_id: nev.id))
             }
         }
     }

--- a/damus/Views/ActionBar/EventDetailBar.swift
+++ b/damus/Views/ActionBar/EventDetailBar.swift
@@ -59,6 +59,16 @@ struct EventDetailBar: View {
                 }
                 .buttonStyle(PlainButtonStyle())
             }
+
+            if bar.relays > 0 {
+                let relays = Array(state.nostrNetwork.pool.seen[target] ?? [])
+                NavigationLink(value: Route.UserRelays(relays: relays)) {
+                    let nounString = pluralizedString(key: "relays_count", count: bar.relays)
+                    let noun = Text(nounString).foregroundColor(.gray)
+                    Text("\(Text(verbatim: bar.relays.formatted()).font(.body.bold())) \(noun)", comment: "Sentence composed of 2 variables to describe how many relays a note was found on. In source English, the first variable is the number of relays, and the second variable is 'Relay' or 'Relays'.")
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes: https://github.com/damus-io/damus/issues/1029

This change adds the relay count to the event detail bar and tapping on it will bring up the relay list for that event.

Some users may want to know which relays an event came from to:
1. Manage their relay list if a large volume of unwanted spam appears to be coming from one of them
2. Ensure content is decentralized amongst the network.
3. Discover relays that are not on their relay list

| Event Detail Bar | Relay List |
|--|--|
| <img width="294" height="640" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-19 at 08 58 56 Medium" src="https://github.com/user-attachments/assets/925850b8-3a46-404e-9aa3-de23284dc878" /> | <img width="294" height="640" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-19 at 08 58 59 Medium" src="https://github.com/user-attachments/assets/e086ba29-ae62-4450-bafd-651c5fa440c0" /> |


## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.5

**Damus:** 225b5acbfb6bfb1e869e435df749592b8c24ea4c

**Steps:**
1. Navigate to any note.
2. Observe that there is a relay count on the event detail bar on the selected note.
3. Tapping on the relay brings up the relay list.

**Results:**
- [x] PASS