### PR TITLE
fix: delete stale lock.mdb during compaction to prevent SIGBUS crash

### DIFF
--- a/damusTests/NdbCompactionTests.swift
+++ b/damusTests/NdbCompactionTests.swift
@@ -129,4 +129,46 @@ final class NdbCompactionTests: XCTestCase {
             "Temp directory should be cleaned up after successful compaction"
         )
     }
+
+    // MARK: - compact_if_needed: lock.mdb removal
+
+    func testCompactIfNeeded_removesLockFileAfterCompaction() {
+        // Given: a real Ndb database that has been opened and closed (so lock.mdb exists)
+        let dbPath = testDirectory.appendingPathComponent("lock_test_db").path
+        try? FileManager.default.createDirectory(atPath: dbPath, withIntermediateDirectories: true)
+
+        guard let ndb = Ndb(path: dbPath) else {
+            XCTFail("Could not open Ndb at \(dbPath)")
+            return
+        }
+        ndb.close()
+
+        let lockPath = "\(dbPath)/lock.mdb"
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: lockPath),
+            "lock.mdb should exist after opening and closing Ndb"
+        )
+
+        // When: compact_if_needed runs
+        Ndb.set_compact_on_next_launch()
+        Ndb.compact_if_needed(db_path: dbPath)
+
+        // Then: lock.mdb should NOT exist (it was deleted during compaction)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: lockPath),
+            "lock.mdb should be removed after compaction to prevent stale reader-table crashes"
+        )
+
+        // And: LMDB recreates a fresh lock.mdb when re-opened
+        guard let reopenedNdb = Ndb(path: dbPath) else {
+            XCTFail("Could not re-open Ndb after compaction — database may be corrupt")
+            return
+        }
+        reopenedNdb.close()
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: lockPath),
+            "lock.mdb should be recreated by LMDB after opening the compacted database"
+        )
+    }
 }

--- a/nostrdb/Ndb+Compaction.swift
+++ b/nostrdb/Ndb+Compaction.swift
@@ -109,6 +109,25 @@ extension Ndb {
         let originalDataMdb = URL(fileURLWithPath: "\(path)/\(main_db_file_name)")
         let compactedDataMdb = URL(fileURLWithPath: "\(tempPath)/\(main_db_file_name)")
 
+        // Validate the compacted file before replacing the original.
+        let originalSize = (try? FileManager.default.attributesOfItem(atPath: originalDataMdb.path)[.size] as? Int) ?? 0
+        let compactedSize = (try? FileManager.default.attributesOfItem(atPath: compactedDataMdb.path)[.size] as? Int) ?? 0
+        Log.info("compact_if_needed: original=%d bytes, compacted=%d bytes", for: .storage, originalSize, compactedSize)
+
+        guard compactedSize > 0 else {
+            Log.error("compact_if_needed: compacted file is missing or empty — aborting", for: .storage)
+            try? FileManager.default.removeItem(atPath: tempPath)
+            return
+        }
+
+        // Delete the stale lock.mdb BEFORE replacing data.mdb.
+        // The temp Ndb wrote reader-table / txn state into lock.mdb that references
+        // pages in the old data.mdb. After data.mdb is replaced with the smaller
+        // compacted copy, those page references become invalid and cause SIGBUS.
+        // LMDB will recreate a fresh lock file on the next open.
+        let lockPath = "\(path)/lock.mdb"
+        try? FileManager.default.removeItem(atPath: lockPath)
+
         do {
             _ = try FileManager.default.replaceItemAt(
                 originalDataMdb,
@@ -116,12 +135,21 @@ extension Ndb {
                 backupItemName: nil,
                 options: [.usingNewMetadataOnly]
             )
-            Log.info("NostrDB compacted successfully", for: .storage)
         } catch {
             Log.error("compact_if_needed: failed to replace db file: %@", for: .storage, String(describing: error))
             try? FileManager.default.removeItem(atPath: tempPath)
             return
         }
+
+        // Post-replace sanity check: verify the destination file exists with the expected size.
+        let finalSize = (try? FileManager.default.attributesOfItem(atPath: originalDataMdb.path)[.size] as? Int) ?? 0
+        if finalSize != compactedSize {
+            Log.error("compact_if_needed: post-replace size mismatch — expected %d, got %d", for: .storage, compactedSize, finalSize)
+            try? FileManager.default.removeItem(atPath: tempPath)
+            return
+        }
+
+        Log.info("NostrDB compacted successfully", for: .storage)
 
         // Clean up the temp directory (any remaining files such as lock.mdb).
         try? FileManager.default.removeItem(atPath: tempPath)


### PR DESCRIPTION
## Summary

- Delete stale `lock.mdb` before replacing `data.mdb` during compaction to prevent SIGBUS (translation fault) crash on next app launch
- Add pre-replace validation: abort if the compacted file is missing or empty, preventing replacement of a working DB with garbage
- Add post-replace sanity check: verify destination file size matches expected compacted size
- Add regression test `testCompactIfNeeded_removesLockFileAfterCompaction` confirming lock file removal and fresh recreation on reopen

**Root cause:** The temp `Ndb` instance opened to drive compaction writes reader-table and transaction state into `lock.mdb`. After `data.mdb` is swapped for the smaller compacted copy, the lock file references pages that no longer exist, causing SIGBUS when the main `Ndb` opens on next launch.

Closes: #3689
Changelog-Fixed: Fixed post-compaction crash (SIGBUS) caused by stale LMDB lock file

Signed-off-by: alltheseas

## Commits (review commit-by-commit)

1. `b4d58625` — fix: delete stale lock.mdb during compaction to prevent SIGBUS crash (27 impl, 42 test)

Total: 27 impl, 42 test

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: Bug fix only adds file deletion and size checks during a one-time startup compaction path — no hot path impact
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 13 mini

**iOS:** 18.x

**Damus:** Built from `fix/post-compact-sigbus-crash` branch (Xcode)

**Setup:** Database with ~9.5GB nostrdb accumulated over normal usage

**Steps:**
1. Ran all `NdbCompactionTests` — 5/5 pass (including new lock.mdb removal test)
2. Tapped "Compact Database" in Settings → Storage
3. Force-quit and relaunched the app
4. Confirmed app launches without crash
5. Verified database compacted from 9.48GB to 5.47GB

**Results:**
- [x] PASS

### Pre-submit test audit (AGENTS.md Rule 17/18)

Regression test `testCompactIfNeeded_removesLockFileAfterCompaction`:

**Without fix** (reverted `Ndb+Compaction.swift` to pre-fix state):
```
NdbCompactionTests.swift:157: error: XCTAssertFalse failed -
  lock.mdb should be removed after compaction to prevent stale reader-table crashes
Test Case 'testCompactIfNeeded_removesLockFileAfterCompaction' failed
```

**With fix** (restored `Ndb+Compaction.swift`):
```
Test Case 'testCompactIfNeeded_removesLockFileAfterCompaction' passed (0.007 seconds)
Executed 5 tests, with 0 failures (0 unexpected)
```

- [x] Every test has at least one assertion that can fail (`XCTAssertTrue`, `XCTAssertFalse`)
- [x] No `do/catch` around non-throwing code
- [x] No `#if FLAG` blocks that silently skip
- [x] Test references only code that ships in this PR

## Other notes

Previously, after compaction the app would crash with SIGBUS (translation fault) at addresses ~15GB and ~18GB — far beyond the compacted file's actual size in the 32GB LMDB mmap. The stale `lock.mdb` was the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened database compaction with pre- and post-replace validation, abort-on-empty-compaction, removal of stale lock artifacts prior to replacement, atomic swap of compacted data, and enhanced logging and cleanup on mismatch.

* **Tests**
  * Added automated test coverage validating the compaction workflow, artifact cleanup, and successful reopen after compaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->