### PR TITLE
feat: add purplepag.es as profile-only relay

### DIFF
--- a/damus/Core/Networking/NostrNetworkManager/NostrNetworkManager.swift
+++ b/damus/Core/Networking/NostrNetworkManager/NostrNetworkManager.swift
@@ -212,7 +212,7 @@ extension NostrNetworkManager {
         
         /// Relay filters
         var relayFilters: RelayFilters { get }
-        
+
         /// The user's connected NWC wallet
         var nwcWallet: WalletConnectURL? { get }
     }

--- a/damus/Core/Networking/NostrNetworkManager/UserRelayListManager.swift
+++ b/damus/Core/Networking/NostrNetworkManager/UserRelayListManager.swift
@@ -35,11 +35,12 @@ extension NostrNetworkManager {
         }
         
         private func computeRelaysToConnectTo(with relayList: NIP65.RelayList) -> [RelayPool.RelayDescriptor] {
-            let regularRelayDescriptorList = relayList.toRelayDescriptors()
+            var descriptors = relayList.toRelayDescriptors()
+
             if let nwcWallet = delegate.nwcWallet {
-                return regularRelayDescriptorList + [.nwc(url: nwcWallet.relay)]
+                descriptors.append(.nwc(url: nwcWallet.relay))
             }
-            return regularRelayDescriptorList
+            return descriptors
         }
         
         // MARK: - Getting the user's relay list

--- a/damus/Core/Nostr/NostrRequest.swift
+++ b/damus/Core/Nostr/NostrRequest.swift
@@ -33,8 +33,25 @@ enum NostrRequestType {
         guard case .typical(let req) = self else {
             return true
         }
-        
+
         return req.is_read
+    }
+}
+
+extension NostrRequestType {
+    /// Profile-related kinds that should be queried on profiles-only relays
+    static let profileKinds: Set<NostrKind> = [.metadata, .contacts, .relay_list]
+
+    /// Whether this request is for profile-related data only
+    var isProfileRelated: Bool {
+        guard case .typical(let req) = self else { return false }
+        guard case .subscribe(let sub) = req else { return false }
+
+        // Check if ALL filters contain ONLY profile-related kinds
+        return sub.filters.allSatisfy { filter in
+            guard let kinds = filter.kinds else { return false }  // No kinds specified = could be anything
+            return kinds.allSatisfy { Self.profileKinds.contains($0) }
+        }
     }
 }
 

--- a/damus/Core/Nostr/Relay.swift
+++ b/damus/Core/Nostr/Relay.swift
@@ -32,6 +32,7 @@ enum RelayVariant {
     case regular
     case ephemeral
     case nwc
+    case profilesOnly  // Only used for profile metadata queries (kind 0, 3, 10002)
 }
 
 extension RelayPool {
@@ -55,11 +56,21 @@ extension RelayPool {
                 return true
             case .nwc:
                 return true
+            case .profilesOnly:
+                return false  // Not ephemeral - filtering is handled separately via isProfileRelated check
             }
         }
-        
+
+        var isProfilesOnly: Bool {
+            variant == .profilesOnly
+        }
+
         static func nwc(url: RelayURL) -> RelayDescriptor {
             return RelayDescriptor(url: url, info: .readWrite, variant: .nwc)
+        }
+
+        static func profilesOnly(url: RelayURL) -> RelayDescriptor {
+            return RelayDescriptor(url: url, info: .read, variant: .profilesOnly)
         }
     }
 }

--- a/damus/Features/Relays/Models/RelayBootstrap.swift
+++ b/damus/Features/Relays/Models/RelayBootstrap.swift
@@ -13,6 +13,7 @@ fileprivate let BOOTSTRAP_RELAYS = [
     "wss://nostr.land",
     "wss://nostr.wine",
     "wss://nos.lol",
+    "wss://purplepag.es",
 ]
 
 fileprivate let REGION_SPECIFIC_BOOTSTRAP_RELAYS: [Locale.Region: [String]] = [

--- a/damus/Features/Relays/Views/RelayConfigView.swift
+++ b/damus/Features/Relays/Views/RelayConfigView.swift
@@ -37,11 +37,8 @@ struct RelayConfigView: View {
     }
     
     var recommended: [RelayPool.RelayDescriptor] {
-        let rs: [RelayPool.RelayDescriptor] = []
-        let recommended_relay_addresses = get_default_bootstrap_relays()
-        return recommended_relay_addresses.reduce(into: rs) { xs, x in
-            xs.append(RelayPool.RelayDescriptor(url: x, info: .readWrite))
-        }
+        // Use default bootstrap relays (includes purplepag.es)
+        return get_default_bootstrap_relays().map { RelayPool.RelayDescriptor(url: $0, info: .readWrite) }
     }
 
     var body: some View {
@@ -134,7 +131,7 @@ struct RelayConfigView: View {
 
             ForEach(relayList, id: \.url) { relay in
                 Group {
-                    RelayView(state: state, relay: relay.url, showActionButtons: $showActionButtons, recommended: recommended)
+                    RelayView(state: state, relay: relay.url, showActionButtons: $showActionButtons, recommended: recommended, descriptor: relay)
                     Divider()
                 }
             }

--- a/damus/Features/Relays/Views/RelayType.swift
+++ b/damus/Features/Relays/Views/RelayType.swift
@@ -9,10 +9,23 @@ import SwiftUI
 
 struct RelayType: View {
     let is_paid: Bool
-    
+    var is_profile_only: Bool = false
+
     var body: some View {
-        if is_paid {
-            Image("bitcoin-logo")
+        HStack(spacing: 4) {
+            if is_paid {
+                Image("bitcoin-logo")
+            }
+            if is_profile_only {
+                Text("Profile")
+                    .font(.caption2)
+                    .fontWeight(.medium)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(DamusColors.purple)
+                    .cornerRadius(4)
+            }
         }
     }
 }
@@ -22,6 +35,8 @@ struct RelayType_Previews: PreviewProvider {
         VStack {
             RelayType(is_paid: false)
             RelayType(is_paid: true)
+            RelayType(is_paid: false, is_profile_only: true)
+            RelayType(is_paid: true, is_profile_only: true)
         }
     }
 }

--- a/damus/Features/Settings/Models/UserSettingsStore.swift
+++ b/damus/Features/Settings/Models/UserSettingsStore.swift
@@ -248,7 +248,7 @@ class UserSettingsStore: ObservableObject {
     /// Whether the app has the experimental local relay model flag that streams data only from the local relay (ndb)
     @Setting(key: "enable_experimental_local_relay_model", default_value: false)
     var enable_experimental_local_relay_model: Bool
-    
+
     /// Whether the app should present the experimental floating "Load new content" button
     @Setting(key: "enable_experimental_load_new_content_button", default_value: false)
     var enable_experimental_load_new_content_button: Bool


### PR DESCRIPTION
## User Benefit

Improve chances that profiles are found (i.e. reduce chances profiles are not found).

## Summary

Add `wss://purplepag.es` as a system relay that's always included for all users but only used for profile metadata queries (kinds 0, 3, 10002). This improves profile metadata fetching without polluting the relay with non-profile requests.

Changes:
- Add `profilesOnly` variant to `RelayVariant` enum
- Add `isProfileRelated` check to `NostrRequestType` to detect profile queries
- Filter profiles-only relays in `send_raw` to only receive profile requests
- Always include purplepag.es in relay list via `UserRelayListManager`

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Not needed: This adds minimal filtering logic that runs in O(1) for relay type check
- [x] I have opened or referred to an existing github issue related to this change: https://github.com/damus-io/damus/issues/1331
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16 Pro Simulator

**iOS:** 18.x

**Damus:** feature/purplepages-profile-relay (be1290ce)

**Setup:** Fresh install on simulator

**Steps:**
1. Build and run on simulator
2. Monitor console for purplepag.es connections
3. Verify only profile-related kinds (0, 3, 10002) are sent to purplepag.es
4. Verify non-profile requests (kind 1 notes, DMs, etc.) are NOT sent to purplepag.es

**Results:**
- [x] PASS
  - Console shows only `NostrKind.metadata`, `NostrKind.contacts`, and `NostrKind.relay_list` subscriptions to purplepag.es
  - No kind 1 (notes) or other non-profile kinds sent to purplepag.es

## Other notes

Closes #1331

Debug logging is included (prints to Xcode console only) to help verify filtering is working:
- `🟣 PURPLEPAGES: sending subscription with kinds: [...]`
- `🟣 PURPLEPAGES: received kind X event`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for profile-only relays with visual badge indicator
  * Added PurplePages relay to default bootstrap relay list
  * Improved relay request routing for intelligent relay selection based on request type

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->