### PR TITLE
Fix async NdbNoteLender borrow scope (fix profile crash)

### DIFF
--- a/nostrdb/src/nostrdb.c
+++ b/nostrdb/src/nostrdb.c
@@ -2328,7 +2328,12 @@ static struct ndb_migration MIGRATIONS[] = {
 int ndb_end_query(struct ndb_txn *txn)
 {
 	// this works on read or write queries.
-	return mdb_txn_commit(txn->mdb_txn) == 0;
+	int rc = mdb_txn_commit(txn->mdb_txn);
+	if (rc != 0) {
+		/* Bubble up failures so callers have context for stuck transactions. */
+		fprintf(stderr, "ndb_end_query: mdb_txn_commit failed with %d\n", rc);
+	}
+	return rc == 0;
 }
 
 int ndb_note_verify(void *ctx, unsigned char *scratch, size_t scratch_size,


### PR DESCRIPTION
Fixes profile-view freezes linked to lingering LMDB child txns.

### testing 

BEFORE PR: nine out of nine (9/9) runs with 100% reproduction of profile crash prior to the PR.
AFTER PR: 0/9 freeze/crash reproduction. 



Closes: https://github.com/damus-io/damus/issues/3327

Signed-off-by: alltheseas