### PR TITLE
Move client tag display from feed to note detail view

### DIFF
--- a/damus/Features/Events/Components/EventTop.swift
+++ b/damus/Features/Events/Components/EventTop.swift
@@ -35,10 +35,7 @@ struct EventTop: View {
             ProfileName(is_anon: is_anon)
             TimeDot()
             RelativeTime(time: state.events.get_cache_data(event.id).relative_time, size: size, font_size: state.settings.font_size)
-            if let clientTag = event.clientTag {
-                TimeDot()
-                ClientTagLabel(clientTag: clientTag, size: size, font_size: state.settings.font_size)
-            }
+
             Spacer()
             if !options.contains(.no_context_menu) {
                 EventMenuContext(damus: state, event: event)
@@ -51,19 +48,5 @@ struct EventTop: View {
 struct EventTop_Previews: PreviewProvider {
     static var previews: some View {
         EventTop(state: test_damus_state, event: test_note, pubkey: test_note.pubkey, is_anon: false, size: .normal, options: [])
-    }
-}
-
-/// Displays the client name that published an event (e.g., "via Damus").
-struct ClientTagLabel: View {
-    let clientTag: ClientTagMetadata
-    let size: EventViewKind
-    let font_size: Double
-
-    var body: some View {
-        Text(String(format: NSLocalizedString("via %@", comment: "Label indicating which client published the event"), clientTag.name))
-            .font(eventviewsize_to_font(size, font_size: font_size))
-            .foregroundColor(.gray)
-            .lineLimit(1)
     }
 }

--- a/damus/Features/Events/SelectedEventView.swift
+++ b/damus/Features/Events/SelectedEventView.swift
@@ -58,10 +58,19 @@ struct SelectedEventView: View {
 
                 Mention
                 
-                Text(verbatim: "\(format_date(created_at: event.created_at))")
-                    .padding([.top, .leading, .trailing])
-                    .font(.footnote)
-                    .foregroundColor(.gray)
+                HStack {
+                    Text(verbatim: "\(format_date(created_at: event.created_at))")
+                        .font(.footnote)
+                        .foregroundColor(.gray)
+                    if let clientTag = event.clientTag {
+                        Text(String(format: NSLocalizedString("via %@", comment: "Label indicating which client published the event"), clientTag.name))
+                            .font(.footnote)
+                            .foregroundColor(.gray)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
+                .padding([.top, .leading, .trailing])
                 
                 Divider()
                     .padding([.bottom], 4)


### PR DESCRIPTION
## Screenshots
<img width="202" height="428" alt="Screenshot 2026-03-11 at 8 24 24 PM" src="https://github.com/user-attachments/assets/4fe0e6c1-a89b-48c7-b7b5-19870ac1e8b4" />
<img width="211" height="428" alt="Screenshot 2026-03-11 at 8 22 31 PM" src="https://github.com/user-attachments/assets/d237c063-0bca-4249-a93d-73ea190de8aa" />

## Summary

- Remove client tag ("via ClientName") from the feed header row (`EventTop`) so it no longer clutters the timeline
- Display it inline next to the timestamp in the note detail view (`SelectedEventView`) with `.footnote` font to match surrounding metadata
- Remove unused `ClientTagLabel` struct (dead code after the move)
- Apply `lineLimit(1)` + `truncationMode(.tail)` to guard against unbounded client tag names

Closes: https://github.com/damus-io/damus/issues/3672

## Commits (review commit-by-commit)

1. `1768432a` — Move client tag from EventTop to SelectedEventView timestamp row (14 impl, 0 test)

Total: 14 impl, 0 test

## Test plan

- [x] `just build` — compiles clean
- [x] `testClientTagParsing` and `testClientTagNilWhenMissing` pass (data model unchanged)
- [x] Manual: scroll main feed — no client tags visible
- [x] Manual: tap into a note with a client tag — "via ClientName" appears next to date in `.footnote` size
- [x] ~~Manual: verify long client names truncate with ellipsis~~ I Don't think there is a long enough client name to warrant this test

No new tests added — this is a pure UI layout change (moving a label between views). Per AGENTS.md, test coverage is not required when code is demonstrably untestable (pure UI layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized client tag display in event details view, relocating it from the event header to the date section with a "via" format indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->