### PR TITLE
Fix app freeze

### DIFF
--- a/damus/Features/Timeline/Views/InnerTimelineView.swift
+++ b/damus/Features/Timeline/Views/InnerTimelineView.swift
@@ -10,17 +10,14 @@ import SwiftUI
 
 struct InnerTimelineView: View {
     var events: EventHolder
-    @ObservedObject var filteredEvents: EventHolder.FilteredHolder
-    var filteredEventHolderId: UUID
+    @StateObject var filteredEvents: EventHolder.FilteredHolder
     let state: DamusState
 
     init(events: EventHolder, damus: DamusState, filter: @escaping (NostrEvent) -> Bool, apply_mute_rules: Bool = true) {
         self.events = events
         self.state = damus
         let filter = apply_mute_rules ? { filter($0) && !damus.mutelist_manager.is_event_muted($0) } : filter
-        let filteredEvents = EventHolder.FilteredHolder(filter: filter)
-        self.filteredEvents = filteredEvents
-        self.filteredEventHolderId = events.add(filteredHolder: filteredEvents)
+        _filteredEvents = StateObject.init(wrappedValue: EventHolder.FilteredHolder(filter: filter, parent: events))
     }
     
     var event_options: EventViewOptions {
@@ -65,11 +62,6 @@ struct InnerTimelineView: View {
                 }
             }
         }
-        .onDisappear {
-            self.events.removeFilteredHolder(id: self.filteredEventHolderId)
-        }
-        //.padding(.horizontal)
-        
     }
 }
 


### PR DESCRIPTION
## Summary

This commit fixes an issue where the app would occasionally freeze.

The filtered holders were being initialized and registered directly from a SwiftUI
initializer, which would sometimes cause hundreds of instances to be
initialized and registered due to re-renders and never get removed by `onDisappear`.

The issue was fixed by initializing such objects with `StateObject`,
which brings it a more stable identity that lives as long as the SwiftUI
view it is in, and by placing the init/deinit registration/clean-up logic
in the filtered holder object itself, better matching its lifecycle and
preventing resource leakage.

Changelog-Fixed: Fixed an issue that would occasionally cause the app to freeze
Closes: https://github.com/damus-io/damus/issues/3383
Signed-off-by: Daniel D’Aquino <daniel@daquino.me>

## Checklist

<!-- 
CHOOSE YOUR CHECKLIST: 
- If this is an EXPERIMENTAL DAMUS LABS FEATURE, follow the "Experimental Feature Checklist" below and DELETE the "Standard PR Checklist"
- If this is a STANDARD PR, follow the "Standard PR Checklist" below and DELETE the "Experimental Feature Checklist"
-->

### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: Checked performance during testing using on-device hang detection, because the present change is already a performance fix.
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 13 mini

**iOS:** 26.2

**Damus:** [7095fc2](https://github.com/damus-io/damus/pull/3510/commits/7095fc21b83b200aa1c07298d72242aada3f32b9)

**Setup:**
- Build for profiling
- No debugger attached
- On-device hang detection with 2000ms reporting threshold

**Steps:**
1. Quickly navigate through several places in the app (profiles, tabs, timeline tabs, back button etc), randomly, for a few minutes (about 5 minutes)
2. Check for any freezes

**Results:**
- [x] PASS
    - Details: Although I have seen some occasional hangs (e.g. 500ms), I have not witnessed a freeze (defined as 2000+ms)
- [ ] Partial PASS
  

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better memory management and automatic cleanup for filtered timelines, reducing leaks.
  * More precise change tracking so filtered timelines update only when events actually change.
  * Reduced unnecessary notifications and lifecycle-related glitches when viewing or closing filtered timelines.
  * Improved stability and responsiveness when navigating between timeline views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->