### PR TITLE
Sort search results by recency

### DIFF
--- a/damus/Features/Search/Views/PullDownSearch.swift
+++ b/damus/Features/Search/Views/PullDownSearch.swift
@@ -46,10 +46,11 @@ struct PullDownSearchView: View {
             }
         }
 
-        let res_ = res
+        // Text search can return keys in a mixed order; enforce newest-first here
+        let sorted = res.sorted { $0.created_at > $1.created_at }
 
-        Task { @MainActor [res_] in
-            results = res_
+        Task { @MainActor [sorted] in
+            results = sorted
         }
     }
 

--- a/damus/Features/Search/Views/SearchResultsView.swift
+++ b/damus/Features/Search/Views/SearchResultsView.swift
@@ -169,10 +169,11 @@ struct SearchResultsView: View {
             }
         }
 
-        let res_ = res
+        // Text search can return keys in a mixed order; enforce newest-first here
+        let sorted = res.sorted { $0.created_at > $1.created_at }
 
-        Task { @MainActor [res_] in
-            results = res_
+        Task { @MainActor [sorted] in
+            results = sorted
         }
     }
     
@@ -296,4 +297,3 @@ func search_profiles(profiles: Profiles, contacts: Contacts, search: String) -> 
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- enforce newest-first ordering for local text search results in search screens so stale notes no longer top the list
- document the sort to clarify why UI enforces ordering

## Checklist
- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [ ] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - If not needed, provide reason: Sorting already uses cached timestamps and only reorders in-memory results; no new allocations or database IO beyond existing search.
- [x] I have opened or referred to an existing github issue related to this change: https://github.com/damus-io/damus/issues/3407
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: 
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

iOS26 xcode simulator iphone 17 pro
1. search for any keyword
2. inspect that top result is the most recent (and that there are no more recent results displayed)
**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: Not run (not requested)

## Other notes
- Relies on existing nostrdb text search results; UI-side sort guarantees newest-first ordering even if the text index returns mixed order.
