### PR TITLE
Add hashtag spam filter to automatically mute posts with too many hashtags

### DIFF
--- a/damus/Features/Settings/Models/UserSettingsStore.swift
+++ b/damus/Features/Settings/Models/UserSettingsStore.swift
@@ -138,7 +138,13 @@ class UserSettingsStore: ObservableObject {
 
     @Setting(key: "hide_nsfw_tagged_content", default_value: false)
     var hide_nsfw_tagged_content: Bool
-    
+
+    @Setting(key: "hide_hashtag_spam", default_value: true)
+    var hide_hashtag_spam: Bool
+
+    @Setting(key: "max_hashtags", default_value: 3)
+    var max_hashtags: Int
+
     @Setting(key: "reduce_bitcoin_content", default_value: false)
     var reduce_bitcoin_content: Bool
     

--- a/damus/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/damus/Features/Settings/Views/AppearanceSettingsView.swift
@@ -36,6 +36,14 @@ struct AppearanceSettingsView: View {
     @State var showing_enable_animation_alert: Bool = false
     @State var enable_animation_toggle_is_user_initiated: Bool = true
 
+    var max_hashtags_binding: Binding<Double> {
+        Binding<Double>(get: {
+            return Double(settings.max_hashtags)
+        }, set: {
+            settings.max_hashtags = Int($0)
+        })
+    }
+
     var FontSize: some View {
         VStack(alignment: .leading) {
             Slider(value: $settings.font_size, in: 0.5...2.0, step: 0.1)
@@ -104,6 +112,14 @@ struct AppearanceSettingsView: View {
                     .toggleStyle(.switch)
                 Toggle(NSLocalizedString("Hide notes with #nsfw tags", comment: "Setting to hide notes with the #nsfw (not safe for work) tags"), isOn: $settings.hide_nsfw_tagged_content)
                     .toggleStyle(.switch)
+                Toggle(NSLocalizedString("Hide posts with too many hashtags", comment: "Setting to hide notes that contain too many hashtags (spam)"), isOn: $settings.hide_hashtag_spam)
+                    .toggleStyle(.switch)
+                if settings.hide_hashtag_spam {
+                    VStack(alignment: .leading) {
+                        Text(String(format: NSLocalizedString("Maximum hashtags: %d", comment: "Label showing the maximum number of hashtags allowed before a post is hidden"), settings.max_hashtags))
+                        Slider(value: max_hashtags_binding, in: 1...20, step: 1)
+                    }
+                }
             }
             
             // MARK: - Profiles


### PR DESCRIPTION
## Summary

Add a hashtag spam filter that automatically hides posts with too many hashtags from timelines. Posts with more than the configured number of hashtags (default: 3) are filtered out, helping reduce hashtag spam.

**Changes:**
- Add `hide_hashtag_spam` setting (default: enabled) and `max_hashtags` setting (default: 3) to UserSettingsStore
- Add `hashtag_spam_filter` function that counts hashtags in content text (works regardless of whether clients add proper `["t", "tag"]` entries)
- Add toggle and slider UI in Settings → Appearance → Content filters

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - If not needed, provide reason: Simple string iteration with early return; negligible performance impact
- [x] I have opened or referred to an existing github issue related to this change: https://github.com/damus-io/damus/issues/1677
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.3.1

**Damus:** ed00301a

**Setup:** Default settings with hashtag spam filter enabled (default)

**Steps:**
1. Open Universe view
2. Verify posts with >3 hashtags are filtered
3. Go to Settings → Appearance → Content filters
4. Toggle "Hide posts with too many hashtags" off/on
5. Adjust "Maximum hashtags" slider (1-20)
6. Verify filter respects settings changes

**Results:**
- [x] PASS

## Other notes

Updated logic now checks both:

  1. "t" tags (ev.referenced_hashtags) - if count > threshold → filter
  2. Content text (scanning for # patterns) - if count > threshold → filter
  
Some Nostr clients don't properly populate `["t", "hashtag"]` tags.

Closes https://github.com/damus-io/damus/issues/1677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added hashtag spam filtering to content filter settings
- Toggle option to hide posts with excessive hashtags
- Configurable maximum hashtag threshold (adjustable 1-20) to customize filtering sensitivity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->