### PR TITLE
Add support for scanning nprofile QR codes

### DIFF
--- a/damus/Shared/Components/QRCodeView.swift
+++ b/damus/Shared/Components/QRCodeView.swift
@@ -435,26 +435,20 @@ fileprivate struct QRCameraView<Content: View>: View {
             guard str.count != 0 else {
                 return nil
             }
-            
+
             if str.hasPrefix("nostr:") {
                 str.removeFirst("nostr:".count)
             }
-            
-            if let decoded = hex_decode(str),
-               str.count == 64
-            {
-                self.pubkey = Pubkey(Data(decoded))
-                return
+
+            let bech32 = Bech32Object.parse(str)
+            switch bech32 {
+            case .nprofile(let nprofile):
+                self.pubkey = nprofile.author
+            case .npub(let pubkey):
+                self.pubkey = pubkey
+            default:
+                return nil
             }
-            
-            if str.starts(with: "npub"),
-               let b32 = try? bech32_decode(str)
-            {
-                self.pubkey = Pubkey(b32.data)
-                return
-            }
-            
-            return nil
         }
     }
 }


### PR DESCRIPTION
## Summary

Amethyst produces nprofile QR codes. Damus supported only npub QR codes. This prevents users from connecting with others in real life who do not use Damus. This PR adds support for nprofile.

Closes: https://github.com/damus-io/damus/issues/2671

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 14 Pro

**iOS:** iOS 26 Public Beta 3

**Damus:** 8f6ea4d8dd47c22d292a91b75611904cb398bbc1

**Steps:**

1. Open side menu.
2. Tap QR code button on the top right corner of the side menu.
3. Tap the `Scan Code` button.
4. Scan the following QR codes from Damus and Amethyst to ensure that they open the profile whether it be an npub or nprofile QR code.

| npub from Damus | nprofile from Amethyst |
|--|--|
| <img width="294" height="640" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-16 at 14 28 27 Medium" src="https://github.com/user-attachments/assets/a182d62b-1030-4d76-856a-326eaea7b292" /> | <img width="303" height="640" alt="Screenshot_20250818_085041 Medium" src="https://github.com/user-attachments/assets/8065a075-17e0-4d40-8e3b-ec5f94160de6" /> |

**Results:**
- [x] PASS