### PR TITLE
fix: add bottom padding to UserRelaysView to prevent last relay cutoff

### DIFF
--- a/damus/Features/Relays/Views/UserRelaysView.swift
+++ b/damus/Features/Relays/Views/UserRelaysView.swift
@@ -31,6 +31,7 @@ struct UserRelaysView: View {
             RelayView(state: state, relay: r, showActionButtons: .constant(true), recommended: true)
         }
         .listStyle(PlainListStyle())
+        .padding(.bottom, tabHeight)
         .navigationBarTitle(NSLocalizedString("Relays", comment: "Navigation bar title that shows the list of relays for a user."))
     }
 }


### PR DESCRIPTION
### screenshots

 | Before | After |                                                                                                                                                  
  |--------|-------|                                                                                                                                                
  | ![IMG_1831](https://github.com/user-attachments/assets/5f1d327a-283e-44ad-a517-a1777c62f9b5)| ![IMG_1832](https://github.com/user-attachments/assets/8cec822d-50ff-446f-84b2-83ddb8e5f276)|               

## Summary

The user relay list view (accessed via a profile's relay count, e.g. "16 relays") was missing `.padding(.bottom, tabHeight)`, causing the last relay entry to be cut off behind the main app tab bar when the list has many relays.

This follows the existing codebase pattern used by other list views (e.g. `ZapsView`, `BookmarksView`, `ReactionsView`, `DirectMessagesView`) to account for the custom tab bar overlay.

Closes: #3697
Changelog-Fixed: Fixed bottom relay being cut off in user relay list view

Signed-off-by: alltheseas

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: Single padding modifier on an existing view — no hot path impact
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 13 mini

**iOS:** 26

**Damus:** 4fe94b081c185259997b9cba3ae1116d11e458f3

**Setup:** None

**Steps:**
1. Go to a user's profile page
2. Tap on their relay count (e.g. "16 relays")
3. Scroll to the bottom of the relay list

**Results:**
- [x] PASS — All relays are fully visible and scrollable past the tab bar

## Other notes

One-line fix. The `tabHeight` global variable is dynamically measured from the actual rendered tab bar in `ContentView`, so this works across all devices and font size settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)