### PR TITLE
Fix thread UI jumpiness

### DIFF
--- a/damus/Features/Chat/ChatEventView.swift
+++ b/damus/Features/Chat/ChatEventView.swift
@@ -36,8 +36,23 @@ struct ChatEventView: View {
     @State var selected_emoji: Emoji?
 
     @State private var isOnTopHalfOfScreen: Bool = false
-    @ObservedObject var bar: ActionBarModel
+    @StateObject private var bar: ActionBarModel
     @Environment(\.swipeViewGroupSelection) var swipeViewGroupSelection
+    
+    init(event: NostrEvent, selected_event: NostrEvent, prev_ev: NostrEvent?, next_ev: NostrEvent?, damus_state: DamusState, thread: ThreadModel, scroll_to_event: ((_ id: NoteId) -> Void)?, focus_event: (() -> Void)?, highlight_bubble: Bool) {
+        self.event = event
+        self.selected_event = selected_event
+        self.prev_ev = prev_ev
+        self.next_ev = next_ev
+        self.damus_state = damus_state
+        self.thread = thread
+        self.scroll_to_event = scroll_to_event
+        self.focus_event = focus_event
+        self.highlight_bubble = highlight_bubble
+        
+        // Initialize @StateObject using wrappedValue
+        _bar = StateObject(wrappedValue: make_actionbar_model(ev: event.id, damus: damus_state))
+    }
     
     enum PopoverState: String {
         case closed
@@ -340,21 +355,17 @@ struct ChatEventView: View {
 }
 
 #Preview {
-    let bar = make_actionbar_model(ev: test_note.id, damus: test_damus_state)
-    return ChatEventView(event: test_note, selected_event: test_note, prev_ev: nil, next_ev: nil, damus_state: test_damus_state, thread: ThreadModel(event: test_note, damus_state: test_damus_state), scroll_to_event: nil, focus_event: nil, highlight_bubble: false, bar: bar)
+    return ChatEventView(event: test_note, selected_event: test_note, prev_ev: nil, next_ev: nil, damus_state: test_damus_state, thread: ThreadModel(event: test_note, damus_state: test_damus_state), scroll_to_event: nil, focus_event: nil, highlight_bubble: false)
 }
 
 #Preview {
-    let bar = make_actionbar_model(ev: test_note.id, damus: test_damus_state)
-    return ChatEventView(event: test_short_note, selected_event: test_note, prev_ev: nil, next_ev: nil, damus_state: test_damus_state, thread: ThreadModel(event: test_note, damus_state: test_damus_state), scroll_to_event: nil, focus_event: nil, highlight_bubble: false, bar: bar)
+    return ChatEventView(event: test_short_note, selected_event: test_note, prev_ev: nil, next_ev: nil, damus_state: test_damus_state, thread: ThreadModel(event: test_note, damus_state: test_damus_state), scroll_to_event: nil, focus_event: nil, highlight_bubble: false)
 }
 
 #Preview {
-    let bar = make_actionbar_model(ev: test_note.id, damus: test_damus_state)
-    return ChatEventView(event: test_short_note, selected_event: test_note, prev_ev: nil, next_ev: nil, damus_state: test_damus_state, thread: ThreadModel(event: test_note, damus_state: test_damus_state), scroll_to_event: nil, focus_event: nil, highlight_bubble: true, bar: bar)
+    return ChatEventView(event: test_short_note, selected_event: test_note, prev_ev: nil, next_ev: nil, damus_state: test_damus_state, thread: ThreadModel(event: test_note, damus_state: test_damus_state), scroll_to_event: nil, focus_event: nil, highlight_bubble: true)
 }
 
 #Preview {
-    let bar = make_actionbar_model(ev: test_note.id, damus: test_damus_state)
-    return ChatEventView(event: test_super_short_note, selected_event: test_note, prev_ev: nil, next_ev: nil, damus_state: test_damus_state, thread: ThreadModel(event: test_note, damus_state: test_damus_state), scroll_to_event: nil, focus_event: nil, highlight_bubble: false, bar: bar)
+    return ChatEventView(event: test_super_short_note, selected_event: test_note, prev_ev: nil, next_ev: nil, damus_state: test_damus_state, thread: ThreadModel(event: test_note, damus_state: test_damus_state), scroll_to_event: nil, focus_event: nil, highlight_bubble: false)
 }

--- a/damus/Features/Chat/ChatroomThreadView.swift
+++ b/damus/Features/Chat/ChatroomThreadView.swift
@@ -64,8 +64,7 @@ struct ChatroomThreadView: View {
                               focus_event: {
                     self.set_active_event(scroller: scroller, ev: ev)
                 },
-                              highlight_bubble: highlighted_note_id == ev.id,
-                              bar: make_actionbar_model(ev: ev.id, damus: damus)
+                              highlight_bubble: highlighted_note_id == ev.id
                 )
                 .id(ev.id)
                 .matchedGeometryEffect(id: ev.id.hex(), in: animation, anchor: .center)


### PR DESCRIPTION
## Summary

Since 991a4a8, the `make_actionbar_model` function introduced an async call to populate the action bar data.

This surfaced a pre-existing problem where the action bar model would reinstantiate in any SwiftUI render pass for the chat bubbles in `ChatroomThreadView`. This issue was not visible before because the whole computation happened directly on the main actor during the render, maintaining the illusion of a stable entity. Since the computation was moved to an async task (for performance and concurrency design reasons), it caused the action bar items to reload in each render pass, causing multiple re-renders and the jumpiness witnessed in the ticket.

The issue was addressed by making the action bar model initialization happen within ChatEventView itself, and wrapping it on `StateObject` to make that entity stable across re-renders.

This fixes an issue for an unreleased change, so no changelog entry is necessary.

Changelog-None
Fixes: 991a4a8
Closes: https://github.com/damus-io/damus/issues/3270

## Checklist

### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: Very narrowly scoped fix that would have no reason to affect performance negatively. In fact it almost guarantees a slight performance improvement.
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [x] I do not need to add a changelog entry. Reason: Fixing an unreleased bug
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 13 mini

**iOS:** 26.1

**Damus:** 
- Under test: 70d38612fecb29ac538d5d4b843a95995f0e1f55
- Baseline: 52115d07c2990fcd06f19bce62f1d5965c091b61

**Setup:** None

**Steps:**
1. Go to different large threads.
2. Navigate them, especially by clicking the small quote view that causes it to scroll.
3. Check if there is jumpiness during the UI transition.

**Repro results:**
- [x] REPRODUCED 3/3

**Test results:**
- [x] PASS (No UI jumpiness)

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_