### PR TITLE
ui: Improve Damus Purple presentation in side view

### DIFF
--- a/damus/Features/Timeline/Views/SideMenuView.swift
+++ b/damus/Features/Timeline/Views/SideMenuView.swift
@@ -48,12 +48,30 @@ struct SideMenuView: View {
 
             if damus_state.purple.enable_purple {
                 NavigationLink(destination: DamusPurpleView(damus_state: damus_state)) {
-                    HStack(spacing: 23) {
-                        Image("nostr-hashtag")
+                    HStack(spacing: 16) {
+                        Image("damus-dark-logo")
+                            .resizable()
+                            .frame(width: 25, height: 25)
+                            .clipShape(RoundedRectangle(cornerRadius: 7.0))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 7)
+                                    .stroke(LinearGradient(
+                                        colors: [DamusColors.lighterPink.opacity(0.8), .white.opacity(0), DamusColors.deepPurple.opacity(0.6)],
+                                        startPoint: .topLeading,
+                                        endPoint: .bottomTrailing), lineWidth: 1)
+                            )
+                            .shadow(radius: 1)
                         Text("Purple")
-                            .foregroundColor(DamusColors.purple)
                             .font(.title2.weight(.semibold))
+                            .foregroundStyle(
+                                LinearGradient(
+                                    colors: [DamusColors.lighterPink, DamusColors.deepPurple],
+                                    startPoint: .bottomLeading,
+                                    endPoint: .topTrailing
+                                )
+                            )
                     }
+                    .padding(.leading, 2)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }


### PR DESCRIPTION
## Summary

This PR simply replaces the purple ostrich in the side view with the Damus Logo. 
As well as adding a gradient to the Purple text.
I think this better represents Damus Purple.

Changelog-Changed: Changed Damus Purple Side View logo and text

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason:
    This is simply a cosmetic change
- [ ] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** _[Please specify the device you used for testing]_
iPhone 13 mini

**iOS:** _[Please specify the iOS version you used for testing]_
17.2

**Damus:** _[Please specify the Damus version or commit hash you used for testing]_
1.15 (1) 8122a8a5

**Setup:** _[Please provide a brief description of the setup you used for testing, if applicable]_
XCode Simulator

**Steps:** _[Please provide a list of steps you took to test the changes in this PR]_
View new logo and text in dark/light mode in side view

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_

<img width="331" height="441" alt="Screenshot 2025-10-17 at 17 51 14" src="https://github.com/user-attachments/assets/26f0f093-4212-4cf4-a6ba-95ce4c26adac" />
<img width="353" height="448" alt="Screenshot 2025-10-17 at 17 51 35" src="https://github.com/user-attachments/assets/138a0962-387d-444d-88c4-f4d27e559cdc" />

