### PR TITLE
Fix double-free crash when creating empty NdbFilter

### DIFF
--- a/nostrdb/src/nostrdb.c
+++ b/nostrdb/src/nostrdb.c
@@ -614,10 +614,20 @@ int ndb_filter_end(struct ndb_filter *filter)
 	memmove(filter->elem_buf.p, filter->data_buf.start, data_len);
 
 	// realloc the whole thing
-	rel = realloc(filter->elem_buf.start, elem_len + data_len);
-	if (rel) 
-		filter->elem_buf.start = rel;
-	assert(filter->elem_buf.start);
+	size_t new_size = elem_len + data_len;
+	if (new_size == 0) {
+		// Avoid calling realloc with size 0 (implementation-defined behavior)
+		// Explicitly free and set to NULL
+		free(filter->elem_buf.start);
+		filter->elem_buf.start = NULL;
+	} else {
+		rel = realloc(filter->elem_buf.start, new_size);
+		if (rel) {
+			filter->elem_buf.start = rel;
+		}
+		// Assert allocation succeeded for non-zero size
+		assert(filter->elem_buf.start);
+	}
 	filter->elem_buf.end = filter->elem_buf.start + elem_len;
 	filter->elem_buf.p = filter->elem_buf.end;
 


### PR DESCRIPTION
## Summary

Fix a double-free memory corruption crash that occurs when creating an empty `NdbFilter` from an empty `NostrFilter`. This was discovered when running `testPerformSnapshot_HandlesEmptyDatabase` with Address Sanitizer enabled.

### Root Cause

The bug occurs in the C function `ndb_filter_end` in `nostrdb/src/nostrdb.c`:

1. **Memory allocation** (`ndb_filter_init_with`): Allocates buffer via `malloc(buf_size)`



2. **Empty filter scenario**: When no fields are added to the filter:   
   - `elem_len + data_len = 0`
   - `realloc(filter->elem_buf.start, 0)` is called
   - Per C standard, `realloc(ptr, 0)` deallocates memory and returns `NULL`
   - Code checks `if (rel)` which is false, leaving `filter->elem_buf.start` pointing to freed memory

```
int ndb_filter_end(struct ndb_filter *filter) {
    (...)
    
    // realloc the whole thing
	rel = realloc(filter->elem_buf.start, elem_len + data_len); // <---- `filter->elem_buf.start` DEALLOCATED HERE
	if (rel)  // `elem_len + data_len = 0`, so `rel` is `NULL`
		filter->elem_buf.start = rel;   // <---- `rel` is `NULL`, so `filter->elem_buf.start` does not get updated
	assert(filter->elem_buf.start);
	filter->elem_buf.end = filter->elem_buf.start + elem_len;
	filter->elem_buf.p = filter->elem_buf.end;

	filter->data_buf.start = filter->elem_buf.end;
	filter->data_buf.end = filter->data_buf.start + data_len;
	filter->data_buf.p = filter->data_buf.end;

	filter->finalized = 1;

	ndb_debug("ndb_filter_end: %ld -> %ld\n", orig_size, elem_len + data_len);

	return 1;
}
```

(The above `ndb_filter_end` function is called by `NdbFilter.from(nostrFilter: NostrFilter)`)

3. **Double-free**: When `NdbFilter` deinitializes, `ndb_filter_destroy` calls `free(filter->elem_buf.start)` on already-freed pointer → crash

```
void ndb_filter_destroy(struct ndb_filter *filter)
{
	if (filter->elem_buf.start)
		free(filter->elem_buf.start); // <---- HERE

	memset(filter, 0, sizeof(*filter));
}
```

(The above is called by `NdbFilter.deinit`)

### Debug Evidence

LLDB session at the problematic first deallocation in `ndb_filter_end`, right after the `realloc` call:

```
(lldb) print rel
(unsigned char *) 0x0000000000000000
(lldb) print elem_len + data_len
(size_t) 0
(lldb) print filter->elem_buf.start
(unsigned char *) 0x00000001292b8800 "\xf8d\U00000004"
```

The pointer remained set to the old (freed) address, causing a double-free when `ndb_filter_destroy` was called.

### Fix

- Explicitly set `filter->elem_buf.start = NULL` when `realloc` returns `NULL` due to zero-size allocation
- Update assertion to allow `NULL` pointers for empty filters (size 0)
- `ndb_filter_destroy` already has safety check: `if (filter->elem_buf.start)` before freeing
- Add test coverage in `NostrFilterTests.testEmptyFilterDoesNotCauseDoubleFree` to verify empty filter lifecycle

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - If not needed, provide reason: Memory safety fix with no performance impact
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 16e Simulator

**iOS:** 26.0

**Damus:** eda601908465f7bd7fd238d55bfbc1cfb65b67c6

**Setup:** Ran all automated tests under `damusTests` with and without Address Sanitizer enabled

**Steps:**
1. Enable Address Sanitizer in Xcode scheme settings
2. Run all tests in `damusTests` target
3. Verify `testPerformSnapshot_HandlesEmptyDatabase` passes
4. Verify no memory error crashes occur in any tests
5. Disable Address Sanitizer and repeat

**Results:**
- [x] PASS - All tests passed with no memory errors detected by Address Sanitizer

## Other notes

Closes #3634


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory allocation safety when resizing filters, including correct handling of zero-sized allocations to avoid invalid pointers and potential crashes.
  * Ensures allocation results are validated before updating internal pointers, reducing risk of corruption during filter operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->