### PR TITLE
ui: fix expanded profile picture showing robot instead of actual PFP

### DIFF
--- a/damus/Features/Profile/Views/ProfileView.swift
+++ b/damus/Features/Profile/Views/ProfileView.swift
@@ -323,7 +323,7 @@ struct ProfileView: View {
                         is_zoomed.toggle()
                     }
                     .damus_full_screen_cover($is_zoomed, damus_state: damus_state) {
-                        ProfilePicImageView(pubkey: profile.pubkey, profiles: damus_state.profiles, settings: damus_state.settings, nav: damus_state.nav, shouldShowEditButton: damus_state.pubkey == profile.pubkey)
+                        ProfilePicImageView(pubkey: profile.pubkey, profiles: damus_state.profiles, settings: damus_state.settings, nav: damus_state.nav, shouldShowEditButton: damus_state.pubkey == profile.pubkey, damusState: damus_state)
                     }
 
                 Spacer()


### PR DESCRIPTION
## Summary

Fixed expanded profile picture showing robot emoji instead of actual profile picture.

`ProfilePicImageView` (the full-screen expanded PFP view) was not streaming profile updates from the network. When the profile wasn't cached at view creation, it fell back to robohash and never updated. Added profile streaming via `profilesManager.streamProfile()` to match the pattern used by `ProfilePicView`.

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Not needed: Minor change adding an async stream that already exists in the small PFP view (`ProfilePicView`). No new computation or blocking operations.
- [x] I have opened or referred to an existing github issue related to this change: https://github.com/damus-io/damus/issues/3540
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 17 Pro (Simulator)

**iOS:** 26.2

**Damus:** 5e29ce4a

**Setup:**
- Debugger attached
- Log filter: `ProfilePicImageView`

**Steps:**
1. Navigate to any profile in the app
2. Tap on the profile picture to expand it to full screen
3. Observe console logs showing profile stream activity
4. Verify the actual profile picture loads (not robohash)

**Results:**
- [x] PASS

Console logs confirm fix works - profile that initially showed robohash URL updated to actual picture URL after stream delivered the profile data.

## Other notes

Debug logging (`Log.debug`) added to `ProfilePicImageView` to aid future debugging. These logs only appear in debug builds (uses `OSLogType.debug`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile pictures now receive live streamed updates so changes appear in real time.

* **Bug Fixes**
  * Improved UI responsiveness, padding, and interaction behavior for profile picture display.
  * Preserved overlay and gesture behavior while fixing update/display glitches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->