### PR TITLE
longform: fix line height setting not working

### DIFF
--- a/damus/Features/Longform/Views/LongformMarkdownView.swift
+++ b/damus/Features/Longform/Views/LongformMarkdownView.swift
@@ -29,11 +29,10 @@ struct LongformMarkdownView: View {
         HStack(spacing: 0) {
             Spacer(minLength: 0)
             Markdown(markdown)
-                // Override only paragraph style, preserving all other default formatting (headings, lists, etc.)
                 .markdownBlockStyle(\.paragraph) { configuration in
                     configuration.label
                         .relativeLineSpacing(.em(relativeLineSpacing))
-                        .markdownMargin(top: 0, bottom: 16)
+                        .markdownMargin(top: .zero, bottom: .em(1))
                 }
                 .markdownImageProvider(.kingfisher(disable_animation: disableAnimation))
                 .markdownInlineImageProvider(.kingfisher)


### PR DESCRIPTION
## Summary

Fixes the longform article line height setting having no visual effect. The user could adjust the line height multiplier in settings, but the text spacing would not change.

**Root Cause:** The upstream `swift-markdown-ui` library's `.relativeLineSpacing()` modifier was applying SwiftUI's `.lineSpacing()` to a container view instead of directly to `Text` views. SwiftUI's `.lineSpacing()` only takes effect when applied directly to `Text`.

**Fix:** 
- Upstream fix in damus-io/swift-markdown-ui#1 passes line spacing through the environment so it can be applied directly to `Text` views
- This PR uses relative units for paragraph margins for consistency

> **⚠️ Dependency:** This PR requires [damus-io/swift-markdown-ui#1](https://github.com/damus-io/swift-markdown-ui/pull/1) to be merged first. After upstream merges, `Package.resolved` needs to be updated to point to the new commit.

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Not needed: Change is minimal (relative units vs absolute), no new logic
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 17 Pro (Simulator)

**iOS:** iOS 26

**Damus:** fix/longform-line-spacing branch + local swift-markdown-ui with fix

**Setup:** Longform article with multiple paragraphs

**Steps:**
1. Open a longform article (kind 30023)
2. Go to Settings and change line height multiplier (e.g., 1.2x to 1.8x)
3. Return to article and observe line spacing

**Results:**
- [x] PASS
- Line spacing visibly changes when setting is adjusted
- No text truncation observed
- Spacing consistent between wrapped lines

## Other notes

Screenshots showing before/after line spacing:
- Tighter spacing (1.2x): Shows minimal space between lines
- Looser spacing (1.8x): Shows increased space between lines within paragraphs

The core fix is in the upstream dependency. This PR will need `Package.resolved` updated after damus-io/swift-markdown-ui#1 merges.

Closes https://github.com/damus-io/damus/issues/3519
Signed-off-by: alltheseas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted paragraph spacing in longform markdown content for improved vertical layout consistency. Bottom margin now uses relative sizing for better proportional spacing across different display sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->