### PR TITLE
Fix long hangs caused by profile updates via notify

### DIFF
--- a/damus/Features/Events/NoteContentView.swift
+++ b/damus/Features/Events/NoteContentView.swift
@@ -45,7 +45,6 @@ struct NoteContentView: View {
     let event: NostrEvent
     @State var blur_images: Bool
     @State var load_media: Bool = false
-    @State private var requestedMentionProfiles: Set<Pubkey> = []
     let size: EventViewKind
     let preview_height: CGFloat?
     let options: EventViewOptions
@@ -274,10 +273,12 @@ struct NoteContentView: View {
         .padding(.horizontal)
     }
     
-    func ensureMentionProfilesAreFetchingIfNeeded() {
+    @concurrent
+    func streamProfiles() async throws {
         var mentionPubkeys: Set<Pubkey> = []
-        try? NdbBlockGroup.borrowBlockGroup(event: event, using: damus_state.ndb, and: damus_state.keypair, borrow: { blockGroup in
-            let _: ()? = try? blockGroup.forEachBlock({ _, block in
+        let event = await self.event.clone()
+        try await NdbBlockGroup.borrowBlockGroup(event: event, using: damus_state.ndb, and: damus_state.keypair, borrow: { blockGroup in
+            blockGroup.forEachBlock({ _, block in
                 guard let pubkey = block.mentionPubkey(tags: event.tags) else {
                     return .loopContinue
                 }
@@ -285,33 +286,13 @@ struct NoteContentView: View {
                 return .loopContinue
             })
         })
-
-        guard !mentionPubkeys.isEmpty else { return }
-
-        var toFetch: [Pubkey] = []
-        for pubkey in mentionPubkeys {
-            if requestedMentionProfiles.contains(pubkey) {
-                continue
-            }
-            requestedMentionProfiles.insert(pubkey)
-
-            if damus_state.profiles.has_fresh_profile(id: pubkey) {
-                continue
-            }
-
-            toFetch.append(pubkey)
+        
+        if mentionPubkeys.isEmpty {
+            return
         }
 
-        guard !toFetch.isEmpty else { return }
-
-        // Kick off metadata fetches for any missing mention profiles so their names can render once loaded.
-        for pubkey in toFetch {
-            Task {
-                for await _ in await damus_state.nostrNetwork.profilesManager.streamProfile(pubkey: pubkey) {
-                    // NO-OP, we will receive the update via `notify`
-                    break
-                }
-            }
+        for await profile in await damus_state.nostrNetwork.profilesManager.streamProfiles(pubkeys: mentionPubkeys) {
+            await load(force_artifacts: true)
         }
     }
 
@@ -319,8 +300,6 @@ struct NoteContentView: View {
         if case .loading = damus_state.events.get_cache_data(event.id).artifacts_model.state {
             return
         }
-
-        ensureMentionProfilesAreFetchingIfNeeded()
         
         // always reload artifacts on load
         let plan = get_preload_plan(evcache: damus_state.events, ev: event, our_keypair: damus_state.keypair, settings: damus_state.settings)
@@ -393,44 +372,13 @@ struct NoteContentView: View {
     
     var body: some View {
         ArtifactContent
-            .onReceive(handle_notify(.profile_updated)) { profile in
-                try? NdbBlockGroup.borrowBlockGroup(event: event, using: damus_state.ndb, and: damus_state.keypair, borrow: { blockGroup in
-                    let _: Int? = blockGroup.forEachBlock { index, block in
-                        switch block {
-                        case .mention(let m):
-                            guard let typ = m.bech32_type else {
-                                return .loopContinue
-                            }
-                            switch typ {
-                            case .nprofile:
-                                if m.bech32.nprofile.matches_pubkey(pk: profile.pubkey) {
-                                    load(force_artifacts: true)
-                                }
-                            case .npub:
-                                if m.bech32.npub.matches_pubkey(pk: profile.pubkey) {
-                                    load(force_artifacts: true)
-                                }
-                            case .nevent: return .loopContinue
-                            case .nrelay: return .loopContinue
-                            case .nsec: return .loopContinue
-                            case .note: return .loopContinue
-                            case .naddr: return .loopContinue
-                            }
-                        case .text: return .loopContinue
-                        case .hashtag: return .loopContinue
-                        case .url: return .loopContinue
-                        case .invoice: return .loopContinue
-                        case .mention_index(_): return .loopContinue
-                        }
-                        return .loopContinue
-                    }
-                })
+            .task {
+                try? await streamProfiles()
             }
             .onAppear {
                 load()
             }
     }
-    
 }
 
 class NoteArtifactsParts {

--- a/damus/Features/NIP05/Views/NIP05DomainTimelineView.swift
+++ b/damus/Features/NIP05/Views/NIP05DomainTimelineView.swift
@@ -46,7 +46,7 @@ struct NIP05DomainTimelineView: View {
 
             if let pubkeys = model.filter.authors {
                 for pubkey in pubkeys {
-                    check_nip05_validity(pubkey: pubkey, profiles: damus_state.profiles)
+                    check_nip05_validity(pubkey: pubkey, damus_state: damus_state)
                 }
             }
         }

--- a/damus/Features/Wallet/Views/NWCSettings.swift
+++ b/damus/Features/Wallet/Views/NWCSettings.swift
@@ -250,7 +250,9 @@ struct NWCSettings: View {
             
             let prof = Profile(name: profile.name, display_name: profile.display_name, about: profile.about, picture: profile.picture, banner: profile.banner, website: profile.website, lud06: profile.lud06, lud16: profile.lud16, nip05: profile.nip05, damus_donation: p, reactions: profile.reactions)
 
-            notify(.profile_updated(.manual(pubkey: self.damus_state.pubkey, profile: prof)))
+            Task {
+                await damus_state.nostrNetwork.profilesManager.notifyProfileUpdate(pubkey: self.damus_state.pubkey)
+            }
         }
         .onDisappear {
             


### PR DESCRIPTION
## Summary

During profiling, I found that some large hangs were being caused by a large number of `notify` calls (and their handling functions) keeping the main thread overly busy.

We cannot move the `notify` mechanism to a background thread (It has to be done on the main actor or else runtime warnings/errors appear), so instead this commit removes a very large source of notify calls/handling around NoteContentView, and replaces it with a background task that streams for profile updates and only updates its view when a relevant profile is updated.

Changelog-Changed: Improved performance around note content views to prevent hangs

## Checklist

<!-- 
CHOOSE YOUR CHECKLIST: 
- If this is an EXPERIMENTAL DAMUS LABS FEATURE, follow the "Experimental Feature Checklist" below and DELETE the "Standard PR Checklist"
- If this is a STANDARD PR, follow the "Standard PR Checklist" below and DELETE the "Experimental Feature Checklist"
-->

### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
- [x] I have opened or referred to an existing github issue related to this change. https://github.com/damus-io/damus/issues/3439
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** iPhone 13 Mini

**iOS:** 26.1

**Damus:** [9b3bbff](https://github.com/damus-io/damus/commit/9b3bbffa0dd5451d0f59275892fae00eafaaa454)

**Setup:** Xcode Instruments setup, attached to a build made for profiling.

**Steps:**
1. Scroll down timeline quickly while profiling.

**Results:**
- [x] PASS, no hangs above 500ms detected

## Before


<img width="1583" height="853" alt="Screenshot 2025-12-10 at 17 15 31" src="https://github.com/user-attachments/assets/259be97c-7aec-4c68-aa24-dcbc0005f1c2" />

<img width="1643" height="1033" alt="Screenshot 2025-12-12 at 16 41 58" src="https://github.com/user-attachments/assets/0d6645e2-aa5a-4a5a-ba7f-46c13a3ad382" />

## After

<img width="1643" height="1033" alt="Screenshot 2025-12-12 at 18 35 12" src="https://github.com/user-attachments/assets/0fc34fa4-1c7a-4c1f-bb6b-d80f55daa85c" />
<img width="1643" height="1033" alt="Screenshot 2025-12-12 at 18 35 43" src="https://github.com/user-attachments/assets/eab0ba9f-9834-4c45-94b3-f1ca78494a28" />
<img width="1643" height="1033" alt="Screenshot 2025-12-12 at 18 35 33" src="https://github.com/user-attachments/assets/f89795ba-8fe2-4778-a758-2f20468e4d5d" />


## Other notes

_[Please provide any other information that you think is relevant to this PR.]_