### PR TITLE
Fix longform note URLs not opening from nevent references

### DIFF
--- a/damus/Features/Events/Models/LoadableNostrEventView.swift
+++ b/damus/Features/Events/Models/LoadableNostrEventView.swift
@@ -62,7 +62,7 @@ class LoadableNostrEventViewModel: ObservableObject {
             guard let ev = await self.loadEvent(noteId: note_id) else { return .not_found }
             guard let known_kind = ev.known_kind else { return .unknown_or_unsupported_kind }
             switch known_kind {
-            case .text, .highlight:
+            case .text, .highlight, .longform:
                 return .loaded(route: Route.Thread(thread: ThreadModel(event: ev, damus_state: damus_state)))
             case .dm:
                 let dm_model = damus_state.dms.lookup_or_create(ev.pubkey)
@@ -74,7 +74,7 @@ class LoadableNostrEventViewModel: ObservableObject {
             case .zap, .zap_request:
                 guard let zap = await get_zap(from: ev, state: damus_state) else { return .not_found }
                 return .loaded(route: Route.Zaps(target: zap.target))
-            case .contacts, .metadata, .delete, .boost, .chat, .mute_list, .list_deprecated, .draft, .longform, .nwc_request, .nwc_response, .http_auth, .status, .relay_list, .follow_list, .interest_list, .contact_card, .live, .live_chat:
+            case .contacts, .metadata, .delete, .boost, .chat, .mute_list, .list_deprecated, .draft, .nwc_request, .nwc_response, .http_auth, .status, .relay_list, .follow_list, .interest_list, .contact_card, .live, .live_chat:
                 return .unknown_or_unsupported_kind
             }
         case .naddr(let naddr):


### PR DESCRIPTION
## Summary

Fix for longform article links (nevent URLs) showing "Can't display note" error instead of opening the article.

Previously, clicking nevent links pointing to longform notes (kind 30023) showed "Can't display note. We do not yet support viewing this type of content." This was because `.longform` was listed as an unsupported kind in `LoadableNostrEventView`. 

This fix adds `.longform` to the supported kinds alongside `.text` and `.highlight`, routing them to `ThreadModel` for proper display.

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - If not needed, provide reason: Minimal code change - adds one enum case to existing switch statement, no new allocations or loops
- [x] I have opened or referred to an existing github issue related to this change: https://github.com/damus-io/damus/issues/3485 #3003 
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 17 Pro Simulator

**iOS:** 26.2

**Damus:** Commit f4bee9c5b082566689c538d8dc1db87b0283d210

**Setup:** Fresh build from fix branch, logged in with test account

**Steps:**
1. Build and run app in iOS Simulator
2. Test nevent URL to longform article via CLI:
   ```
   xcrun simctl openurl booted "damus:nostr:nevent1qqs2r28rpxzphrpv3ssefz5w4ccsuh5h7d33jv47w09kjd7625f7jcspzpmhxue69uhkummnw3ezumrpdejqz9rhwden5te0wfjkccte9ejxzmt4wvhxjmcpp4mhxue69uhkummn9ekx7mqzyzm7669svt0xkjsju50a22zurc0qa589z2xd4yatzx6p2z64a5e0cqcyqqq823c3h6qpg"
   ```
3. Test additional naddr URLs to longform articles:
   ```
   xcrun simctl openurl booted "damus:nostr:naddr1qvzqqqr4gupzpdlddzcx9hntfgfw28749pwpu8sw6rj39rx6jw43rdq4pd276vhuqqgxgv3hxf3njef4xvunqv33xumrjy5my73"
   xcrun simctl openurl booted "damus:nostr:naddr1qvzqqqr4gupzqfngzhsvjggdlgeycm96x4emzjlwf8dyyzdfg4hefp89zpkdgz99qqxkzursd3jhxct4vdjj6a34lj6934"
   xcrun simctl openurl booted "damus:nostr:naddr1qvzqqqr4gupzpcatwy3kdjl7wde5r0wqk492hqaqfs8zfjv9ms8ur22my2my9s73qq25zv2g2ee9v6m6wpkyxct6v46xymzhddzx548ky3j"
   xcrun simctl openurl booted "damus:nostr:naddr1qvzqqqr4gupzpef89h53f0fsza2ugwdc3e54nfpun5nxfqclpy79r6w8nxsk5yp0qqn8wetz94hkvtt5wf6hxapdwa5x2un9945hxtt5dpjj6arjw4ehgttnd9nkuctv378l06"
   ```
4. Verified all 5 URLs open the longform article correctly

**Results:**
- [x] PASS

## Other notes

Closes: #3003
Closes: #3485

🤖 Generated with [Claude Code](https://claude.com/claude-code)