### PR TITLE
Add stale issue cleanup workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,13 +11,13 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
-          days-before-stale: 60
+          days-before-stale: 180
           days-before-close: 30
           stale-issue-label: 'stalled'
           stale-issue-message: >
-            This issue has had no activity for 60 days. This usually means
+            This issue has had no activity for 180 days. This usually means
             it's too big and should be broken down, is blocked and needs
             attention, or isn't a priority right now.
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,32 @@
+name: Stale issue cleanup
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # every Monday at 9am UTC
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 60
+          days-before-close: 30
+          stale-issue-label: 'stalled'
+          stale-issue-message: >
+            This issue has had no activity for 60 days. This usually means
+            it's too big and should be broken down, is blocked and needs
+            attention, or isn't a priority right now.
+
+            It will be auto-closed in 30 days if there's no further activity.
+            Feel free to comment to keep it open, or close it if it's no longer relevant.
+          close-issue-message: >
+            Closed due to inactivity. Reopen anytime if this becomes relevant again.
+          exempt-issue-labels: 'bounty,security,regression,pinned'
+          exempt-all-assignees: true
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          operations-per-run: 30


### PR DESCRIPTION
## Summary

- Adds a weekly GitHub Action (`actions/stale@v9`) that labels inactive issues as **stalled** after 60 days and auto-closes them after 30 more days (90 total)
- Exempts `bounty`, `security`, `regression`, and `pinned` labels, plus any issue with an assignee
- Does not affect PRs

## Rationale

Issues that sit idle for a long time usually mean one of:
1. Too big — should be broken down into smaller issues
2. Blocked — needs explicit attention
3. Not a priority right now — close it, reopen later if needed

This keeps the issue tracker focused on what's actually active.

## Config

| Setting | Value |
|---|---|
| Stale after | 60 days |
| Close after | 30 more days (90 total) |
| Schedule | Weekly, Monday 9am UTC |
| Exempt labels | bounty, security, regression, pinned |
| Exempt assignees | yes |
| PRs | not affected |

## Note

A `stalled` label will need to be created for this to look right. Suggested: orange (`#FFA500`), description: "No activity — needs attention or triage"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated stale issue management to maintain a clean issue tracker. Inactive issues will be labeled after 60 days and closed after 30 additional days of inactivity. Issues marked as bounties, security concerns, regressions, or pinned, as well as assigned issues, are exempt from automatic closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->