### PR TITLE
Reduce max age for stale temporary snapshots

### DIFF
--- a/damus/Core/Storage/DatabaseSnapshotManager.swift
+++ b/damus/Core/Storage/DatabaseSnapshotManager.swift
@@ -25,7 +25,7 @@ actor DatabaseSnapshotManager {
     private static let temporarySnapshotDirectoryPrefix = "snapshot_temp_"
 
     /// Maximum age for temporary snapshot directories before they are considered stale.
-    private static let staleTemporarySnapshotLifetime: TimeInterval = 60 * 60 * 24
+    private static let staleTemporarySnapshotLifetime: TimeInterval = 60 * 30    // 30 minutes
     
     /// Key for storing last snapshot timestamp in UserDefaults
     private static let lastSnapshotDateKey = "lastDatabaseSnapshotDate"


### PR DESCRIPTION
## Summary

The previous fix that implemented cleanup of temporary snapshots included a max age for stale temporary snapshots, which was originally set to 24h.

This improved the situation, but it still meant that the app could accumulate 24 old snapshots, which leads to a non-trivial storage amount.

This commit changes that to 30 minutes for better storage efficiency.

The previous fix was not published on the App Store yet, so no changelog entry is needed.

Closes: https://github.com/damus-io/damus/issues/3696 Changelog-None

## Checklist

<!-- 
CHOOSE YOUR CHECKLIST: 
- If this is an EXPERIMENTAL DAMUS LABS FEATURE, follow the "Experimental Feature Checklist" below and DELETE the "Standard PR Checklist"
- If this is a STANDARD PR, follow the "Standard PR Checklist" below and DELETE the "Experimental Feature Checklist"
-->


### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: trivial change
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** iPhone 16e simulator

**iOS:** 26

**Damus:** 96eb780f11e91aa1171999946a6e49eaaaa061dd

**Setup:** None

**Steps:**
1. Run automated tests
2. Smoke test app

**Results:**
- [x] PASS

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced temporary storage management with more aggressive cleanup of temporary database snapshots. The retention period has been significantly reduced, allowing stale snapshot directories to be removed more frequently. This improvement helps reduce unnecessary disk space usage and maintains better overall system efficiency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->