### PR TITLE
Add performance profiling requirement to PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,9 @@ _[Please provide a summary of the changes in this PR.]_
 
 - [ ] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
 - [ ] I have tested the changes in this PR
+- [ ] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
+    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
+    - If not needed, provide reason:
 - [ ] I have opened or referred to an existing github issue related to this change.
 - [ ] My PR is either small, or I have split it into smaller logical commits that are easier to review
 - [ ] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)


### PR DESCRIPTION
## Summary

This adds a performance profiling requirement to new PRs via the PR checklist.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [x] I do not need to add a changelog entry. Reason: No user-facing changes
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

Checked rich diff to make sure the markdown renders correctly and that the URL leads to the intended page.

**Results:**
- [x] PASS

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_
