### PR TITLE
fix: Don't show onboarding when logged in with npub

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -303,8 +303,10 @@ struct ContentView: View {
             try? AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, mode: .default, options: .mixWithOthers)
             setup_notifications()
             if !hasSeenOnboardingSuggestions || damus_state!.settings.always_show_onboarding_suggestions {
-                active_sheet = .onboardingSuggestions
-                hasSeenOnboardingSuggestions = true
+                if damus_state.is_privkey_user {
+                    active_sheet = .onboardingSuggestions
+                    hasSeenOnboardingSuggestions = true
+                }
             }
             self.appDelegate?.state = damus_state
             Task {  // We probably don't need this to be a detached task. According to https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/#Defining-and-Calling-Asynchronous-Functions, awaits are only suspension points that do not block the thread.


### PR DESCRIPTION
This PR makes sure to not show the onboarding screens when a user is logged in with an npub as it doesn't make sense for them to see that.

Changelog-Fixes: Fixes issue where onboarding views are shown to npub users

## Summary

_[Please provide a summary of the changes in this PR.]_

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [ ] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: Simply adds a conditional, shouldn't affect performance
- [ ] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** _[Please specify the device you used for testing]_

iPhone 15 Pro Max

**iOS:** _[Please specify the iOS version you used for testing]_
17.0

**Damus:** _[Please specify the Damus version or commit hash you used for testing]_
1.15 (1) 02296d77

**Setup:** _[Please provide a brief description of the setup you used for testing, if applicable]_
XCode Simulator

**Steps:** _[Please provide a list of steps you took to test the changes in this PR]_
Verfied Onboarding isnt displayed when logged in with npub but still shows when a new user logged with nsec on first install

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_
