### PR TITLE
Fix overlay issue on short replies

### DIFF
--- a/damus/Features/Chat/ChatEventView.swift
+++ b/damus/Features/Chat/ChatEventView.swift
@@ -294,6 +294,8 @@ struct ChatEventView: View {
             HStack {
                 if by_other_user { Spacer() }
 
+                // Offset pushes the bar below the bubble to avoid overlapping short message text.
+                // Previously used .padding(.vertical, -20) which pulled the bar UP into the bubble.
                 EventActionBar(damus_state: damus_state, event: event, bar: bar, options: [.no_spread, .hide_items_without_activity])
                     .padding(10)
                     .background(DamusColors.adaptableLighterGrey)
@@ -302,10 +304,10 @@ struct ChatEventView: View {
                     .overlay(RoundedRectangle(cornerSize: CGSize(width: 100, height: 100)).stroke(DamusColors.adaptableWhite, lineWidth: 1))
                     .shadow(color: Color.black.opacity(0.05), radius: 3, y: 3)
                     .scaleEffect(0.7, anchor: is_ours ? .leading : .trailing)
+                    .offset(y: 15)
 
                 if is_ours { Spacer() }
             }
-            .padding(.vertical, -20)
         }
     }
     


### PR DESCRIPTION
## Summary

- Align chat action bar visibility check with EventActionBar's `has_any_action` logic to prevent empty styled containers ("dots") from appearing
- Replace `.padding(.vertical, -20)` with `.offset(y: 15)` to push the action bar below the bubble instead of pulling it up into the content


|Before|After|
|--|--|
| <img width="361" height="618" alt="notfixed" src="https://github.com/user-attachments/assets/130eb11a-ba90-43cf-9757-5d3aadf01868" />| <img width="351" height="600" alt="fixedit" src="https://github.com/user-attachments/assets/542c4957-36c6-4ff1-a4a1-4b21fc196c6c" />|
|--|--|

## Test plan

- [x] Tested on Xcode iOS 26 iPhone 17 simulator
- [x] Used test account to reply, like, repost, and comment on a reply
- [x] Verified action bar no longer covers text on short messages
- [x] Verified empty dots no longer appear when only relays are present

Closes: #3445

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced action bar visibility logic in chat messages to intelligently determine when to display interaction options (replies, boosts, likes, and zaps)
* Improved action bar positioning and layout to prevent overlap with message content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->