### PR TITLE
Hide empty chat action bar overlays

### DIFF
--- a/damus/Features/Actions/ActionBar/Views/EventActionBar.swift
+++ b/damus/Features/Actions/ActionBar/Views/EventActionBar.swift
@@ -185,32 +185,42 @@ struct EventActionBar: View {
         let should_hide_repost = hide_items_without_activity && bar.boosts == 0
         let should_hide_reactions = hide_items_without_activity && bar.likes == 0
         let zap_model = self.damus_state.events.get_cache_data(self.event.id).zaps_model
-        let should_hide_zap = hide_items_without_activity && zap_model.zap_total > 0
+        let should_hide_zap = hide_items_without_activity && zap_model.zap_total == 0
         let should_hide_share_button = hide_items_without_activity
+        // Only render the bar if at least one action is visible; avoids empty overlays/dots.
+        let has_any_action = (!should_hide_chat_bubble && damus_state.keypair.privkey != nil)
+            || !should_hide_repost
+            || (show_like && !should_hide_reactions)
+            || (!should_hide_zap && self.lnurl != nil)
+            || !should_hide_share_button
 
-        return HStack(spacing: options.contains(.no_spread) ? 10 : 0) {
-            if damus_state.keypair.privkey != nil && !should_hide_chat_bubble {
-                self.reply_button
-            }
-            
-            if !should_hide_repost {
-                self.space_if_spread
-                self.repost_button
-            }
-            
-            if show_like && !should_hide_reactions {
-                self.space_if_spread
-                self.like_button
-            }
-                
-            if let lnurl = self.lnurl, !should_hide_zap {
-                self.space_if_spread
-                NoteZapButton(damus_state: damus_state, target: ZapTarget.note(id: event.id, author: event.pubkey), lnurl: lnurl, zaps: zap_model)
-            }
-            
-            if !should_hide_share_button {
-                self.space_if_spread
-                self.share_button
+        return Group {
+            if has_any_action {
+                HStack(spacing: options.contains(.no_spread) ? 10 : 0) {
+                    if damus_state.keypair.privkey != nil && !should_hide_chat_bubble {
+                        self.reply_button
+                    }
+                    
+                    if !should_hide_repost {
+                        self.space_if_spread
+                        self.repost_button
+                    }
+                    
+                    if show_like && !should_hide_reactions {
+                        self.space_if_spread
+                        self.like_button
+                    }
+                        
+                    if let lnurl = self.lnurl, !should_hide_zap {
+                        self.space_if_spread
+                        NoteZapButton(damus_state: damus_state, target: ZapTarget.note(id: event.id, author: event.pubkey), lnurl: lnurl, zaps: zap_model)
+                    }
+                    
+                    if !should_hide_share_button {
+                        self.space_if_spread
+                        self.share_button
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: alltheseas

Closes https://github.com/damus-io/damus/issues/3368

## Summary

removes zap icon/circle artefacts from bottom left corner of own replies.

## Checklist

### Standard PR Checklist


- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [ ] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason:
- [x] I have opened or referred to an existing github issue related to this change:https://github.com/damus-io/damus/issues/3368
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [ ] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [ x I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

iOS 26 13 mini 
scroll to thread with own replies, verify that there is no artefact in own purple chat bubble bottom left corner
### before
<img width="190" height="380" alt="image" src="https://github.com/user-attachments/assets/8bb882a4-904b-40e3-8dc4-1d07cdf6f285" />


### after
<img width="195" height="400" alt="image" src="https://github.com/user-attachments/assets/c2de28c0-13f2-4c07-9f1e-4f5ab8959b53" />


**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_

## Other notes
