### PR TITLE
Add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Damus Overview
 
-Damus is an iOS client built around a local relay model ([damus-io/damus#3204](https://github.com/damus-io/damus/pull/3204)) to keep interactions snappy and resilient. The app operates on `nostrdb` ([source](https://github.com/damus-io/damus/tree/master/nostrdbm)), and agents working on Damus should maximize usage of `nostrdb` facilities whenever possible.
+Damus is an iOS client built around a local relay model ([damus-io/damus#3204](https://github.com/damus-io/damus/pull/3204)) to keep interactions snappy and resilient. The app operates on `nostrdb` ([source](https://github.com/damus-io/damus/tree/master/nostrdb)), and agents working on Damus should maximize usage of `nostrdb` facilities whenever possible.
 
 ## Codebase Layout
 


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` documenting expectations for automation agents contributing to Damus.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [ ] I have tested the changes in this PR
- [ ] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [ ] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [x] I do not need to add a changelog entry. Reason: Documentation-only addition for automation agents.
- [ ] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** N/A – documentation-only change

**iOS:** N/A

**Damus:** dd3634b2a3fb00b50308feb51b6fe394431ed1c3

**Setup:** Documentation content only

**Steps:** No runtime changes to exercise

**Results:**
- [ ] PASS
- [ ] Partial PASS
  - Details: N/A
- [x] Not Run
  - Details: Documentation-only change; no tests required.

## Other notes

- Ported upstream commit dd3634b2a3fb00b50308feb51b6fe394431ed1c3 as-is so the fork exposes agent guidance publicly.
