### PR TITLE
Fix profile crash

### DIFF
--- a/damus/Core/Networking/NostrNetworkManager/UserRelayListManager.swift
+++ b/damus/Core/Networking/NostrNetworkManager/UserRelayListManager.swift
@@ -135,13 +135,12 @@ extension NostrNetworkManager {
             let filter = NostrFilter(kinds: [.relay_list], authors: [delegate.keypair.pubkey])
             for await noteLender in self.reader.streamIndefinitely(filters: [filter]) {
                 let currentRelayListCreationDate = self.getUserCurrentRelayListCreationDate()
-                try? await noteLender.borrow({ note in
-                    guard note.pubkey == self.delegate.keypair.pubkey else { return }               // Ensure this new list was ours
-                    guard note.createdAt > (currentRelayListCreationDate ?? 0) else { return }      // Ensure this is a newer list
-                    guard let relayList = try? NIP65.RelayList(event: note) else { return }         // Ensure it is a valid NIP-65 list
-                    
-                    try? await self.set(userRelayList: relayList)                                         // Set the validated list
-                })
+                guard let note = noteLender.justGetACopy() else { continue }
+                guard note.pubkey == self.delegate.keypair.pubkey else { continue }               // Ensure this new list was ours
+                guard note.created_at > (currentRelayListCreationDate ?? 0) else { continue }     // Ensure this is a newer list
+                guard let relayList = try? NIP65.RelayList(event: note) else { continue }         // Ensure it is a valid NIP-65 list
+                
+                try? await self.set(userRelayList: relayList)                                     // Set the validated list
             }
         }
         


### PR DESCRIPTION
## Summary

This fixes a crash that would occasionally occur when visiting profiles.

NdbTxn objects were being deinitialized on different threads from their initialization, causing incorrect reference count decrements in thread-local transaction dictionaries. This led to premature destruction of shared ndb_txn C objects still in use by other tasks, resulting in use-after-free crashes.

The root cause is that Swift does not guarantee tasks resume on the same thread after await suspension points, while NdbTxn's init/deinit rely on thread-local storage to track inherited transaction reference counts.

This means that `NdbTxn` objects cannot be used in async functions, as that may cause the garbage collector to deinitialize `NdbTxn` at the end of such function, which may be running on a different thread at that point, causing the issue explained above.

The fix in this case is to eliminate the `async` version of the `NdbNoteLender.borrow` method, and update usages to utilize other available methods.

Note: This is a rewrite of the fix in https://github.com/damus-io/damus/pull/3329

Co-authored-by: alltheseas <64376233+alltheseas@users.noreply.github.com>

Closes: https://github.com/damus-io/damus/issues/3327

## Checklist

### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: _Small scoped changes_
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [x] I do not need to add a changelog entry. Reason: _Fix to an unreleased feature_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** iPhone 13 Mini

**iOS:** 26.1

**Damus:** 
- 37c434981b5517958f0f0320798cc2bf6545b19e
- Baseline for repro: 8c4783c62248ed30bb8525381ce058278289fdd8

**Setup:** Debugger attached

**Steps:**
1. Search for Jack Dorsey's profile
2. Click on the profile to visit it
3. Click "back" 
4. Repeat steps 2 and 3 several times and watch for memory crashes.

**Issue reproduction:**
- [x] REPRODUCED
    - Got 2 crashes out of 29 cycles of steps 2 and 3.

**Results:**
- [x] PASS
    - Got zero crashes out of 100 cycles of steps 2 and 3.


## Other notes

The testing in https://github.com/damus-io/damus/pull/3329 (similar fix) further proves the efficacy of this fix.