### PR TITLE
Wait for app to load the relay list and connect before loading universe view

### DIFF
--- a/damus/Core/Networking/NostrNetworkManager/NostrNetworkManager.swift
+++ b/damus/Core/Networking/NostrNetworkManager/NostrNetworkManager.swift
@@ -35,6 +35,16 @@ class NostrNetworkManager {
     let reader: SubscriptionManager
     let profilesManager: ProfilesManager
     
+    /// Tracks whether the network manager has completed its initial connection
+    private var isConnected = false
+    /// A list of continuations waiting for connection to complete
+    ///
+    /// We use a unique ID for each connection request so that multiple concurrent calls to `awaitConnection()`
+    /// can be properly tracked and resumed. This follows the pattern established in `RelayConnection` and `WalletModel`.
+    private var connectionContinuations: [UUID: CheckedContinuation<Void, Never>] = [:]
+    /// A lock to ensure thread-safe access to the continuations dictionary and connection state
+    private let continuationsLock = NSLock()
+    
     init(delegate: Delegate, addNdbToRelayPool: Bool = true) {
         self.delegate = delegate
         let pool = RelayPool(ndb: addNdbToRelayPool ? delegate.ndb : nil, keypair: delegate.keypair)
@@ -54,10 +64,110 @@ class NostrNetworkManager {
         await self.userRelayList.connect()    // Will load the user's list, apply it, and get RelayPool to connect to it.
         await self.profilesManager.load()
         await self.reader.startPreloader()
+        
+        continuationsLock.lock()
+        isConnected = true
+        continuationsLock.unlock()
+        
+        resumeAllConnectionContinuations()
+    }
+    
+    /// Waits for the app to be connected to the network by checking for the next `connect()` call to complete
+    ///
+    /// This method allows code to await the app to load the relay list and connect to it.
+    /// It uses Swift continuations to handle completion notifications from potentially different threads.
+    ///
+    /// - Parameter timeout: Optional timeout duration (defaults to 30 seconds)
+    ///
+    /// ## Usage
+    /// ```swift
+    /// await nostrNetworkManager.awaitConnection()
+    /// // Code here runs after connection is established
+    /// ```
+    ///
+    /// ## Implementation notes
+    ///
+    /// - Thread-safe: Can be called from any thread and will handle synchronization properly
+    /// - Multiple callers: Supports multiple concurrent calls, each tracked by a unique ID
+    /// - Timeout handling: Automatically resumes after timeout even if connection fails
+    /// - Short-circuits immediately if already connected, preventing unnecessary waiting
+    func awaitConnection(timeout: Duration = .seconds(30)) async {
+        // Short-circuit if already connected
+        continuationsLock.lock()
+        let alreadyConnected = isConnected
+        continuationsLock.unlock()
+        
+        guard !alreadyConnected else {
+            return
+        }
+        
+        let requestId = UUID()
+        var timeoutTask: Task<Void, Never>?
+        var isResumed = false
+        
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            // Store the continuation in a thread-safe manner
+            continuationsLock.lock()
+            connectionContinuations[requestId] = continuation
+            continuationsLock.unlock()
+            
+            // Set up timeout
+            timeoutTask = Task {
+                try? await Task.sleep(for: timeout)
+                if !isResumed {
+                    self.resumeConnectionContinuation(requestId: requestId, isResumed: &isResumed)
+                }
+            }
+        }
+        
+        timeoutTask?.cancel()
+    }
+    
+    /// Resumes a connection continuation in a thread-safe manner
+    ///
+    /// This can be called from any thread and ensures the continuation is only resumed once
+    ///
+    /// - Parameters:
+    ///   - requestId: The unique identifier for this connection request
+    ///   - isResumed: Flag to track if the continuation has already been resumed
+    private func resumeConnectionContinuation(requestId: UUID, isResumed: inout Bool) {
+        continuationsLock.lock()
+        defer { continuationsLock.unlock() }
+        
+        guard !isResumed, let continuation = connectionContinuations[requestId] else {
+            return
+        }
+        
+        isResumed = true
+        connectionContinuations.removeValue(forKey: requestId)
+        continuation.resume()
+    }
+    
+    /// Resumes all pending connection continuations in a thread-safe manner
+    ///
+    /// This is useful for notifying all waiting callers when the connection is established
+    /// or when you need to unblock all pending connection requests.
+    ///
+    /// This can be called from any thread and ensures all continuations are resumed safely.
+    private func resumeAllConnectionContinuations() {
+        continuationsLock.lock()
+        defer { continuationsLock.unlock() }
+        
+        // Resume all pending continuations
+        for (_, continuation) in connectionContinuations {
+            continuation.resume()
+        }
+        
+        // Clear the dictionary
+        connectionContinuations.removeAll()
     }
     
     func disconnectRelays() async {
         await self.pool.disconnect()
+        
+        continuationsLock.lock()
+        isConnected = false
+        continuationsLock.unlock()
     }
     
     func handleAppBackgroundRequest() async {
@@ -88,6 +198,10 @@ class NostrNetworkManager {
             for await value in group { continue }
             await pool.close()
         }
+        
+        continuationsLock.lock()
+        isConnected = false
+        continuationsLock.unlock()
     }
     
     func ping() async {

--- a/damus/Features/Search/Models/SearchHomeModel.swift
+++ b/damus/Features/Search/Models/SearchHomeModel.swift
@@ -55,6 +55,8 @@ class SearchHomeModel: ObservableObject {
         DispatchQueue.main.async {
             self.loading = true
         }
+        await damus_state.nostrNetwork.awaitConnection()
+        
         let to_relays = await damus_state.nostrNetwork.ourRelayDescriptors
             .map { $0.url }
             .filter { !damus_state.relay_filters.is_filtered(timeline: .search, relay_id: $0) }

--- a/damus/Features/Search/Views/SearchHomeView.swift
+++ b/damus/Features/Search/Views/SearchHomeView.swift
@@ -14,7 +14,6 @@ struct SearchHomeView: View {
     @StateObject var model: SearchHomeModel
     @State var search: String = ""
     @FocusState private var isFocused: Bool
-    @State var loadingTask: Task<Void, Never>?
 
     func content_filter(_ fstate: FilterState) -> ((NostrEvent) -> Bool) {
         var filters = ContentFilters.defaults(damus_state: damus_state)
@@ -118,13 +117,8 @@ struct SearchHomeView: View {
         .onReceive(handle_notify(.new_mutes)) { _ in
             self.model.filter_muted()
         }
-        .onAppear {
-            if model.events.events.isEmpty {
-                loadingTask = Task { await model.load() }
-            }
-        }
-        .onDisappear {
-            loadingTask?.cancel()
+        .task {
+            await model.load()
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses a race condition that happened when the user initializes the app on the universe view, where the loading function would run before the relay list was fully loaded and connected, causing the loading function to connect to an empty relay list.

The issue was fixed by introducing a method that allows callers to wait for the app to connect to the network

Changelog-Fixed: Fixed issue where the app would occasionally launch an empty universe view
Closes: https://github.com/damus-io/damus/issues/3528

## Checklist

<!-- 
CHOOSE YOUR CHECKLIST: 
- If this is an EXPERIMENTAL DAMUS LABS FEATURE, follow the "Experimental Feature Checklist" below and DELETE the "Standard PR Checklist"
- If this is a STANDARD PR, follow the "Standard PR Checklist" below and DELETE the "Experimental Feature Checklist"
-->

### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: _Very scoped changes that should not adversely affect performance_
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report


**Device:** iPhone 16e simulator

**iOS:** 26.0

**Damus:** 689be41e274d713bb6b9494d51af58bf8867a172

**Setup:** App setup to initialize on the universe view

**Steps:**
1. Launch app
2. Ensure universe view loads on launch.

**Results:**
- [x] PASS 3/3 times (Previously I could reproduce the issue 3/3 times using the same test and setup)

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved search reliability by ensuring the app waits for a network connection before processing queries.
  * More robust handling of connection loss and recovery to reduce failed searches.

* **Refactor**
  * Connection management improved to better support multiple concurrent requests and wake pending work when connectivity is established.
  * Simplified search view lifecycle by using modern async task handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->