### PR TITLE
Fix overriding mutelist bug

### DIFF
--- a/damus/Core/Networking/NostrNetworkManager/SubscriptionManager.swift
+++ b/damus/Core/Networking/NostrNetworkManager/SubscriptionManager.swift
@@ -533,7 +533,7 @@ extension NostrNetworkManager {
         /// Returns notes from both NostrDB and the network, in parallel, treating it with similar importance against the network relays. Generic EOSE is fired when EOSE is received from both the network and NostrDB
         /// `optimizeNetworkFilter`: Returns notes from ndb, then streams from the network with an added "since" filter set to the latest note stored on ndb.
         case ndbAndNetworkParallel(optimizeNetworkFilter: Bool)
-        /// Ignores the network. Used for testing purposes
+        /// Ignores the network.
         case ndbOnly
         
         var optimizeNetworkFilter: Bool {


### PR DESCRIPTION
## Summary

This commit adds a new event subscription task in HomeModel, one which streams low volume but important filters from NostrDB.

This was done to address an issue where the contact filters in the general handler task could yield too many notes from NostrDB, hitting its limits and clipping off important events such as mute-lists, leading to downstream issues such as unintended mute-list overrides.

This issue was not present since the last public release, therefore no changelog entry is needed.

Changelog-None
Closes: https://github.com/damus-io/damus/issues/3256

## Checklist

### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: No changes that could significantly affect performance.
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Setup:**
- Account with busy timeline
- "Old" mute-list (Last updated at least a few weeks ago)

**Steps:**
1. Restart app completely
2. Go to mute-list view. Mute-list should be present.

### Repro

**Device:** iPhone 13 Mini

**iOS:** 26

**Damus:** 01150155ab0cf500d8d8d604f337b8c8b7a5d18d

**Results:** REPRODUCED 3/3 (No mute-list present, meaning that it would override on the next mute addition)

### Test

**Device:** iPhone 13 Mini
**iOS:** 26

**Damus:** 645edc76364573985e309d02ec5aaf1c9f262a27

**Results:**
- [ ] PASS
- [x] Partial PASS (3 of 3)
  - Details: There seems to be an AttributeGraph cycle which does not seem to have been introduced in this change, so I had to manually check the existence of the mute-list.

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_