### PR TITLE
Expand hit test area for timeline switcher

### DIFF
--- a/damus/Features/Timeline/Views/PostingTimelineSwitcherView.swift
+++ b/damus/Features/Timeline/Views/PostingTimelineSwitcherView.swift
@@ -36,10 +36,9 @@ struct PostingTimelineSwitcherView: View {
                 }
             }
         } label: {
-            Image(systemName: "square.stack")
-                .foregroundColor(DamusColors.purple)
-                .frame(height: 35)
+            Color.clear
         }
+        .frame(width: 50, height: 35)
         .menuOrder(.fixed)
         .accessibilityLabel(NSLocalizedString("Timeline switcher, select \(TimelineSource.follows.description) or \(TimelineSource.favorites.description)", comment: "Accessibility label for the timeline switcher button at the topbar"))
     }
@@ -68,10 +67,13 @@ struct PostingTimelineSwitcherView: View {
 
 struct PostingTimelineSwitcherView_Previews: PreviewProvider {
     static var previews: some View {
-        PostingTimelineSwitcherView(
-            damusState: test_damus_state,
-            timelineSource: .constant(.follows)
-        )
+        VStack {
+            PostingTimelineSwitcherView(
+                damusState: test_damus_state,
+                timelineSource: .constant(.follows)
+            )
+            Spacer()
+        }
     }
 }
 

--- a/damus/Features/Timeline/Views/PostingTimelineView.swift
+++ b/damus/Features/Timeline/Views/PostingTimelineView.swift
@@ -64,7 +64,7 @@ struct PostingTimelineView: View {
                 HStack {}
                 .frame(height: getSafeAreaTop())
 
-                HStack(alignment: .top) {
+                HStack(alignment: .center) {
                     TopbarSideMenuButton(damus_state: damus_state, isSideBarOpened: $isSideBarOpened)
 
                     Spacer()
@@ -77,8 +77,12 @@ struct PostingTimelineView: View {
                                 timelineSource: $timeline_source
                             )
                             if #available(iOS 17.0, *) {
+                                Image(systemName: "square.stack")
+                                    .foregroundColor(DamusColors.purple)
+                                    .overlay(
                                 switchView
                                     .popoverTip(PostingTimelineSwitcherView.TimelineSwitcherTip.shared)
+                                    )
                             } else {
                                 switchView
                             }


### PR DESCRIPTION
## Summary

Fixes alignment of Timeline switcher and SignalView in Action bar. 
Fixes larger hit test area for Timeline switcher

## Checklist

### Experimental Feature Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md).
- [x] I have done some testing on the changes in this PR to ensure it is at least functional.
- [x] I made sure that this new feature is only available when the user opts-in from the Damus Labs screen, and does not affect the rest of the app when turned off. 
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review.
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin).
- [x] I have added an appropriate changelog entry to my commit in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc).
    - Example changelog entry: `Changelog-Added: Added experimental feature <X> to Damus Labs`

### Standard PR Checklist

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** iPhone 17 pro simulator

**iOS:** 26.1

**Damus:** 1.15

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_
<img width="488" height="278" alt="Skärmavbild 2025-12-07 kl  08 36 25" src="https://github.com/user-attachments/assets/be95f4e6-f1c2-4a9f-9616-d89eed06266d" />
