### PR TITLE
Fix favorites

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -131,6 +131,7 @@ struct ContentView: View {
     @State var confirm_overwrite_mutelist: Bool = false
     @State private var isSideBarOpened = false
     @State var headerOffset: CGFloat = 0.0
+    @State var postingTimelineSource: TimelineSource = .follows
     var home: HomeModel = HomeModel()
     @StateObject var navigationCoordinator: NavigationCoordinator = NavigationCoordinator()
     @AppStorage("has_seen_suggested_users") private var hasSeenOnboardingSuggestions = false
@@ -186,7 +187,7 @@ struct ContentView: View {
                 }
                 
             case .home:
-                PostingTimelineView(damus_state: damus_state!, home: home, homeEvents: home.events, isSideBarOpened: $isSideBarOpened, active_sheet: $active_sheet, headerOffset: $headerOffset)
+                PostingTimelineView(damus_state: damus_state!, home: home, homeEvents: home.events, isSideBarOpened: $isSideBarOpened, active_sheet: $active_sheet, headerOffset: $headerOffset, timeline_source: $postingTimelineSource)
                 
             case .notifications:
                 NotificationsView(state: damus, notifications: home.notifications, subtitle: $menu_subtitle)

--- a/damus/Features/ContactCard/Views/FavoriteButtonView.swift
+++ b/damus/Features/ContactCard/Views/FavoriteButtonView.swift
@@ -15,18 +15,23 @@ struct FavoriteButtonView: View {
     var body: some View {
         Button(
             action: {
+                guard let keypair = damus_state.keypair.to_full() else { return}
+
                 damus_state.contactCards.toggleFavorite(
                     pubkey,
                     postbox: damus_state.nostrNetwork.postbox,
-                    keyPair: damus_state.keypair.to_full()
+                    keyPair: keypair
                 )
-            favorite.toggle()
+                favorite = damus_state.contactCards.isFavorite(pubkey)
         }) {
             Image(favorite ? "heart.fill" : "heart")
                 .foregroundColor(favorite ? DamusColors.purple : .primary)
                 .font(.system(size: 16, weight: .medium))
         }
         .buttonStyle(PlainButtonStyle())
+        .onReceive(handle_notify(.favoriteUpdated)) { _ in
+            favorite = damus_state.contactCards.isFavorite(pubkey)
+        }
     }
 }
 

--- a/damus/Features/Timeline/Models/HomeModel.swift
+++ b/damus/Features/Timeline/Models/HomeModel.swift
@@ -69,6 +69,7 @@ class HomeModel: ContactsDelegate, ObservableObject {
 
     var homeHandlerTask: Task<Void, Never>?
     var favoritesHandlerTask: Task<Void, Never>?
+    private var lastFavoritesCount: Int = 0
     var notificationsHandlerTask: Task<Void, Never>?
     var generalHandlerTask: Task<Void, Never>?
     var dmsHandlerTask: Task<Void, Never>?
@@ -738,7 +739,19 @@ class HomeModel: ContactsDelegate, ObservableObject {
         guard damus_state.settings.enable_favourites_feature else { return }
 
         let all_favorites = Array(damus_state.contactCards.favorites)
-        guard !all_favorites.isEmpty else { return }
+
+        // Always reset the subscription so we don't keep streaming stale authors.
+        favoritesHandlerTask?.cancel()
+        favoritesHandlerTask = nil
+
+        // If we have no favorites, clear the favorites timeline and stop here.
+        guard !all_favorites.isEmpty else {
+            Task { @MainActor in
+                favoriteEvents.reset()
+            }
+            lastFavoritesCount = 0
+            return
+        }
 
         var home_filter_kinds: [NostrKind] = [.text, .longform, .boost, .highlight]
         if !damus_state.settings.onlyzaps_mode {
@@ -749,9 +762,24 @@ class HomeModel: ContactsDelegate, ObservableObject {
         favorites_filter.authors = all_favorites
         favorites_filter.limit = 500
 
-        self.favoritesHandlerTask?.cancel()
-        self.favoritesHandlerTask = Task {
-            for await item in damus_state.nostrNetwork.reader.advancedStream(filters: [favorites_filter], streamMode: .ndbAndNetworkParallel(networkOptimization: .sinceOptimization)) {
+        // Reset current favorites timeline contents; they'll be re-filled from NDB + network.
+        Task { @MainActor in
+            favoriteEvents.reset()
+        }
+
+        // IMPORTANT:
+        // When favorites goes from 0 -> N, `sinceOptimization` often results in
+        // a `since` very close to "now", which prevents backfilling recent notes for those newly
+        // favorited authors. For the first favorites subscription, disable the optimization so we
+        // get immediate history.
+        let shouldBackfill = lastFavoritesCount == 0
+        let streamMode: NostrNetworkManager.StreamMode =
+            shouldBackfill
+            ? .ndbAndNetworkParallel(networkOptimization: nil)
+            : .ndbAndNetworkParallel(networkOptimization: .sinceOptimization)
+
+        favoritesHandlerTask = Task {
+            for await item in damus_state.nostrNetwork.reader.advancedStream(filters: [favorites_filter], streamMode: streamMode) {
                 switch item {
                 case .event(let lender):
                     await lender.justUseACopy({ await self.insert_favorite_event($0) })
@@ -760,6 +788,7 @@ class HomeModel: ContactsDelegate, ObservableObject {
                 }
             }
         }
+        lastFavoritesCount = all_favorites.count
     }
 
     @MainActor

--- a/damus/Features/Timeline/Views/PostingTimelineView.swift
+++ b/damus/Features/Timeline/Views/PostingTimelineView.swift
@@ -28,7 +28,7 @@ struct PostingTimelineView: View {
     @State var headerHeight: CGFloat = 0
     @Binding var headerOffset: CGFloat
     @SceneStorage("PostingTimelineView.filter_state") var filter_state : FilterState = .posts_and_replies
-    @State var timeline_source: TimelineSource = .follows
+    @Binding var timeline_source: TimelineSource
     
     @State private var damusTips: Any? = {
         if #available(iOS 18.0, *) {
@@ -187,7 +187,8 @@ struct PostingTimelineView_Previews: PreviewProvider {
             homeEvents: .init(),
             isSideBarOpened: .constant(false),
             active_sheet: .constant(nil),
-            headerOffset: .constant(0)
+            headerOffset: .constant(0),
+            timeline_source: .constant(.follows)
         )
     }
 }


### PR DESCRIPTION
## Summary

- Keep TimelineSource state in ContentView. 
- Unfavorites removes posts from timeline.
- Keep derived FavoritesButton state. 
- Backfill with older posts when adding first favorite.  
## Checklist

### Experimental Feature Checklist

> [!TIP]
> This Pull Request is an experimental feature for Damus Labs, and follows a fast-track review process.
> The overall requirements are lowered and the review process is not as strict as usual. However, the feature will only be available for Purple users who opt-in.

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md).
- [x] I have done some testing on the changes in this PR to ensure it is at least functional.
- [x] I made sure that this new feature is only available when the user opts-in from the Damus Labs screen, and does not affect the rest of the app when turned off. 
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review.
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin).
- [x] I have added an appropriate changelog entry to my commit in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc).
    - Example changelog entry: `Changelog-Added: Added experimental feature <X> to Damus Labs`

## Test report

**Device:** Simulator

**iOS:** 26.3


**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved favorites button state updates to sync immediately after toggling and listen for real-time changes.

* **Improvements**
  * Enhanced favorites timeline with smarter loading strategy that backfills history on initial load.
  * Refactored timeline source management for better application architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->