### PR TITLE
fixes standalone longform replies. changes longform replies from kind…

### DIFF
--- a/damus/Core/Nostr/Id.swift
+++ b/damus/Core/Nostr/Id.swift
@@ -143,6 +143,41 @@ struct ReplaceableParam: TagConvertible {
     var keychar: AsciiCharacter { "d" }
 }
 
+struct AddressPointer: Hashable {
+    let kind: UInt32
+    let pubkey: Pubkey
+    let identifier: String
+
+    init(kind: UInt32, pubkey: Pubkey, identifier: String) {
+        self.kind = kind
+        self.pubkey = pubkey
+        self.identifier = identifier
+    }
+
+    init?(rawValue: String) {
+        let components = rawValue.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
+        guard components.count == 3,
+              let kind = UInt32(components[0]),
+              let pubkey = Pubkey(hex: String(components[1]))
+        else {
+            return nil
+        }
+
+        self.init(kind: kind, pubkey: pubkey, identifier: String(components[2]))
+    }
+
+    static func from(tag: TagSequence, allowedKeys: Set<AsciiCharacter>) -> AddressPointer? {
+        guard tag.count >= 2,
+              let key = tag[0].single_char,
+              allowedKeys.contains(key)
+        else {
+            return nil
+        }
+
+        return AddressPointer(rawValue: tag[1].string())
+    }
+}
+
 struct Signature: Codable, Hashable, Equatable {
     let data: Data
     

--- a/damus/Core/Nostr/NostrKind.swift
+++ b/damus/Core/Nostr/NostrKind.swift
@@ -18,6 +18,7 @@ enum NostrKind: UInt32, Codable {
     case boost = 6
     case like = 7
     case chat = 42
+    case comment = 1111
     case mute_list = 10000
     case relay_list = 10002
     case interest_list = 10015

--- a/damus/Features/Profile/Models/ProfileModel.swift
+++ b/damus/Features/Profile/Models/ProfileModel.swift
@@ -75,7 +75,7 @@ class ProfileModel: ObservableObject, Equatable {
     }
 
     func subscribe() {
-        var text_filter = NostrFilter(kinds: [.text, .longform, .highlight])
+        var text_filter = NostrFilter(kinds: [.text, .longform, .highlight, .comment])
         var profile_filter = NostrFilter(kinds: [.contacts, .metadata, .boost])
         var relay_list_filter = NostrFilter(kinds: [.relay_list], authors: [pubkey])
 
@@ -98,7 +98,7 @@ class ProfileModel: ObservableObject, Equatable {
             return
         }
 
-        let conversation_kinds: [NostrKind] = [.text, .longform, .highlight]
+        let conversation_kinds: [NostrKind] = [.text, .longform, .highlight, .comment]
         let limit: UInt32 = 500
         let conversations_filter_them = NostrFilter(kinds: conversation_kinds, pubkeys: [damus.pubkey], limit: limit, authors: [pubkey])
         let conversations_filter_us = NostrFilter(kinds: conversation_kinds, pubkeys: [pubkey], limit: limit, authors: [damus.pubkey])

--- a/damus/Features/Timeline/Models/HomeModel.swift
+++ b/damus/Features/Timeline/Models/HomeModel.swift
@@ -199,7 +199,7 @@ class HomeModel: ContactsDelegate {
         }
 
         switch kind {
-        case .chat, .longform, .text, .highlight:
+        case .chat, .longform, .text, .highlight, .comment:
             handle_text_event(sub_id: sub_id, ev)
         case .contacts:
             handle_contact_event(sub_id: sub_id, relay_id: relay_id, ev: ev)
@@ -637,7 +637,7 @@ class HomeModel: ContactsDelegate {
     func subscribe_to_home_filters(friends fs: [Pubkey]? = nil, relay_id: RelayURL? = nil) {
         // TODO: separate likes?
         var home_filter_kinds: [NostrKind] = [
-            .text, .longform, .boost, .highlight
+            .text, .longform, .boost, .highlight, .comment
         ]
         if !damus_state.settings.onlyzaps_mode {
             home_filter_kinds.append(.like)
@@ -1214,4 +1214,3 @@ func create_in_app_event_zap_notification(profiles: Profiles, zap: Zap, locale: 
         }
     }
 }
-


### PR DESCRIPTION
…-1 to kind-1111. displays kind-1111 replies to longform in replies tab. signed by -npub1zafcms4xya5ap9zr7xxr0jlrtrattwlesytn2s42030lzu0dwlzqpd26k5

## Summary

_eliminates standalone longform replies. changes longform replies from kind-1 to kind-1111. displays kind-1111 longform replies in replies tab_

## Checklist

- [ ] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [ ] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason:
- [x] I have opened or referred to an existing github issue related to this change. https://github.com/damus-io/damus/issues/1533
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [ ] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [ ] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** _Xcode iOS simulator 17 pro iOS 26_


**Steps:** _1. find longform article 2. reply to longform article 3. observe JSON for kind-1111 4. observe that kind-1111 reply displays in replies tab 5. confirm in third party app that supports kind-1111 that reply is attached to longform, and is kind-1111._

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_

## Other notes

