### PR TITLE
Fix longform notes opening midway instead of at top

### DIFF
--- a/damus/Features/Chat/ChatroomThreadView.swift
+++ b/damus/Features/Chat/ChatroomThreadView.swift
@@ -250,7 +250,10 @@ struct ChatroomThreadView: View {
             }
             .onAppear() {
                 thread.subscribe()
-                scroll_to_event(scroller: scroller, id: thread.selected_event.id, delay: 0.1, animate: false)
+                // Use .top anchor for longform articles so they open at the title,
+                // keep .bottom for regular notes to preserve parent context visibility
+                let anchor: UnitPoint = thread.selected_event.known_kind == .longform ? .top : .bottom
+                scroll_to_event(scroller: scroller, id: thread.selected_event.id, delay: 0.1, animate: false, anchor: anchor)
             }
             .onDisappear() {
                 thread.unsubscribe()


### PR DESCRIPTION
## Summary

Fix for longform articles opening midway or at the bottom instead of at the top.

The `scroll_to_event` function in `ChatroomThreadView.swift` defaults to `anchor: .bottom`, which positions the selected event at the bottom of the viewport. For longform notes, this causes the article to appear midway through or at the end instead of at the top where the title is.

**Change:** Added conditional anchor selection based on event kind:
- **Longform articles (kind 30023):** Uses `.top` anchor so articles open at the title
- **Regular notes:** Preserves `.bottom` anchor to keep parent context visible in reply threads

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - If not needed, provide reason: Single conditional check on existing enum property, no new allocations or computations
- [x] I have opened or referred to an existing github issue related to this change: https://github.com/damus-io/damus/issues/2481
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 17 Pro Simulator

**iOS:** 26.2

**Damus:** Commit 6a605b38f7005a123ae7e80eb4d2cd99425a4a03

**Setup:** Fresh build from fix branch, logged in with test account

**Steps:**
1. Build and run app in iOS Simulator
2. Test longform articles open at top:
   ```bash
   xcrun simctl openurl booted "damus:nostr:naddr1qvzqqqr4gupzpdlddzcx9hntfgfw28749pwpu8sw6rj39rx6jw43rdq4pd276vhuqqgxgv3hxf3njef4xvunqv33xumrjy5my73"
   ```
3. Verified longform article opens at the top with title visible
4. Tested regular notes by tapping from timeline
5. Verified regular notes preserve parent context (selected note near bottom, parents visible above)

**Results:**
- [x] PASS

## Other notes

Closes: #2481

🤖 Generated with [Claude Code](https://claude.com/claude-code)