### PR TITLE
Show mute placeholder without expand button for muted users

### DIFF
--- a/damus/Features/Events/EventMutingContainerView.swift
+++ b/damus/Features/Events/EventMutingContainerView.swift
@@ -21,6 +21,7 @@ struct EventMutingContainerView<Content: View>: View {
     /// By default this is the same as `should_show_event`. However, if the user taps the button to manually show a muted note, this can become out of sync with `should_show_event`.
     @State var shown: Bool
 
+    /// Cached muted reason for this event, or nil when unmuted.
     @State var muted_reason: MuteItem?
 
     init(damus_state: DamusState, event: NostrEvent, @ViewBuilder content: () -> Content) {
@@ -42,36 +43,31 @@ struct EventMutingContainerView<Content: View>: View {
         return !should_show_event(state: damus_state, ev: event)
     }
 
+    /// Resolved muted reason, preferring cached state over fresh lookup.
     var current_muted_reason: MuteItem? {
         if let muted_reason {
             return muted_reason
         }
         return damus_state.mutelist_manager.event_muted_reason(event)
     }
-    
-    var should_show_mute_box: Bool {
-        guard should_mute else {
-            return false
-        }
-        guard let reason = current_muted_reason else {
-            return true
-        }
-        if case .user = reason {
-            // Skip placeholders for people the user has muted entirely.
-            return false
-        }
+
+    /// Whether the mute box should include an expand button.
+    /// User mutes show a static box with no expand option (like Twitter).
+    var should_show_expand_button: Bool {
+        guard let reason = current_muted_reason else { return true }
+        if case .user = reason { return false }
         return true
     }
-    
+
     var body: some View {
         Group {
-            if should_show_mute_box {
+            if should_mute {
                 let reason = current_muted_reason
                 if let customMuteBox {
                     customMuteBox($shown, reason)
                 }
                 else {
-                    EventMutedBoxView(shown: $shown, reason: reason)
+                    EventMutedBoxView(shown: $shown, reason: reason, showExpandButton: should_show_expand_button)
                 }
             }
             if shown || !should_mute {
@@ -101,12 +97,13 @@ struct EventMutingContainerView<Content: View>: View {
 struct EventMutedBoxView: View {
     @Binding var shown: Bool
     var reason: MuteItem?
+    var showExpandButton: Bool = true
 
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 20)
                 .foregroundColor(DamusColors.adaptableGrey)
-            
+
             HStack {
                 if let reason {
                     Text("Note from a \(reason.title) you've muted", comment: "Text to indicate that what is being shown is a note which has been muted.")
@@ -114,8 +111,10 @@ struct EventMutedBoxView: View {
                     Text("Note you've muted", comment: "Text to indicate that what is being shown is a note which has been muted.")
                 }
                 Spacer()
-                Button(shown ? NSLocalizedString("Hide", comment: "Button to hide a note which has been muted.") : NSLocalizedString("Show", comment: "Button to show a note which has been muted.")) {
-                    shown.toggle()
+                if showExpandButton {
+                    Button(shown ? NSLocalizedString("Hide", comment: "Button to hide a note which has been muted.") : NSLocalizedString("Show", comment: "Button to show a note which has been muted.")) {
+                        shown.toggle()
+                    }
                 }
             }
             .padding(10)

--- a/damus/Features/Muting/Models/Lists.swift
+++ b/damus/Features/Muting/Models/Lists.swift
@@ -7,30 +7,45 @@
 
 import Foundation
 
+/// Creates or updates a mutelist by adding items.
+/// Replaces existing items with same identity to update expiration.
 func create_or_update_mutelist(keypair: FullKeypair, mprev: NostrEvent?, to_add: Set<MuteItem>) -> NostrEvent? {
-    let muted_items: Set<MuteItem> = (mprev?.mute_list ?? Set<MuteItem>()).union(to_add).filter { !$0.is_expired() }
-    let tags: [[String]] = muted_items.map { $0.tag }
+    var merged: [MuteItem] = Array(mprev?.mute_list ?? [])
+
+    for item in to_add {
+        if let index = merged.firstIndex(where: { $0.matchesStorage(item) }) {
+            merged[index] = item
+        } else {
+            merged.append(item)
+        }
+    }
+
+    let tags: [[String]] = merged.map { $0.tag }
     return NostrEvent(content: mprev?.content ?? "", keypair: keypair.to_keypair(), kind: NostrKind.mute_list.rawValue, tags: tags)
 }
 
+/// Creates or updates a mutelist by adding a single item.
 func create_or_update_mutelist(keypair: FullKeypair, mprev: NostrEvent?, to_add: MuteItem) -> NostrEvent? {
     return create_or_update_mutelist(keypair: keypair, mprev: mprev, to_add: [to_add])
 }
 
+/// Removes an item from the mutelist.
+/// Uses `matchesStorage` to find and remove items, including expired ones.
 func remove_from_mutelist(keypair: FullKeypair, prev: NostrEvent?, to_remove: MuteItem) -> NostrEvent? {
-    let muted_items: Set<MuteItem> = (prev?.mute_list ?? Set<MuteItem>()).subtracting([to_remove]).filter { !$0.is_expired() }
-    let tags: [[String]] = muted_items.map { $0.tag }
+    let existing: [MuteItem] = Array(prev?.mute_list ?? [])
+    let filtered = existing.filter { !$0.matchesStorage(to_remove) }
+    let tags: [[String]] = filtered.map { $0.tag }
     return NostrEvent(content: "", keypair: keypair.to_keypair(), kind: NostrKind.mute_list.rawValue, tags: tags)
 }
 
+/// Toggles an item in the mutelist (adds if not present, removes if present).
+/// Uses `matchesStorage` to check existence, allowing toggle of expired items.
 func toggle_from_mutelist(keypair: FullKeypair, prev: NostrEvent?, to_toggle: MuteItem) -> NostrEvent? {
-    let existing_muted_items: Set<MuteItem> = (prev?.mute_list ?? Set<MuteItem>())
+    let existing: [MuteItem] = Array(prev?.mute_list ?? [])
 
-    if existing_muted_items.contains(to_toggle) {
-        // Already exists, remove
+    if existing.contains(where: { $0.matchesStorage(to_toggle) }) {
         return remove_from_mutelist(keypair: keypair, prev: prev, to_remove: to_toggle)
     } else {
-        // Doesn't exist, add
         return create_or_update_mutelist(keypair: keypair, mprev: prev, to_add: to_toggle)
     }
 }

--- a/damus/Features/Muting/Models/MutelistManager.swift
+++ b/damus/Features/Muting/Models/MutelistManager.swift
@@ -24,9 +24,9 @@ class MutelistManager {
     var words: Set<MuteItem> = [] {
         didSet { self.reset_cache() }
     }
-    
+
     var muted_notes_cache: [NoteId: EventMuteStatus] = [:]
-    
+
     nonisolated init(user_keypair: Keypair) {
         self.user_keypair = user_keypair
     }
@@ -62,49 +62,73 @@ class MutelistManager {
         self.muted_notes_cache = [:]
     }
 
+    /// Checks if an item is muted AND currently active (not expired).
     func is_muted(_ item: MuteItem) -> Bool {
+        let set: Set<MuteItem>
         switch item {
-        case .user(_, _):
-            return users.contains(item)
-        case .hashtag(_, _):
-            return hashtags.contains(item)
-        case .word(_, _):
-            return words.contains(item)
-        case .thread(_, _):
-            return threads.contains(item)
+        case .user:
+            set = users
+        case .hashtag:
+            set = hashtags
+        case .word:
+            set = words
+        case .thread:
+            set = threads
         }
+        // Find matching item and check if it's active
+        guard let stored = set.first(where: { $0 == item }) else { return false }
+        return stored.isActive()
     }
 
     func is_event_muted(_ ev: NostrEvent) -> Bool {
         return self.event_muted_reason(ev) != nil
     }
 
+    /// Updates the mutelist, detecting adds, removes, and expiration changes.
     func set_mutelist(_ ev: NostrEvent) {
         let oldlist = self.event
         self.event = ev
 
-        let old: Set<MuteItem> = oldlist?.mute_list ?? Set<MuteItem>()
-        let new: Set<MuteItem> = ev.mute_list ?? Set<MuteItem>()
-        let diff = old.symmetricDifference(new)
+        let oldItems = Array(oldlist?.mute_list ?? [])
+        let newItems = Array(ev.mute_list ?? [])
+
+        // Build identity-based maps
+        var oldMap: [MuteItem: MuteItem] = [:]
+        for item in oldItems { oldMap[item] = item }
+        var newMap: [MuteItem: MuteItem] = [:]
+        for item in newItems { newMap[item] = item }
 
         var new_mutes = Set<MuteItem>()
         var new_unmutes = Set<MuteItem>()
 
-        for d in diff {
-            if new.contains(d) {
-                add_mute_item(d)
-                new_mutes.insert(d)
+        // Process adds and expiration updates
+        for (identity, newItem) in newMap {
+            if let oldItem = oldMap[identity] {
+                // Identity exists - check if expiration changed
+                if oldItem.expirationDate != newItem.expirationDate {
+                    remove_mute_item(oldItem)
+                    add_mute_item(newItem)
+                }
             } else {
-                remove_mute_item(d)
-                new_unmutes.insert(d)
+                // New item
+                add_mute_item(newItem)
+                new_mutes.insert(newItem)
             }
         }
 
-        if new_mutes.count > 0 {
+        // Process removals
+        for (identity, oldItem) in oldMap {
+            if newMap[identity] == nil {
+                remove_mute_item(oldItem)
+                new_unmutes.insert(oldItem)
+            }
+        }
+
+        if !new_mutes.isEmpty {
             notify(.new_mutes(new_mutes))
         }
 
-        if new_unmutes.count > 0 {
+        if !new_unmutes.isEmpty {
             notify(.new_unmutes(new_unmutes))
         }
     }
@@ -139,9 +163,23 @@ class MutelistManager {
         }
     }
     
+    /// Returns the mute reason for an event, using cache with expiration validation.
     func event_muted_reason(_ ev: NostrEvent) -> MuteItem? {
-        if let cached_mute_status = self.muted_notes_cache[ev.id] {
-            return cached_mute_status.mute_reason()
+        if let cached = self.muted_notes_cache[ev.id] {
+            // Re-validate cached mute status in case it expired
+            if case .muted(let reason) = cached {
+                if !reason.isActive() {
+                    // Mute expired - recompute to check for other active mute reasons
+                    self.muted_notes_cache[ev.id] = .not_muted
+                    if let fresh = self.compute_event_muted_reason(ev) {
+                        self.muted_notes_cache[ev.id] = .muted(reason: fresh)
+                        return fresh
+                    }
+                    return nil
+                }
+                return reason
+            }
+            return cached.mute_reason()
         }
         if let reason = self.compute_event_muted_reason(ev) {
             self.muted_notes_cache[ev.id] = .muted(reason: reason)
@@ -155,37 +193,37 @@ class MutelistManager {
     /// Check if an event is muted given a collection of ``MutedItem``.
     ///
     /// - Parameter ev: The ``NostrEvent`` that you want to check the muted reason for.
-    /// - Returns: The ``MuteItem`` that matched the event. Or `nil` if the event is not muted.
+    /// - Returns: The ``MuteItem`` that matched the event (if active). Or `nil` if the event is not muted.
     func compute_event_muted_reason(_ ev: NostrEvent) -> MuteItem? {
         // Events from the current user should not be muted.
         guard self.user_keypair.pubkey != ev.pubkey else { return nil }
 
-        // Check if user is muted
+        // Check if user is muted (and active)
         let check_user_item = MuteItem.user(ev.pubkey, nil)
-        if users.contains(check_user_item) {
-            return check_user_item
+        if let stored = users.first(where: { $0 == check_user_item }), stored.isActive() {
+            return stored
         }
 
-        // Check if hashtag is muted
+        // Check if hashtag is muted (and active)
         for hashtag in ev.referenced_hashtags {
             let check_hashtag_item = MuteItem.hashtag(hashtag, nil)
-            if hashtags.contains(check_hashtag_item) {
-                return check_hashtag_item
+            if let stored = hashtags.first(where: { $0 == check_hashtag_item }), stored.isActive() {
+                return stored
             }
         }
 
-        // Check if thread is muted
+        // Check if thread is muted (and active)
         for thread_id in ev.referenced_ids {
             let check_thread_item = MuteItem.thread(thread_id, nil)
-            if threads.contains(check_thread_item) {
-                return check_thread_item
+            if let stored = threads.first(where: { $0 == check_thread_item }), stored.isActive() {
+                return stored
             }
         }
 
-        // Check if word is muted
+        // Check if word is muted (and active)
         if let content: String = ev.maybe_get_content(self.user_keypair)?.lowercased() {
             for word in words {
-                if case .word(let string, _) = word {
+                if case .word(let string, _) = word, word.isActive() {
                     if content.contains(string.lowercased()) {
                         return word
                     }


### PR DESCRIPTION
## Summary

- Shows mute box for muted user replies but without an expand button (like Twitter does)
- This allows users to understand reply context without exposing muted content
- Removes notifications from muted users
- Fixes temporary mute expiration handling

Addresses feedback from @jb55:
> "I think we would need the mute box there but just with no button to open it?"
> "I believe this is what twitter does. otherwise it will be confusing, as you wouldn't be able to see who they are actually replying to?"

## Changes

- `EventMutingContainerView`: Add `should_show_expand_button` property that returns false for user mutes
- `EventMutedBoxView`: Add `showExpandButton` parameter to conditionally hide the Show/Hide button
- `MuteItem`: Fix equality/hash to be identity-based and symmetric, case-insensitive for hashtags/words
- `Lists.swift`: Replace existing items instead of deduplicating (allows expiration updates)
- `MutelistManager`: Detect expiration changes, fix cache invalidation with recomputation

## Test Plan

- [ ] Mute a user, verify their replies show placeholder without expand button
- [ ] Mute a hashtag, verify notes with that hashtag show placeholder WITH expand button
- [ ] Set temporary mute, verify it expires correctly
- [ ] Update mute expiration, verify change takes effect

Closes: https://github.com/damus-io/damus/issues/3166
Replaces: #3260

Changelog-Fixed: Temporary mutes now properly expire
Changelog-Fixed: Show mute placeholder for muted users in threads (without expand button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed muting system to properly respect expiration dates for muted items
  * Improved mute reason caching and validation for accurate state tracking

* **New Features**
  * Enhanced muting UI with better control over expand button visibility based on mute context
  * Improved mute detection to account for active/expired states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->