### PR TITLE
Reduce default zap amount and deduplicate from preset zap amount items

### DIFF
--- a/damus/Features/Settings/Models/UserSettingsStore.swift
+++ b/damus/Features/Settings/Models/UserSettingsStore.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UIKit
 
-let fallback_zap_amount = 1000
+let fallback_zap_amount = 21
 let default_emoji_reactions = ["🤣", "🤙", "⚡", "💜", "🔥", "😀", "😃", "😄", "🥶"]
 
 func setting_property_key(key: String) -> String {

--- a/damus/Features/Zaps/Views/CustomizeZapView.swift
+++ b/damus/Features/Zaps/Views/CustomizeZapView.swift
@@ -8,6 +8,17 @@
 import SwiftUI
 import Combine
 
+let zapAmounts: [Int: String] = [
+    69: "😘",
+    420: "🌿",
+    5000: "💜",
+    10_000: "😍",
+    20_000: "🤩",
+    50_000: "🔥",
+    100_000: "🚀",
+    1_000_000: "🤯",
+]
+
 struct ZapAmountItem: Identifiable, Hashable {
     let amount: Int
     let icon: String
@@ -22,19 +33,14 @@ func get_default_zap_amount_item(_ def: Int) -> ZapAmountItem {
 }
 
 func get_zap_amount_items(_ default_zap_amt: Int) -> [ZapAmountItem] {
-    let def_item = get_default_zap_amount_item(default_zap_amt)
-    var entries = [
-        ZapAmountItem(amount: 69, icon: "😘"),
-        ZapAmountItem(amount: 420, icon: "🌿"),
-        ZapAmountItem(amount: 5000, icon: "💜"),
-        ZapAmountItem(amount: 10_000, icon: "😍"),
-        ZapAmountItem(amount: 20_000, icon: "🤩"),
-        ZapAmountItem(amount: 50_000, icon: "🔥"),
-        ZapAmountItem(amount: 100_000, icon: "🚀"),
-        ZapAmountItem(amount: 1_000_000, icon: "🤯"),
-    ]
-    entries.append(def_item)
-    
+    var entries = zapAmounts.map { ZapAmountItem(amount: $0.key, icon: $0.value) }
+
+    // Add default zap amount to the list only if it is not one of the preset entries so that it is not duplicated.
+    if zapAmounts[default_zap_amt] == nil {
+        let def_item = get_default_zap_amount_item(default_zap_amt)
+        entries.append(def_item)
+    }
+
     entries.sort { $0.amount < $1.amount }
     return entries
 }


### PR DESCRIPTION
## Summary

Closes: https://github.com/damus-io/damus/issues/3198

1000 sats as the default zap amount is too high given the change in price since it was last set. This PR reduces it down to 21 sats.

There was also a bug where if the default zap amount is equal to one of the preset zap amounts, it would be duplicated. I've deduplicated it from the list.

<img width="295" height="640" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-23 at 11 03 10 Medium" src="https://github.com/user-attachments/assets/f0aa0eaf-5699-4744-987c-369c3e22ffa8" />
<img width="295" height="640" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-23 at 11 02 54 Medium" src="https://github.com/user-attachments/assets/c9251b74-6db4-425f-89c2-e5502f69692b" />

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Max

**iOS:** iOS 18.5

**Damus:** 0b288c921ed87128457685e4564b9aab0b774d6c

**Setup:**
Set up a fresh account

**Steps:**
1. Long-press zap button on a note to bring up zap sheet.
2. Observe that 21 sats is the default with the 🤙 emoji.
3. Tap outside to dismiss.
4. Go to Settings > Zaps.
5. Change zap default from 21 sats to 10000 sats.
6. Go back to the feed and long-press the zap button on a note again.
7. Observe that 10000 sats appears only once and has the preset 😍 emoji instead of the 🤙 emoji (normally used for the default zap amount) because it has been deduplicated.
8. Observe that 1m (1 million) sats appears instead.

**Results:**
- [x] PASS