### PR TITLE
Fix NSFW filtering across universe

### DIFF
--- a/damus/Features/Bookmarks/Views/BookmarksView.swift
+++ b/damus/Features/Bookmarks/Views/BookmarksView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct BookmarksView: View {
     let state: DamusState
-    private let noneFilter: (NostrEvent) -> Bool = { _ in true }
     private let bookmarksTitle = NSLocalizedString("Bookmarks", comment: "Title of bookmarks view")
     @State private var clearAllAlert: Bool = false
     
@@ -37,7 +36,11 @@ struct BookmarksView: View {
                 }
             } else {
                 ScrollView {
-                    InnerTimelineView(events: EventHolder(events: bookmarks, incoming: []), damus: state, filter: noneFilter)
+                    InnerTimelineView(
+                        events: EventHolder(events: bookmarks, incoming: []),
+                        damus: state,
+                        filter: ContentFilters.default_filters(damus_state: state).filter(ev:)
+                    )
                 }
                 .padding(.bottom, 10 + tabHeight + getSafeAreaBottom())
             }

--- a/damus/Features/FollowPack/Views/FollowPackTimeline.swift
+++ b/damus/Features/FollowPack/Views/FollowPackTimeline.swift
@@ -52,7 +52,7 @@ struct FollowPackTimelineView<Content: View>: View {
                     .id("startblock")
                     .frame(height: 0)
 
-                FollowPackInnerView(events: events, damus: damus, filter: loading ? { _ in true } : filter, apply_mute_rules: self.apply_mute_rules)
+                FollowPackInnerView(events: events, damus: damus, filter: filter, apply_mute_rules: self.apply_mute_rules)
                     .redacted(reason: loading ? .placeholder : [])
                     .shimmer(loading)
                     .disabled(loading)
@@ -132,4 +132,3 @@ struct FollowPackInnerView: View {
         
     }
 }
-

--- a/damus/Features/Timeline/Models/ContentFilters.swift
+++ b/damus/Features/Timeline/Models/ContentFilters.swift
@@ -43,9 +43,16 @@ enum FilterState : Int {
     }
 }
 
+/// Returns true when an event is tagged with #nsfw (case-insensitive).
+func event_has_nsfw_tag(_ ev: NostrEvent) -> Bool {
+    return ev.referenced_hashtags.contains { tag in
+        tag.hashtag.caseInsensitiveCompare("nsfw") == .orderedSame
+    }
+}
+
 /// Simple filter to determine whether to show posts with #nsfw tags
 func nsfw_tag_filter(ev: NostrEvent) -> Bool {
-    return ev.referenced_hashtags.first(where: { t in t.hashtag.caseInsensitiveCompare("nsfw") == .orderedSame }) == nil
+    return !event_has_nsfw_tag(ev)
 }
 
 func get_repost_of_muted_user_filter(damus_state: DamusState) -> ((_ ev: NostrEvent) -> Bool) {

--- a/damus/Features/Timeline/Models/HomeModel.swift
+++ b/damus/Features/Timeline/Models/HomeModel.swift
@@ -1157,6 +1157,20 @@ func should_show_event(state: DamusState, ev: NostrEvent) -> Bool {
         return false
     }
 
+    if state.settings.hide_nsfw_tagged_content {
+        if event_has_nsfw_tag(ev) {
+            return false
+        }
+
+        if ev.known_kind == .boost,
+           let inner_ev = ev.get_cached_inner_event(cache: state.events),
+           inner_ev.referenced_hashtags.contains(where: { tag in
+               tag.hashtag.caseInsensitiveCompare("nsfw") == .orderedSame
+           }) {
+            return false
+        }
+    }
+
     return ev.should_show_event
 }
 
@@ -1214,4 +1228,3 @@ func create_in_app_event_zap_notification(profiles: Profiles, zap: Zap, locale: 
         }
     }
 }
-

--- a/damus/Features/Timeline/Views/TimelineView.swift
+++ b/damus/Features/Timeline/Views/TimelineView.swift
@@ -61,7 +61,7 @@ struct TimelineView<Content: View>: View {
                     .id("startblock")
                     .frame(height: 0)
 
-                InnerTimelineView(events: events, damus: damus, filter: loading ? { _ in true } : filter, apply_mute_rules: self.apply_mute_rules)
+                InnerTimelineView(events: events, damus: damus, filter: filter, apply_mute_rules: self.apply_mute_rules)
                     .redacted(reason: loading ? .placeholder : [])
                     .shimmer(loading)
                     .disabled(loading)


### PR DESCRIPTION
-Added a reusable helper to detect #nsfw tags so all timelines share the same check.
- Updated timeline filtering (including boosts and loading states) plus bookmarks to respect the user’s “Hide #nsfw” preference everywhere.
-'platform=iOS Simulator,name=iPhone 15 Pro' build
-fixes https://github.com/damus-io/damus/issues/2203