### PR TITLE
Fix AttributeGraph cycle

### DIFF
--- a/damus/Features/Muting/Views/MutelistView.swift
+++ b/damus/Features/Muting/Views/MutelistView.swift
@@ -17,6 +17,8 @@ struct MutelistView: View {
     @State var words: [MuteItem] = []
     
     @State var new_text: String = ""
+    
+    @State var paddingBottom: CGFloat = 30
 
     func RemoveAction(item: MuteItem) -> some View {
         Button {
@@ -91,7 +93,7 @@ struct MutelistView: View {
             }
             Section(
                 header: Text(NSLocalizedString("Users", comment: "Section header title for a list of muted users.")),
-                footer: Text("").padding(.bottom, 10 + tabHeight + getSafeAreaBottom())
+                footer: VStack { EmptyView() }.padding(.bottom, paddingBottom)
             ) {
                 ForEach(users, id: \.self) { user in
                     if case let MuteItem.user(pubkey, _) = user {
@@ -110,6 +112,9 @@ struct MutelistView: View {
         .navigationTitle(NSLocalizedString("Muted", comment: "Navigation title of view to see list of muted users & phrases."))
         .onAppear {
             updateMuteItems()
+            // Note: Do not place this calculation on the view body, otherwise AttributeGraph cycles may occur, freezing the entire app
+            // FUTURE FIXME: The way the floating tab bar layout was setup feels a bit hacky. Can't we make that work without introspecting sizes of objects and manually computing layout numbers?
+            paddingBottom = 10 + tabHeight + getSafeAreaBottom()
         }
         .onReceive(handle_notify(.new_mutes)) { new_mutes in
             updateMuteItems()


### PR DESCRIPTION
## Summary

This fixes an AttributeGraph cycle on the mute list view that lead to freezes when accessing the view.

## Checklist

### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: Very small focused change
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16e simulator

**iOS:** 26.0

**Damus:** d0a94b71926b27ee2bd0c87c86cacf8d698a8a1c

**Setup:** At least one muted user on the mute list

**Steps:**
1. Go to the mute list view
2. Check if app freezes

**Repro:**
- Reproduced 3/3 times on 7eafe973d92c4f3889bb902cdc31ff59f0967244 in both simulator and real device

**Results:**
- [x] PASS


## Other notes

_[Please provide any other information that you think is relevant to this PR.]_
