### PR TITLE
Hide the Favourites feature behind a feature flag

### DIFF
--- a/damus/Features/Profile/Views/ProfileActionSheetView.swift
+++ b/damus/Features/Profile/Views/ProfileActionSheetView.swift
@@ -150,7 +150,9 @@ struct ProfileActionSheetView: View {
             ScrollView(.horizontal) {
                 HStack(spacing: 20) {
                     followButton
-                    favoriteButton
+                    if damus_state.settings.enable_favourites_feature {
+                        favoriteButton
+                    }
                     zapButton
                     dmButton
                     if damus_state.keypair.pubkey != profile.pubkey && damus_state.keypair.privkey != nil {

--- a/damus/Features/Profile/Views/ProfileView.swift
+++ b/damus/Features/Profile/Views/ProfileView.swift
@@ -270,7 +270,9 @@ struct ProfileView: View {
 
     func actionSection(record: ProfileRecord?, pubkey: Pubkey) -> some View {
         return Group {
-            FavoriteButtonView(pubkey: profile.pubkey, damus_state: damus_state)
+            if damus_state.settings.enable_favourites_feature {
+                FavoriteButtonView(pubkey: profile.pubkey, damus_state: damus_state)
+            }
             if let record,
                let profile = record.profile,
                let lnurl = record.lnurl,

--- a/damus/Features/Settings/Models/UserSettingsStore.swift
+++ b/damus/Features/Settings/Models/UserSettingsStore.swift
@@ -253,6 +253,10 @@ class UserSettingsStore: ObservableObject {
     @Setting(key: "enable_experimental_load_new_content_button", default_value: false)
     var enable_experimental_load_new_content_button: Bool
     
+    /// Whether the app should show the Favourites feature (Damus Labs)
+    @Setting(key: "enable_favourites_feature", default_value: false)
+    var enable_favourites_feature: Bool
+    
     @StringSetting(key: "purple_environment", default_value: .production)
     var purple_enviroment: DamusPurpleEnvironment
 

--- a/damus/Features/Timeline/Models/HomeModel.swift
+++ b/damus/Features/Timeline/Models/HomeModel.swift
@@ -599,13 +599,15 @@ class HomeModel: ContactsDelegate, ObservableObject {
         }
 
         // Add filter for favorited users who we dont follow
-        let all_favorites = damus_state.contactCards.favorites
-        let favorited_not_followed = Array(all_favorites.subtracting(Set(friends)))
-        if !favorited_not_followed.isEmpty {
-            var favorites_filter = NostrFilter(kinds: home_filter_kinds)
-            favorites_filter.authors = favorited_not_followed
-            favorites_filter.limit = 500
-            home_filters.append(favorites_filter)
+        if damus_state.settings.enable_favourites_feature {
+            let all_favorites = damus_state.contactCards.favorites
+            let favorited_not_followed = Array(all_favorites.subtracting(Set(friends)))
+            if !favorited_not_followed.isEmpty {
+                var favorites_filter = NostrFilter(kinds: home_filter_kinds)
+                favorites_filter.authors = favorited_not_followed
+                favorites_filter.limit = 500
+                home_filters.append(favorites_filter)
+            }
         }
 
         self.homeHandlerTask?.cancel()

--- a/damus/Features/Timeline/Views/PostingTimelineView.swift
+++ b/damus/Features/Timeline/Views/PostingTimelineView.swift
@@ -40,7 +40,11 @@ struct PostingTimelineView: View {
     func content_filter(_ fstate: FilterState) -> ((NostrEvent) -> Bool) {
         var filters = ContentFilters.defaults(damus_state: damus_state)
         filters.append(fstate.filter)
-        switch timeline_source {
+        
+        // If favourites feature is disabled, always use follows
+        let sourceToUse = damus_state.settings.enable_favourites_feature ? timeline_source : .follows
+        
+        switch sourceToUse {
         case .follows:
             filters.append(damus_state.contacts.friend_filter)
         case .favorites:
@@ -67,15 +71,17 @@ struct PostingTimelineView: View {
 
                     HStack(alignment: .center) {
                         SignalView(state: damus_state, signal: home.signal)
-                        let switchView = PostingTimelineSwitcherView(
-                            damusState: damus_state,
-                            timelineSource: $timeline_source
-                        )
-                        if #available(iOS 17.0, *) {
-                            switchView
-                                .popoverTip(PostingTimelineSwitcherView.TimelineSwitcherTip.shared)
-                        } else {
-                            switchView
+                        if damus_state.settings.enable_favourites_feature {
+                            let switchView = PostingTimelineSwitcherView(
+                                damusState: damus_state,
+                                timelineSource: $timeline_source
+                            )
+                            if #available(iOS 17.0, *) {
+                                switchView
+                                    .popoverTip(PostingTimelineSwitcherView.TimelineSwitcherTip.shared)
+                            } else {
+                                switchView
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Some issues were encountered with this feature. Disabling it for now.

Once we have the full Damus Labs UI, we will add the feature there.

Changelog-Changed: Placed the Favorites feature behind a feature flag
Closes: https://github.com/damus-io/damus/issues/3304

## Checklist

<!-- 
CHOOSE YOUR CHECKLIST: 
- If this is an EXPERIMENTAL DAMUS LABS FEATURE, follow the "Experimental Feature Checklist" below and DELETE the "Standard PR Checklist"
- If this is a STANDARD PR, follow the "Standard PR Checklist" below and DELETE the "Experimental Feature Checklist"
-->

### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: Hiding a feature, very unlikely to affect performance
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16e simulator

**iOS:** iOS 26

**Damus:** 9aa371c95a38492bb47dd426b6cd93ee25beab6f

**Setup:** 
- Added a toggle in developer settings locally.
- Enable "reset tips on launch".

**Steps:**
1. Ensure the timeline shows posts from follows.
2. Ensure that the timeline switcher is not visible.
3. Ensure that the "favourite" heart button does not appear.

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_