### PR TITLE
Highlight search terms in note search results

### DIFF
--- a/damus/Features/Events/EventView.swift
+++ b/damus/Features/Events/EventView.swift
@@ -21,12 +21,14 @@ struct EventView: View {
     let options: EventViewOptions
     let damus: DamusState
     let pubkey: Pubkey
+    let highlightTerms: [String]
 
-    init(damus: DamusState, event: NostrEvent, pubkey: Pubkey? = nil, options: EventViewOptions = []) {
+    init(damus: DamusState, event: NostrEvent, pubkey: Pubkey? = nil, options: EventViewOptions = [], highlightTerms: [String] = []) {
         self.event = event
         self.options = options
         self.damus = damus
         self.pubkey = pubkey ?? event.pubkey
+        self.highlightTerms = highlightTerms
     }
 
     var body: some View {
@@ -48,7 +50,7 @@ struct EventView: View {
             } else if event.known_kind == .highlight {
                 HighlightView(state: damus, event: event, options: options)
             } else {
-                TextEvent(damus: damus, event: event, pubkey: pubkey, options: options)
+                TextEvent(damus: damus, event: event, pubkey: pubkey, options: options, highlightTerms: highlightTerms)
                     //.padding([.top], 6)
             }
         }
@@ -158,4 +160,3 @@ struct EventView_Previews: PreviewProvider {
         .padding()
     }
 }
-

--- a/damus/Features/Events/TextEvent.swift
+++ b/damus/Features/Events/TextEvent.swift
@@ -38,13 +38,15 @@ struct TextEvent: View {
     let pubkey: Pubkey
     let options: EventViewOptions
     let evdata: EventData
+    let highlightTerms: [String]
     
-    init(damus: DamusState, event: NostrEvent, pubkey: Pubkey, options: EventViewOptions) {
+    init(damus: DamusState, event: NostrEvent, pubkey: Pubkey, options: EventViewOptions, highlightTerms: [String] = []) {
         self.damus = damus
         self.event = event
         self.pubkey = pubkey
         self.options = options
         self.evdata = damus.events.get_cache_data(event.id)
+        self.highlightTerms = highlightTerms
     }
     
     var body: some View {
@@ -62,7 +64,8 @@ struct TextEvent: View {
                 event: event,
                 blur_images: blur_imgs,
                 size: .small,
-                options: options)
+                options: options,
+                highlightTerms: highlightTerms)
         }
         
         return NoteContentView(
@@ -70,7 +73,8 @@ struct TextEvent: View {
             event: event,
             blur_images: blur_imgs,
             size: .normal,
-            options: options
+            options: options,
+            highlightTerms: highlightTerms
         )
     }
 
@@ -87,4 +91,3 @@ struct TextEvent_Previews: PreviewProvider {
         }
     }
 }
-

--- a/damus/Features/Search/Views/SearchResultsView.swift
+++ b/damus/Features/Search/Views/SearchResultsView.swift
@@ -68,7 +68,7 @@ struct InnerSearchResults: View {
     }
     
     func TextSearch(_ txt: String) -> some View {
-        return NavigationLink(value: Route.NDBSearch(results: $results)) {
+        return NavigationLink(value: Route.NDBSearch(results: $results, query: txt)) {
             HStack {
                 Text("Search word: \(txt)", comment: "Navigation link to search for a word.")
             }
@@ -296,4 +296,3 @@ func search_profiles(profiles: Profiles, contacts: Contacts, search: String) -> 
         }
     }
 }
-

--- a/damus/Shared/Components/DamusColors.swift
+++ b/damus/Shared/Components/DamusColors.swift
@@ -28,7 +28,15 @@ class DamusColors {
     static let green = Color("DamusGreen")
     static let purple = Color("DamusPurple")
     static let deepPurple = Color("DamusDeepPurple")
-    static let highlight = Color("DamusHighlight")
+    static let highlight = Color(UIColor { traits in
+        if traits.userInterfaceStyle == .dark {
+            // Vivid Damus magenta tuned for dark backgrounds (strong contrast without glow)
+            return UIColor(red: 0.95, green: 0.43, blue: 0.82, alpha: 0.78)
+        } else {
+            // Slightly deeper pink on light so text stays legible
+            return UIColor(red: 0.88, green: 0.32, blue: 0.74, alpha: 0.62)
+        }
+    })
     static let blue = Color("DamusBlue")
     static let bitcoin = Color("Bitcoin")
     static let success = Color("DamusSuccessPrimary")

--- a/damus/Shared/Utilities/Router.swift
+++ b/damus/Shared/Utilities/Router.swift
@@ -39,7 +39,7 @@ enum Route: Hashable {
     case Reactions(reactions: EventsModel)
     case Zaps(target: ZapTarget)
     case Search(search: SearchModel)
-    case NDBSearch(results:  Binding<[NostrEvent]>)
+    case NDBSearch(results:  Binding<[NostrEvent]>, query: String)
     case EULA
     case Login
     case CreateAccount
@@ -115,8 +115,8 @@ enum Route: Hashable {
             ZapsView(state: damusState, target: target)
         case .Search(let search):
             SearchView(appstate: damusState, search: search)
-        case .NDBSearch(let results):
-            NDBSearchView(damus_state: damusState, results: results)
+        case .NDBSearch(let results, let query):
+            NDBSearchView(damus_state: damusState, results: results, searchQuery: query)
         case .EULA:
             EULAView(nav: navigationCoordinator)
         case .Login:
@@ -226,8 +226,9 @@ enum Route: Hashable {
         case .Search(let search):
             hasher.combine("search")
             hasher.combine(search.search)
-        case .NDBSearch:
+        case .NDBSearch(_, let query):
             hasher.combine("results")
+            hasher.combine(query)
         case .EULA:
             hasher.combine("eula")
         case .Login:


### PR DESCRIPTION
## Summary
- propagate note search query through routing so NDB results can highlight matches (plain text + hashtags), case-insensitive and multi-word
- keep the search term visible on the results page and strengthen the highlight contrast color
- highlight matches inline only (no side markers) while keeping existing layout

## Checklist
- [x] I have read (or I am familiar with) the Contribution Guidelines
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - If not needed, provide reason: UI-only highlight changes
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See Signing off your work
- [x] I have added appropriate changelog entries for the changes in this PR. See Adding changelog entries
    - [ ] I do not need to add a changelog entry. Reason: 
- [x] I have added appropriate Closes: or Fixes: tags in the commit messages wherever applicable, or made sure those are not needed. See Submitting patches

## Test report
iOS simulator iOS26 17 pro
1. open app
2. go to search
3. search for any keyword (e.g. vibe)
4. observe highlights in results

### screenshot
<img width="351" height="750" alt="image" src="https://github.com/user-attachments/assets/05911e9e-e019-4e0e-b67c-4e00324abf14" />
<img width="339" height="770" alt="image" src="https://github.com/user-attachments/assets/9ac672a2-e760-414d-8102-876344015b38" />


**Results:**
- [x] PASS
- [ ] Partial PASS

## Other notes
- Highlight is limited to inline text; vertical markers were removed per request.