### PR TITLE
longform: Fix NIP-19 nostr links not rendering in markdown content

### DIFF
--- a/damusTests/NoteContentViewTests.swift
+++ b/damusTests/NoteContentViewTests.swift
@@ -361,21 +361,28 @@ class NoteContentViewTests: XCTestCase {
     }
     
     func testMentionStr_Pubkey_ContainsAbbreviated() throws {
-        let compatibleText = createCompatibleText(test_pubkey.npub)
-        
-        assertCompatibleTextHasExpectedString(compatibleText: compatibleText, expected: "17ldvg64:nq5mhr77")
+        let npub = test_pubkey.npub
+        let compatibleText = createCompatibleText(npub)
+
+        // When profile not cached, should show abbreviated bech32 (npub1xxx:yyy)
+        // instead of abbreviated pubkey (abc123:xyz789)
+        let expectedAbbrev = abbrev_identifier(npub)
+        assertCompatibleTextHasExpectedString(compatibleText: compatibleText, expected: expectedAbbrev)
     }
-    
+
     func testMentionStr_Pubkey_ContainsFullBech32() {
         let compatableText = createCompatibleText(test_pubkey.npub)
 
         assertCompatibleTextHasExpectedString(compatibleText: compatableText, expected: test_pubkey.npub)
     }
-    
+
     func testMentionStr_Nprofile_ContainsAbbreviated() throws {
-        let compatibleText = createCompatibleText("nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p")
-                
-        assertCompatibleTextHasExpectedString(compatibleText: compatibleText, expected: "180cvv07:wsyjh6w6")
+        let nprofile = "nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p"
+        let compatibleText = createCompatibleText(nprofile)
+
+        // When profile not cached, should show abbreviated bech32 (nprofile1xxx:yyy)
+        let expectedAbbrev = abbrev_identifier(nprofile)
+        assertCompatibleTextHasExpectedString(compatibleText: compatibleText, expected: expectedAbbrev)
     }
     
     func testMentionStr_Nprofile_ContainsFullBech32() throws {


### PR DESCRIPTION
## Summary

- Fixed NIP-19 nostr links (nprofile, npub, note, nevent, naddr) not rendering as clickable mentions in longform content
- Links now display human-readable profile names when available, falling back to abbreviated bech32 format (npun123; nprofile123)
- Supports both `nostr:` prefixed URIs and bare bech32 entities for consistency with kind1 notes

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Not needed: This is text preprocessing with simple regex operations, no significant performance impact
- [x] I have opened or referred to an existing github issue related to this change: [
](https://github.com/damus-io/damus/issues/3426)- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 15 Pro (Simulator)

**iOS:** 18.0

**Damus:** Current master + this PR

**Setup:** Longform article containing nprofile, npub, note, and nevent mentions both with and without nostr: prefix

**Steps:**
1. Open a longform article (kind 30023) containing nostr:nprofile mentions
2. Verify mentions render as clickable links with profile names
3. Test bare npub/nprofile without nostr: prefix
4. Verify fallback display when profile not cached (shows @npub1abc:xyz format)
5. Run unit tests: `xcodebuild test -scheme damus -destination 'platform=iOS Simulator,name=iPhone 15 Pro'`

**Results:**
- [x] PASS

## Other notes

This fix addresses issue #3426 where nostr:nprofile links in longform articles were rendering as plain text instead of clickable mentions.

The implementation preprocesses markdown content before passing to MarkdownUI, converting nostr entities into standard markdown link syntax that MarkdownUI can render. Profile display names are looked up from the cache, with a fallback to abbreviated bech32 format (e.g., `@npub1abc:xyz`) when the profile isn't available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)