### PR TITLE
Fix app swap crash

### DIFF
--- a/nostrdb/NdbTxn.swift
+++ b/nostrdb/NdbTxn.swift
@@ -30,7 +30,10 @@ class NdbTxn<T>: RawNdbTxnAccessible {
         self.name = name ?? "txn"
         self.ndb = ndb
         self.generation = ndb.generation
-        if let active_txn = Thread.current.threadDictionary["ndb_txn"] as? ndb_txn {
+        if let active_txn = Thread.current.threadDictionary["ndb_txn"] as? ndb_txn,
+           let txn_generation = Thread.current.threadDictionary["txn_generation"] as? Int,
+           txn_generation == ndb.generation
+        {
             // some parent thread is active, use that instead
             print("txn: inherited txn")
             self.txn = active_txn
@@ -147,7 +150,10 @@ class SafeNdbTxn<T: ~Copyable> {
         var generation = ndb.generation
         var txn: ndb_txn
         let inherited: Bool
-        if let active_txn = Thread.current.threadDictionary["ndb_txn"] as? ndb_txn {
+        if let active_txn = Thread.current.threadDictionary["ndb_txn"] as? ndb_txn,
+           let txn_generation = Thread.current.threadDictionary["txn_generation"] as? Int,
+           txn_generation == ndb.generation
+        {
             // some parent thread is active, use that instead
             print("txn: inherited txn")
             txn = active_txn


### PR DESCRIPTION
## Summary

This commit fixes a crash that occurred when swapping between Damus and other apps.

When Damus enters background mode, NostrDB is closed and its resources released. When Damus re-enters foreground mode, NostrDB is reopened.

However, an issue with the transaction inheritance logic caused a race condition where a side menu profile lookup would get an obsolete transaction containing pointers that have been freed at the time NostrDB was closed, causing a "use-after-free" memory error.

The issue was fixed by improving the transaction inheritance logic to double-check if the "generation" counter (which auto increments when Damus closes and re-opens) matches the generation marked on the inherited transaction. This effectively prevents lookups from inheriting an obsolete transaction from a previous NostrDB generation.

Closes: https://github.com/damus-io/damus/issues/3167
Changelog-Fixed: Fixed an issue where the app would crash when swapping between apps

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone SE simulator

**iOS:** 18.2

**Damus:** 3fb3c0b4e2095f442c9cf588f7bf092badad181b

**Setup:** Nothing special

**Steps:**
1. Launch app
2. Swap apps and stay outside Damus until the logs say "NostrDB Closed"
3. Reopen the app
4. Repeat this several times. App should not crash

**Results:**
- [x] PASS
  - Notes: The original issue was not 100% reproducible on every single try, so this is not an iron clad test and statistically there is still room for a false positive. However, considering the `nostrdb-update` branch is experimental, it is more efficient to push this to that branch and launch an internal TestFlight to perform further validation.

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_
