### PR TITLE
Fix SafeNdbTxn failure cleanup and reclaim stale LMDB readers on startup

### DIFF
--- a/nostrdb/NdbTxn.swift
+++ b/nostrdb/NdbTxn.swift
@@ -210,7 +210,22 @@ class SafeNdbTxn<T: ~Copyable> {
         print("txn: open  gen\(generation) '\(name)' \(txn_count)")
         #endif
         let placeholderTxn = PlaceholderNdbTxn(txn: txn)
-        guard let val = valueGetter(placeholderTxn) else { return nil }
+        guard let val = valueGetter(placeholderTxn) else {
+            if inherited {
+                if let refCount = Thread.current.threadDictionary["ndb_txn_ref_count"] as? Int {
+                    Thread.current.threadDictionary["ndb_txn_ref_count"] = max(0, refCount - 1)
+                }
+                return nil
+            }
+
+            _ = try? ndb.withNdb({
+                ndb_end_query(&placeholderTxn.txn)
+            }, maxWaitTimeout: .milliseconds(200))
+            Thread.current.threadDictionary.removeObject(forKey: "ndb_txn")
+            Thread.current.threadDictionary.removeObject(forKey: "ndb_txn_ref_count")
+            Thread.current.threadDictionary.removeObject(forKey: "txn_generation")
+            return nil
+        }
         return SafeNdbTxn<T>(ndb: ndb, txn: txn, val: val, generation: generation, inherited: inherited, name: name)
     }
 

--- a/nostrdb/Test/NdbTests.swift
+++ b/nostrdb/Test/NdbTests.swift
@@ -22,6 +22,36 @@ func test_ndb_dir() -> String? {
 final class NdbTests: XCTestCase {
     var db_dir: String = ""
 
+    /// Saves and clears thread-local transaction state for deterministic transaction tests, then returns a restoration closure.
+    @discardableResult
+    private func resetThreadLocalTransactionState() -> () -> Void {
+        let threadDictionary = Thread.current.threadDictionary
+        let originalTxn = threadDictionary["ndb_txn"]
+        let originalRefCount = threadDictionary["ndb_txn_ref_count"]
+        let originalGeneration = threadDictionary["txn_generation"]
+        threadDictionary.removeObject(forKey: "ndb_txn")
+        threadDictionary.removeObject(forKey: "ndb_txn_ref_count")
+        threadDictionary.removeObject(forKey: "txn_generation")
+
+        return {
+            if let originalTxn {
+                threadDictionary["ndb_txn"] = originalTxn
+            } else {
+                threadDictionary.removeObject(forKey: "ndb_txn")
+            }
+            if let originalRefCount {
+                threadDictionary["ndb_txn_ref_count"] = originalRefCount
+            } else {
+                threadDictionary.removeObject(forKey: "ndb_txn_ref_count")
+            }
+            if let originalGeneration {
+                threadDictionary["txn_generation"] = originalGeneration
+            } else {
+                threadDictionary.removeObject(forKey: "txn_generation")
+            }
+        }
+    }
+
     override func setUpWithError() throws {
         guard let db = test_ndb_dir() else {
             XCTFail("Could not create temp directory")
@@ -182,6 +212,46 @@ final class NdbTests: XCTestCase {
 
         let ndb_txn = Thread.current.threadDictionary.value(forKey: "ndb_txn")
         XCTAssertNil(ndb_txn)
+    }
+    
+    /// Verifies that a failed top-level SafeNdbTxn creation fully cleans up thread-local transaction state.
+    func testSafeNdbTxnFailure_cleansUpTopLevelThreadLocalTransactionState() throws {
+        let restoreThreadLocalTransactionState = resetThreadLocalTransactionState()
+        defer { restoreThreadLocalTransactionState() }
+
+        let ndb = try XCTUnwrap(Ndb(path: db_dir))
+
+        let txn = SafeNdbTxn<Int>.new(on: ndb, with: { _ in nil }, name: "failing_top_level_txn")
+
+        XCTAssertNil(txn)
+        XCTAssertNil(Thread.current.threadDictionary["ndb_txn"], "Top-level SafeNdbTxn failure should clear the thread-local transaction")
+        XCTAssertNil(Thread.current.threadDictionary["ndb_txn_ref_count"], "Top-level SafeNdbTxn failure should clear the thread-local reference count")
+        XCTAssertNil(Thread.current.threadDictionary["txn_generation"], "Top-level SafeNdbTxn failure should clear the thread-local generation")
+    }
+    
+    /// Verifies that a failed inherited SafeNdbTxn creation decrements the ref-count without clearing the parent transaction.
+    func testSafeNdbTxnFailure_onInheritedTransactionRestoresParentThreadLocalState() throws {
+        let restoreThreadLocalTransactionState = resetThreadLocalTransactionState()
+        defer { restoreThreadLocalTransactionState() }
+
+        let ndb = try XCTUnwrap(Ndb(path: db_dir))
+
+        let parent = try XCTUnwrap(SafeNdbTxn<Int>.new(on: ndb, with: { _ in 1 }, name: "parent_txn"))
+        let parentThreadTxn = Thread.current.threadDictionary["ndb_txn"] as? ndb_txn
+        XCTAssertNotNil(parentThreadTxn)
+        XCTAssertEqual(Thread.current.threadDictionary["ndb_txn_ref_count"] as? Int, 1)
+
+        let child = SafeNdbTxn<Int>.new(on: ndb, with: { _ in nil }, name: "failing_child_txn")
+
+        XCTAssertNil(child)
+        let restoredThreadTxn = Thread.current.threadDictionary["ndb_txn"] as? ndb_txn
+        XCTAssertNotNil(restoredThreadTxn, "Inherited SafeNdbTxn failure should keep the parent transaction installed")
+        XCTAssertEqual(restoredThreadTxn?.lmdb, parentThreadTxn?.lmdb)
+        XCTAssertEqual(restoredThreadTxn?.mdb_txn, parentThreadTxn?.mdb_txn)
+        XCTAssertEqual(Thread.current.threadDictionary["ndb_txn_ref_count"] as? Int, 1, "Inherited SafeNdbTxn failure should restore the parent ref-count")
+        XCTAssertEqual(Thread.current.threadDictionary["txn_generation"] as? Int, ndb.generation)
+
+        _ = parent
     }
 
     func test_decode_perf() throws {

--- a/nostrdb/src/nostrdb.c
+++ b/nostrdb/src/nostrdb.c
@@ -165,6 +165,32 @@ struct ndb_lmdb {
 	MDB_dbi dbs[NDB_DBS];
 };
 
+/**
+ * Clears stale LMDB reader slots after opening the environment.
+ *
+ * This protects startup on platforms where reader slots are not reclaimed
+ * automatically after process termination.
+ *
+ * @param[in] env The LMDB environment to inspect.
+ * @return 1 when the check succeeds, 0 when LMDB reports an error.
+ */
+static int ndb_lmdb_reader_check(MDB_env *env)
+{
+	int rc;
+	int dead = 0;
+
+	rc = mdb_reader_check(env, &dead);
+	if (rc != MDB_SUCCESS) {
+		fprintf(stderr, "mdb_reader_check failed: %s\n", mdb_strerror(rc));
+		return 0;
+	}
+
+	if (dead > 0)
+		fprintf(stderr, "mdb_reader_check cleared %d stale reader(s)\n", dead);
+
+	return 1;
+}
+
 struct ndb_writer {
 	struct ndb_lmdb *lmdb;
 	struct ndb_monitor *monitor;
@@ -5846,6 +5872,12 @@ static int ndb_init_lmdb(const char *filename, struct ndb_lmdb *lmdb, size_t map
 
 	if ((rc = mdb_env_open(lmdb->env, filename, 0, 0664))) {
 		fprintf(stderr, "mdb_env_open failed, error %d\n", rc);
+		return 0;
+	}
+
+	if (!ndb_lmdb_reader_check(lmdb->env)) {
+		mdb_env_close(lmdb->env);
+		lmdb->env = NULL;
 		return 0;
 	}
 


### PR DESCRIPTION
## Summary

This PR:
1. fixes `SafeNdbTxn` cleanup when a value getter returns `nil`, to avoid reader transaction leakage.
2. adds a startup LMDB reader check to clear stale reader slots, as recommended by `lmdb.h` documentation.

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: This change only adjusts transaction cleanup/error-handling paths and performs a one-time LMDB reader check during environment initialization, so dedicated profiling was not necessary.
- [x] I have opened or referred to an existing github issue related to this change: https://github.com/damus-io/damus/issues/3738
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)
    - Not needed, this is a tentative fix without definitive proof that it actually solves the core issue.

## Test report

**Device:** Simulator / local test environment

**iOS:** 26.4

**Damus:** b91bedcc16536456703e2046c4a708f693c88df7

**Steps:**
1. Run automated tests (old and new)
2. Run new automated tests against previous implementation (before the txn leakage fix), and ensure those fail (meaning they do cover this edge case)

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: _[Please provide details of the partial pass]_




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure thread-local transaction state and reference counts are properly cleaned/restored when transaction creation fails.
  * On startup, detect and clear stale LMDB reader slots and abort DB initialization if the reader check fails.

* **Tests**
  * Added tests covering transaction-failure cleanup for both top-level and inherited transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->