### PR TITLE
Hide image URLs in kind1 rendering

### DIFF
--- a/damus/Features/Events/Models/NoteContent.swift
+++ b/damus/Features/Events/Models/NoteContent.swift
@@ -262,6 +262,11 @@ func render_blocks(blocks: borrowing NdbBlockGroup, profiles: Profiles, can_hide
                 invoices.append(inv)
             case .url(let url):
                 guard let url = URL(string: url.as_str()) else { return .loopContinue }
+                let url_type = classify_url(url)
+                if case .media(.image) = url_type {
+                    // Hide image URLs in the rendered text; the media itself is shown separately.
+                    return .loopContinue
+                }
                 return .loopReturn(str + url_str(url))
             case .mention_index:
                 return .loopContinue

--- a/damus/Features/Events/NoteContentView.swift
+++ b/damus/Features/Events/NoteContentView.swift
@@ -60,7 +60,10 @@ struct NoteContentView: View {
         if damus_state.settings.undistractMode {
             return .separated(.just_content(Undistractor.makeGibberish(text: event.get_content(damus_state.keypair))))
         }
-        return self.artifacts_model.state.artifacts ?? .separated(.just_content(event.get_content(damus_state.keypair)))
+        if let artifacts = self.artifacts_model.state.artifacts {
+            return artifacts
+        }
+        return render_immediately_available_note_content(ndb: damus_state.ndb, ev: event, profiles: damus_state.profiles, keypair: damus_state.keypair)
     }
     
     init(damus_state: DamusState, event: NostrEvent, blur_images: Bool, size: EventViewKind, options: EventViewOptions) {

--- a/damusTests/NoteContentViewTests.swift
+++ b/damusTests/NoteContentViewTests.swift
@@ -342,6 +342,21 @@ class NoteContentViewTests: XCTestCase {
         XCTAssertTrue((parsed.blocks[0].asURL != nil), "NoteContentView does not correctly parse an image block when url in JSON content contains optional escaped slashes.")
     }
     
+    func testImageUrlsAreNotRenderedInContent() throws {
+        let content = "Look at this https://damus.io/image.png wow"
+        let note = try XCTUnwrap(NostrEvent(content: content, keypair: test_keypair))
+        let parsed = try XCTUnwrap(parse_note_content(content: .init(note: note, keypair: test_keypair)))
+
+        let noteArtifactsSeparated: NoteArtifactsSeparated = render_blocks(blocks: parsed, profiles: test_damus_state.profiles, can_hide_last_previewable_refs: true)
+        let attributedText: AttributedString = noteArtifactsSeparated.content.attributed
+        let renderedText = attributedText.description
+
+        XCTAssertFalse(renderedText.contains("https://damus.io/image.png"))
+        XCTAssertTrue(renderedText.contains("Look at this"))
+        XCTAssertTrue(renderedText.contains("wow"))
+        XCTAssertEqual(noteArtifactsSeparated.images.first?.absoluteString, "https://damus.io/image.png")
+    }
+    
     /// Quick test that exercises the direct parsing methods (i.e. not fetching blocks from nostrdb) from `NdbBlockGroup`, and its bridging code with C.
     /// The parsing logic itself already has test coverage at the nostrdb level.
     func testDirectBlockParsing() {


### PR DESCRIPTION
closes https://github.com/damus-io/damus/issues/3370

Signed-off-by: alltheseas

## Summary

Hide image URLs in kind1 rendering
Before vs After
<img width="188" height="400" alt="image" src="https://github.com/user-attachments/assets/f4174582-4dda-4bb9-b720-23383a28f455" />
<img width="171" height="375" alt="image" src="https://github.com/user-attachments/assets/69b60919-c2c5-4e40-8d51-e6bdd8b2baf2" />

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason:
- [x] I have opened or referred to an existing github issue related to this change: https://github.com/damus-io/damus/issues/3370
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

simulator xcode iphone 17pro ios26

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_

## Other notes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image URLs in notes now display as separate media instead of appearing as inline text.

* **Bug Fixes**
  * Fixed note content rendering to properly exclude image URLs from text display.

* **Tests**
  * Added test to verify image URLs are correctly excluded from text rendering while preserving surrounding content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->