### PR TITLE
Preload profiles from network on timelines

### DIFF
--- a/damus/Core/Networking/NostrNetworkManager/ProfilesManager.swift
+++ b/damus/Core/Networking/NostrNetworkManager/ProfilesManager.swift
@@ -208,7 +208,8 @@ extension NostrNetworkManager {
             if self.streams[pubkey]?.keys.count == 0 {
                 // We don't need to subscribe to this profile anymore
                 self.streams[pubkey] = nil
-                self.subscriptionNeedsUpdate = true
+                // NOTE: Do not update network subscription yet to avoid constant resubscriptions that resend the same large filter again and again
+                // Just leave the extra pubkey in the subscription until we naturally need to update the filter to fetch a new profile
             }
         }
         

--- a/damus/Features/Timeline/Views/InnerTimelineView.swift
+++ b/damus/Features/Timeline/Views/InnerTimelineView.swift
@@ -38,6 +38,12 @@ struct InnerTimelineView: View {
                 ForEach(indexed, id: \.0.id) { tup in
                     let ev = tup.0
                     let ind = tup.1
+                    let to_preload = Array([indexed[safe: ind+1]?.0,
+                           indexed[safe: ind+2]?.0,
+                           indexed[safe: ind+3]?.0,
+                           indexed[safe: ind+4]?.0,
+                           indexed[safe: ind+5]?.0
+                          ].compactMap({ $0 }))
                     EventView(damus: state, event: ev, options: event_options)
                         .onTapGesture {
                             let event = ev.get_inner_event(cache: state.events) ?? ev
@@ -46,15 +52,25 @@ struct InnerTimelineView: View {
                         }
                         .padding(.top, 7)
                         .onAppear {
-                            let to_preload =
-                            Array([indexed[safe: ind+1]?.0,
-                                   indexed[safe: ind+2]?.0,
-                                   indexed[safe: ind+3]?.0,
-                                   indexed[safe: ind+4]?.0,
-                                   indexed[safe: ind+5]?.0
-                                  ].compactMap({ $0 }))
-                            
                             preload_events(state: state, events: to_preload)
+                        }
+                        .task {
+                            // NOTE: Profile loading is also done in the events themselves. So this is more of an optimization to preload profiles
+                            // into NostrDB before the notes appear, in order to prevent a "poppy" feel.
+                            // NOTE 2: Perhaps this should be in "preload_events", but that function is designed as a fire-and-forget function,
+                            // which is not compatible with a continuous streaming task with a lifetime bound to the view itself,
+                            // so I will do this preloading here as it has a more predictable lifecycle that will auto-cleanup
+                            // the task once the view disappears
+                            guard let pubkeysToPreload = try? getPubkeysToPreloadFor(events: to_preload, ndb: state.ndb, ourKeypair: state.keypair) else {
+                                Log.error("Error preloading profiles in timeline", for: .timeline)
+                                return
+                            }
+                            Log.debug("PRELOAD: preloading %d pubkeys", for: .timeline, pubkeysToPreload.count)
+                            for await profile in await state.nostrNetwork.profilesManager.streamProfiles(pubkeys: pubkeysToPreload, yieldCached: false) {
+                                Log.debug("PRELOAD: Preloaded %s", for: .timeline, profile.display_name ?? "someone")
+                                // NO-OP, we just want these to be in ndb
+                                continue
+                            }
                         }
                     
                     ThiccDivider()
@@ -62,6 +78,35 @@ struct InnerTimelineView: View {
                 }
             }
         }
+    }
+}
+
+extension InnerTimelineView {
+    // MARK: Functions to help with preloading profiles
+    
+    fileprivate func getPubkeysToPreloadFor(events: [NdbNote], ndb: Ndb, ourKeypair: Keypair) throws -> Set<Pubkey> {
+        var relevantPubkeys: Set<Pubkey> = []
+        
+        for event in events {
+            relevantPubkeys.formUnion(try getPubkeysToPreloadFor(event: event, ndb: ndb, ourKeypair: ourKeypair))
+        }
+        
+        return relevantPubkeys
+    }
+    
+    fileprivate func getPubkeysToPreloadFor(event: NdbNote, ndb: Ndb, ourKeypair: Keypair) throws -> Set<Pubkey> {
+        var relevantPubkeys: Set<Pubkey> = [event.pubkey]
+        try NdbBlockGroup.borrowBlockGroup(event: event, using: ndb, and: ourKeypair, borrow: { blockGroup in
+            blockGroup.forEachBlock({ _, block in
+                guard let pubkey = block.mentionPubkey(tags: event.tags) else {
+                    return .loopContinue
+                }
+                relevantPubkeys.insert(pubkey)
+                return .loopContinue
+            })
+        })
+        
+        return relevantPubkeys
     }
 }
 


### PR DESCRIPTION
## Summary

This commit adds some logic to load profiles in upcoming events on the timeline that have not been loaded into view yet.

This helps get the loading to happen earlier and reduce poppiness on the UI from having the view to re-render without and with the profile data.

Closes: https://github.com/damus-io/damus/issues/3513
Changelog-Changed: Improved profile loading in timelines to load profiles faster

## Checklist

<!-- 
CHOOSE YOUR CHECKLIST: 
- If this is an EXPERIMENTAL DAMUS LABS FEATURE, follow the "Experimental Feature Checklist" below and DELETE the "Standard PR Checklist"
- If this is a STANDARD PR, follow the "Standard PR Checklist" below and DELETE the "Experimental Feature Checklist"
-->

### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason:
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report


**Device:** iPhone 16e

**iOS:** 26.2

**Damus:** 9adfd40b86b4f2649474365c80d6e069b9ddf2c1

**Setup:**
- Debugger attached
- Log level set to debug
- Setup log filter to "PRELOAD:" to show only logs that we are interested in

**Steps:**
1. Go to the Universe View (or some timeline where there might be lots of undownloaded profiles)
2. Scroll down at a reasonable scrolling speed
3. Ensure that profiles mostly look to be fully loaded by the time they appear on screen.
4. Check that preloaded profile names do correspond to the profiles that show up on screen after a few notes scrolled.

**Results:**
- [x] PASS

## Performance check

Device: iPhone 13 mini
iOS: 26.2
Damus: [9adfd40](https://github.com/damus-io/damus/pull/3514/commits/9adfd40b86b4f2649474365c80d6e069b9ddf2c1)

Steps:
1. Scroll down a timeline

<img width="1583" height="1033" alt="Screenshot 2026-01-09 at 18 28 00" src="https://github.com/user-attachments/assets/9ffd1b9c-e59f-4a66-bf76-baa482b327c1" />

Results: No regressions found

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent profile preloading in the timeline. User information for upcoming posts now loads in advance, providing a faster and smoother browsing experience as you scroll.

* **Refactor**
  * Improved network subscription handling to reduce redundant filter updates. When profile streams are removed, unnecessary resubscriptions are now avoided, decreasing network overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->