### PR TITLE
ui: Fixes for iOS 26 toolbars

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -1706,6 +1706,9 @@
 		D76BE18C2E0CF3DA004AD0C6 /* Interests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76BE18B2E0CF3D5004AD0C6 /* Interests.swift */; };
 		D76BE18D2E0CF3DA004AD0C6 /* Interests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76BE18B2E0CF3D5004AD0C6 /* Interests.swift */; };
 		D76BE18E2E0CF3DA004AD0C6 /* Interests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76BE18B2E0CF3D5004AD0C6 /* Interests.swift */; };
+		D76C034D2F6B6D78002CAEB5 /* ToolbarItemModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C034C2F6B6D78002CAEB5 /* ToolbarItemModifier.swift */; };
+		D76C034E2F6B6D78002CAEB5 /* ToolbarItemModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C034C2F6B6D78002CAEB5 /* ToolbarItemModifier.swift */; };
+		D76C034F2F6B6D78002CAEB5 /* ToolbarItemModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76C034C2F6B6D78002CAEB5 /* ToolbarItemModifier.swift */; };
 		D77135D32E7B766B00E7639F /* DataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77135D22E7B766300E7639F /* DataExtensions.swift */; };
 		D77135D42E7B766B00E7639F /* DataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77135D22E7B766300E7639F /* DataExtensions.swift */; };
 		D77135D52E7B766B00E7639F /* DataExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77135D22E7B766300E7639F /* DataExtensions.swift */; };
@@ -2863,6 +2866,7 @@
 		D767066E2C8BB3CE00F09726 /* URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLHandler.swift; sourceTree = "<group>"; };
 		D76874F22AE3632B00FB0F68 /* ProfileZapLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileZapLinkView.swift; sourceTree = "<group>"; };
 		D76BE18B2E0CF3D5004AD0C6 /* Interests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interests.swift; sourceTree = "<group>"; };
+		D76C034C2F6B6D78002CAEB5 /* ToolbarItemModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarItemModifier.swift; sourceTree = "<group>"; };
 		D77135D22E7B766300E7639F /* DataExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtensions.swift; sourceTree = "<group>"; };
 		D773BC5E2C6D538500349F0A /* CommentItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentItem.swift; sourceTree = "<group>"; };
 		D774A5C72F4F93F5006A4D64 /* StorageStatsViewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageStatsViewHelper.swift; sourceTree = "<group>"; };
@@ -5458,6 +5462,7 @@
 			children = (
 				5C8F97482EB46208009399B1 /* Glow.swift */,
 				F7F0BA24297892BD009531F3 /* SwipeToDismiss.swift */,
+				D76C034C2F6B6D78002CAEB5 /* ToolbarItemModifier.swift */,
 			);
 			path = Modifiers;
 			sourceTree = "<group>";
@@ -6197,6 +6202,7 @@
 				5C513FCC2984ACA60072348F /* QRCodeView.swift in Sources */,
 				4CC14FF52A740BB7007AEB17 /* NoteId.swift in Sources */,
 				4C19AE512A5CEF7C00C90DB7 /* NostrScript.swift in Sources */,
+				D76C034E2F6B6D78002CAEB5 /* ToolbarItemModifier.swift in Sources */,
 				4C32B95E2A9AD44700DC3548 /* FlatBufferObject.swift in Sources */,
 				D783A63F2AD4E53D00658DDA /* SuggestedHashtagsView.swift in Sources */,
 				D73FA9E12DDC12AA00C706E1 /* OnboardingContentSettings.swift in Sources */,
@@ -6775,6 +6781,7 @@
 				82D6FB8F2CD99F7900C925F4 /* DirectMessagesModel.swift in Sources */,
 				D73C7EDD2DE517A1001F9392 /* OnboardingContentSettings.swift in Sources */,
 				82D6FB902CD99F7900C925F4 /* DirectMessageModel.swift in Sources */,
+				D76C034F2F6B6D78002CAEB5 /* ToolbarItemModifier.swift in Sources */,
 				82D6FB912CD99F7900C925F4 /* UserSettingsStore.swift in Sources */,
 				82D6FB922CD99F7900C925F4 /* Wallet.swift in Sources */,
 				82D6FB932CD99F7900C925F4 /* Report.swift in Sources */,
@@ -7348,6 +7355,7 @@
 				D73E5EF72C6A97F4007EB227 /* PullDownSearch.swift in Sources */,
 				D73E5EF82C6A97F4007EB227 /* NotificationsView.swift in Sources */,
 				D5C1AFC12E5DF7E60092F72F /* ContactCardManager.swift in Sources */,
+				D76C034D2F6B6D78002CAEB5 /* ToolbarItemModifier.swift in Sources */,
 				D73B74E32D8365BA0067BDBC /* ExtraFonts.swift in Sources */,
 				D73E5EF92C6A97F4007EB227 /* EventGroupView.swift in Sources */,
 				D73E5EFA2C6A97F4007EB227 /* NotificationItemView.swift in Sources */,

--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -254,6 +254,7 @@ struct ContentView: View {
                                 ToolbarItem(placement: .navigationBarLeading) {
                                     TopbarSideMenuButton(damus_state: damus, isSideBarOpened: $isSideBarOpened)
                                 }
+                                .hideToolbarBackground()
                                 
                                 ToolbarItem(placement: .navigationBarTrailing) {
                                     HStack(alignment: .center) {
@@ -271,6 +272,7 @@ struct ContentView: View {
                                         }
                                     }
                                 }
+                                .hideToolbarBackground()
                             }
                     }
                     .background(DamusColors.adaptableWhite)

--- a/damus/Features/Notifications/Views/NotificationsView.swift
+++ b/damus/Features/Notifications/Views/NotificationsView.swift
@@ -124,6 +124,8 @@ struct NotificationsView: View {
                     }
                 )
             }
+            .hideToolbarBackground()
+            
             ToolbarItem(placement: .navigationBarTrailing) {
                 if showTrustedButton {
                     TrustedNetworkButton(filter: $filter.friend_filter) {
@@ -133,6 +135,7 @@ struct NotificationsView: View {
                     }
                 }
             }
+            .hideToolbarBackground()
         }
         .onChange(of: filter.friend_filter) { val in
             state.settings.friend_filter = val

--- a/damus/Features/Profile/Views/ProfileView.swift
+++ b/damus/Features/Profile/Views/ProfileView.swift
@@ -503,6 +503,8 @@ struct ProfileView: View {
                         .padding(.top, max(5, 15 + (yOffset / 30)))
                     }
                 }
+                .hideToolbarBackground()
+                
                 if showFollowBtnInBlurrBanner() {
                     ToolbarItem(placement: .topBarTrailing) {
                         FollowButtonView(
@@ -512,12 +514,14 @@ struct ProfileView: View {
                         )
                         .padding(.top, 8)
                     }
+                    .hideToolbarBackground()
                 } else {
                     ToolbarItem(placement: .topBarTrailing) {
                         navActionSheetButton
                             .padding(.top, 5)
                             .accentColor(DamusColors.white)
                     }
+                    .hideToolbarBackground()
                 }
             }
             .toolbarBackground(.hidden)

--- a/damus/Shared/Modifiers/ToolbarItemModifier.swift
+++ b/damus/Shared/Modifiers/ToolbarItemModifier.swift
@@ -1,0 +1,35 @@
+//
+//  ToolbarItemModifier.swift
+//  damus
+//
+
+import SwiftUI
+
+/// Extension that adds the `.hideToolbarBackground()` modifier to toolbar content.
+///
+/// This modifier conditionally applies `.sharedBackgroundVisibility(.hidden)` on iOS 26+,
+/// eliminating the need for duplicated `if #available(iOS 26.0, *)` checks throughout the codebase.
+///
+/// - Usage:
+///   ```swift
+///   .toolbar {
+///       ToolbarItem(placement: .navigationBarLeading) {
+///           Button("Action") { }
+///       }
+///       .hideToolbarBackground()
+///   }
+///   ```
+@available(iOS 15.0, *)
+extension ToolbarContent {
+    /// Hides the toolbar background on iOS 26+, leaving it unchanged on earlier versions.
+    ///
+    /// Apply this modifier to `ToolbarItem` views to suppress the shared background
+    /// visibility introduced in iOS 26 without duplicating version checks.
+    func hideToolbarBackground() -> some ToolbarContent {
+        if #available(iOS 26.0, *) {
+            return self.sharedBackgroundVisibility(.hidden)
+        } else {
+            return self
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This allows us to enable iOS 26, the main issue was with our toolbars using custom buttons.
The glass effect was removed in order to fix this.

Changelog-Added: Enable iOS 26 UI
Changelog-Fixed: Fixed toolbars to be compatible with iOS 26

### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason:
Changes were UI driven
- [ ] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
    - [ ] I do not need to add a changelog entry. Reason: _[Please provide a reason]_
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** _[Please specify the device you used for testing]_
iPhone 15 Pro Max / iPhone 17 Pro Max
**iOS:** _[Please specify the iOS version you used for testing]_
18.6 / 26.0

**Damus:** _[Please specify the Damus version or commit hash you used for testing]_

1.17 (1) 546e9eec

**Setup:** _[Please provide a brief description of the setup you used for testing, if applicable]_

XCode Simulator

**Steps:** _[Please provide a list of steps you took to test the changes in this PR]_

Check toolbars in all Views to make sure the UI looks fine on both iOS 26 and lower version

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_

## Other notes

Relevant issue: https://github.com/damus-io/damus/issues/3239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toolbar controls now support hiding their background on newer iOS, improving immersion.

* **Refactor**
  * Toolbar handling updated to apply background-visibility behavior consistently across timeline, notifications, and profile screens.

* **Style**
  * Improved toolbar visual consistency: gear/trusted-network controls and profile/timeline toolbar items display without background on supported iOS versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->