### PR TITLE
Configure UI to be in compatibility mode

### DIFF
--- a/damus/Features/Timeline/Views/TimelineView.swift
+++ b/damus/Features/Timeline/Views/TimelineView.swift
@@ -50,6 +50,15 @@ struct TimelineView<Content: View>: View {
         MainContent
     }
     
+    var topPadding: CGFloat {
+        if #available(iOS 26.0, *) {
+            headerHeight
+        }
+        else {
+            headerHeight - getSafeAreaTop()
+        }
+    }
+    
     var MainContent: some View {
         ScrollViewReader { scroller in
             ScrollView {
@@ -65,7 +74,7 @@ struct TimelineView<Content: View>: View {
                     .redacted(reason: loading ? .placeholder : [])
                     .shimmer(loading)
                     .disabled(loading)
-                    .padding(.top, headerHeight - getSafeAreaTop())
+                    .padding(.top, topPadding)
                     .offsetY { previous, current in
                         if previous > current{
                             if direction != .up && current < 0 {

--- a/damus/Info.plist
+++ b/damus/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>INSendMessageIntent</string>


### PR DESCRIPTION
## Summary

This temporarily addresses iOS 26 UI issues by setting a UI configuration called "compatibility mode" until we implement full iOS 26 support.

See https://developer.apple.com/documentation/BundleResources/Information-Property-List/UIDesignRequiresCompatibility

Furthermore, it addresses one remaining UI issue with the timeline top padding by altering the padding calculation for iOS 26 targets.

Changelog-None
Closes: https://github.com/damus-io/damus/issues/3283

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: **Changes are minimal.**
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [x] I do not need to add a changelog entry. Reason: Should not change user-facing behaviour from previous public release
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device + iOS combos:** 
- iPhone 16e simulator @ iOS 26.0
- iPhone 16 simulator @ iOS 18.1

**Damus:** cacd6474941954445cf4de38850142778969a36f

**Setup:** None

**Steps:**
1. Check timeline view top note is not cutoff
2. Check profile view looks as it used to
3. Check full screen video controls work as expected
4. Check for overlapping text in notifications view

**Results:**
- [x] PASS

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_
