### PR TITLE
stories: viewer-only MVP (kind:20 + #T=story + NIP-40)

### DIFF
--- a/damus/Core/Nostr/NostrFilter.swift
+++ b/damus/Core/Nostr/NostrFilter.swift
@@ -19,6 +19,7 @@ struct NostrFilter: Codable, Equatable {
     var hashtag: [String]?
     var parameter: [String]?
     var quotes: [NoteId]?
+    var tag_T: [String]?
 
     private enum CodingKeys : String, CodingKey {
         case ids
@@ -28,13 +29,14 @@ struct NostrFilter: Codable, Equatable {
         case hashtag = "#t"
         case parameter = "#d"
         case quotes = "#q"
+        case tag_T = "#T"
         case since
         case until
         case authors
         case limit
     }
-    
-    init(ids: [NoteId]? = nil, kinds: [NostrKind]? = nil, referenced_ids: [NoteId]? = nil, pubkeys: [Pubkey]? = nil, since: UInt32? = nil, until: UInt32? = nil, limit: UInt32? = nil, authors: [Pubkey]? = nil, hashtag: [String]? = nil, quotes: [NoteId]? = nil) {
+
+    init(ids: [NoteId]? = nil, kinds: [NostrKind]? = nil, referenced_ids: [NoteId]? = nil, pubkeys: [Pubkey]? = nil, since: UInt32? = nil, until: UInt32? = nil, limit: UInt32? = nil, authors: [Pubkey]? = nil, hashtag: [String]? = nil, quotes: [NoteId]? = nil, tag_T: [String]? = nil) {
         self.ids = ids
         self.kinds = kinds
         self.referenced_ids = referenced_ids
@@ -45,6 +47,7 @@ struct NostrFilter: Codable, Equatable {
         self.authors = authors
         self.hashtag = hashtag
         self.quotes = quotes
+        self.tag_T = tag_T
     }
     
     public static func copy(from: NostrFilter) -> NostrFilter {

--- a/damus/Core/Nostr/NostrKind.swift
+++ b/damus/Core/Nostr/NostrKind.swift
@@ -17,6 +17,7 @@ enum NostrKind: UInt32, Codable {
     case delete = 5
     case boost = 6
     case like = 7
+    case picture = 20
     case chat = 42
     case live_chat = 1311
     case mute_list = 10000

--- a/damus/Features/Events/Models/LoadableNostrEventView.swift
+++ b/damus/Features/Events/Models/LoadableNostrEventView.swift
@@ -78,7 +78,7 @@ class LoadableNostrEventViewModel: ObservableObject {
             case .zap, .zap_request:
                 guard let zap = await get_zap(from: ev, state: damus_state) else { return .not_found }
                 return .loaded(route: Route.Zaps(target: zap.target))
-            case .contacts, .metadata, .delete, .boost, .chat, .mute_list, .list_deprecated, .draft, .nwc_request, .nwc_response, .http_auth, .status, .relay_list, .follow_list, .interest_list, .contact_card, .live, .live_chat:
+            case .contacts, .metadata, .delete, .boost, .chat, .mute_list, .list_deprecated, .draft, .nwc_request, .nwc_response, .http_auth, .status, .relay_list, .follow_list, .interest_list, .contact_card, .live, .live_chat, .picture:
                 return .unknown_or_unsupported_kind
             }
         case .naddr(let naddr):

--- a/damus/Features/Stories/Models/StoriesModel.swift
+++ b/damus/Features/Stories/Models/StoriesModel.swift
@@ -1,0 +1,236 @@
+//
+//  StoriesModel.swift
+//  damus
+//
+//  Created by William Casarin on 2026-05-11.
+//
+
+import Foundation
+
+struct StorySlide: Identifiable, Equatable {
+    let event: NostrEvent
+    let imeta: ImageMetadata
+    let expiresAt: Date?
+
+    var id: NoteId { event.id }
+    var createdAt: UInt32 { event.created_at }
+
+    static func == (lhs: StorySlide, rhs: StorySlide) -> Bool {
+        lhs.event.id == rhs.event.id
+    }
+}
+
+struct Story: Identifiable, Equatable {
+    let author: Pubkey
+    var slides: [StorySlide]
+
+    var id: Pubkey { author }
+    var latestCreatedAt: UInt32 { slides.map(\.createdAt).max() ?? 0 }
+}
+
+@MainActor
+class StoriesModel: ObservableObject {
+    @Published private(set) var tray: [Story] = []
+
+    let damus: DamusState
+    private var listener: Task<Void, Never>? = nil
+    private var stories: [Pubkey: Story] = [:]
+
+    private static let WINDOW: TimeInterval = 24 * 60 * 60
+
+    init(damus: DamusState) {
+        self.damus = damus
+    }
+
+    func subscribe() {
+        listener?.cancel()
+        listener = Task { [weak self] in
+            await self?.runSubscription()
+        }
+    }
+
+    func unsubscribe() {
+        listener?.cancel()
+        listener = nil
+    }
+
+    private func runSubscription() async {
+        var authors = damus.contacts.get_friend_list()
+        authors.insert(damus.pubkey)
+        let since = UInt32(Date().timeIntervalSince1970 - Self.WINDOW)
+        let nostrFilter = NostrFilter(
+            kinds: [.picture],
+            since: since,
+            authors: Array(authors),
+            tag_T: ["story"]
+        )
+        do {
+            let ndbFilter = try NdbFilter(from: nostrFilter)
+            for await item in try damus.ndb.subscribe(filters: [ndbFilter]) {
+                switch item {
+                case .eose:
+                    continue
+                case .event(let noteKey):
+                    let lender = NdbNoteLender(ndb: damus.ndb, noteKey: noteKey)
+                    if let ev = lender.justGetACopy() {
+                        ingest(ev)
+                    }
+                }
+            }
+        } catch {
+            print("StoriesModel: local subscription failed: \(error)")
+        }
+    }
+
+    private func ingest(_ ev: NostrEvent) {
+        guard ev.known_kind == .picture else { return }
+        guard hasStoryTag(ev) else { return }
+        guard let imeta = event_image_metadata(ev: ev).first else { return }
+
+        let now = Date()
+        let expiresAt = parseExpiration(ev)
+        if let expiresAt, expiresAt <= now { return }
+        let cutoff = UInt32(now.timeIntervalSince1970 - Self.WINDOW)
+        if ev.created_at < cutoff { return }
+
+        let slide = StorySlide(event: ev, imeta: imeta, expiresAt: expiresAt)
+        let author = ev.pubkey
+
+        var story = stories[author] ?? Story(author: author, slides: [])
+        if story.slides.contains(where: { $0.id == slide.id }) { return }
+        story.slides.append(slide)
+        story.slides.sort { $0.createdAt < $1.createdAt }
+        stories[author] = story
+
+        rebuildTray()
+    }
+
+    private func rebuildTray() {
+        let now = Date()
+        let cutoff = UInt32(now.timeIntervalSince1970 - Self.WINDOW)
+        for (pk, var story) in stories {
+            story.slides.removeAll { slide in
+                if let exp = slide.expiresAt, exp <= now { return true }
+                return slide.createdAt < cutoff
+            }
+            if story.slides.isEmpty {
+                stories.removeValue(forKey: pk)
+            } else {
+                stories[pk] = story
+            }
+        }
+        let me = damus.pubkey
+        tray = stories.values.sorted { a, b in
+            if a.author == me { return true }
+            if b.author == me { return false }
+            return a.latestCreatedAt > b.latestCreatedAt
+        }
+    }
+}
+
+@MainActor
+class StoryViewerModel: ObservableObject {
+    @Published private(set) var authorIndex: Int
+    @Published private(set) var slideIndex: Int = 0
+    @Published private(set) var progress: Double = 0
+    @Published var paused: Bool = false
+
+    let stories: [Story]
+    let onDismiss: () -> Void
+
+    static let SLIDE_DURATION: TimeInterval = 5.0
+
+    init(stories: [Story], startAuthorIndex: Int, onDismiss: @escaping () -> Void) {
+        self.stories = stories
+        self.authorIndex = startAuthorIndex
+        self.onDismiss = onDismiss
+    }
+
+    var currentStory: Story? {
+        guard stories.indices.contains(authorIndex) else { return nil }
+        return stories[authorIndex]
+    }
+
+    var currentSlide: StorySlide? {
+        guard let s = currentStory, s.slides.indices.contains(slideIndex) else { return nil }
+        return s.slides[slideIndex]
+    }
+
+    func fillFraction(at i: Int) -> Double {
+        if i < slideIndex { return 1.0 }
+        if i == slideIndex { return progress }
+        return 0
+    }
+
+    /// Drive one slide's progress to completion, then advance.
+    /// The view owns the Task via `.task(id:)`; cancellation happens when slide/author changes.
+    func runCurrentSlide() async {
+        progress = 0
+        let steps = 60
+        let stepDuration = Self.SLIDE_DURATION / Double(steps)
+        for _ in 0..<steps {
+            if Task.isCancelled { return }
+            try? await Task.sleep(for: .seconds(stepDuration))
+            if Task.isCancelled { return }
+            if !paused {
+                progress = min(1.0, progress + 1.0 / Double(steps))
+            }
+        }
+        if Task.isCancelled { return }
+        nextSlide()
+    }
+
+    func previousSlide() {
+        if slideIndex > 0 {
+            slideIndex -= 1
+        } else {
+            previousAuthor()
+        }
+    }
+
+    func nextSlide() {
+        guard let count = currentStory?.slides.count else { return }
+        if slideIndex + 1 < count {
+            slideIndex += 1
+        } else {
+            nextAuthor()
+        }
+    }
+
+    func previousAuthor() {
+        if authorIndex > 0 {
+            authorIndex -= 1
+            slideIndex = 0
+        } else {
+            slideIndex = 0
+        }
+    }
+
+    func nextAuthor() {
+        if authorIndex + 1 < stories.count {
+            authorIndex += 1
+            slideIndex = 0
+        } else {
+            onDismiss()
+        }
+    }
+}
+
+private func hasStoryTag(_ ev: NostrEvent) -> Bool {
+    for tag in ev.tags {
+        guard tag.count >= 2 else { continue }
+        if tag[0].matches_char("T") && tag[1].matches_str("story") {
+            return true
+        }
+    }
+    return false
+}
+
+private func parseExpiration(_ ev: NostrEvent) -> Date? {
+    guard let tag = ev.tags.first(where: { t in t.count >= 2 && t[0].matches_str("expiration") }),
+          tag.count == 2,
+          let expires = UInt32(tag[1].string()) else {
+        return nil
+    }
+    return Date(timeIntervalSince1970: TimeInterval(expires))
+}

--- a/damus/Features/Stories/Models/StoriesModel.swift
+++ b/damus/Features/Stories/Models/StoriesModel.swift
@@ -40,6 +40,11 @@ class StoriesModel: ObservableObject {
 
     init(damus: DamusState) {
         self.damus = damus
+        subscribe()
+    }
+
+    deinit {
+        listener?.cancel()
     }
 
     func subscribe() {

--- a/damus/Features/Stories/Views/StoryTrayView.swift
+++ b/damus/Features/Stories/Views/StoryTrayView.swift
@@ -1,0 +1,102 @@
+//
+//  StoryTrayView.swift
+//  damus
+//
+//  Created by William Casarin on 2026-05-11.
+//
+
+import SwiftUI
+
+struct StoryTrayContainerView: View {
+    let damus_state: DamusState
+    @StateObject private var stories: StoriesModel
+    @State private var selectedAuthor: Pubkey? = nil
+
+    init(damus_state: DamusState) {
+        self.damus_state = damus_state
+        self._stories = StateObject(wrappedValue: StoriesModel(damus: damus_state))
+    }
+
+    var body: some View {
+        Group {
+            if !stories.tray.isEmpty {
+                StoryTrayView(damus_state: damus_state, tray: stories.tray) { pk in
+                    selectedAuthor = pk
+                }
+            }
+        }
+        .onAppear { stories.subscribe() }
+        .onDisappear { stories.unsubscribe() }
+        .fullScreenCover(item: Binding(
+            get: { selectedAuthor.map { AuthorPick(pubkey: $0) } },
+            set: { selectedAuthor = $0?.pubkey }
+        )) { pick in
+            if let startIndex = stories.tray.firstIndex(where: { $0.author == pick.pubkey }) {
+                StoryViewerView(
+                    damus_state: damus_state,
+                    stories: stories.tray,
+                    startAuthorIndex: startIndex,
+                    onDismiss: { selectedAuthor = nil }
+                )
+            }
+        }
+    }
+}
+
+private struct AuthorPick: Identifiable {
+    let pubkey: Pubkey
+    var id: Pubkey { pubkey }
+}
+
+struct StoryTrayView: View {
+    let damus_state: DamusState
+    let tray: [Story]
+    let onTap: (Pubkey) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 14) {
+                ForEach(tray) { story in
+                    StoryTrayItem(damus_state: damus_state, story: story)
+                        .onTapGesture { onTap(story.author) }
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+        }
+    }
+}
+
+private struct StoryTrayItem: View {
+    let damus_state: DamusState
+    let story: Story
+
+    private let avatarSize: CGFloat = 60
+
+    var body: some View {
+        VStack(spacing: 4) {
+            ZStack {
+                Circle()
+                    .strokeBorder(
+                        LinearGradient(
+                            colors: [DamusColors.purple, .pink, .orange],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        lineWidth: 2.5
+                    )
+                    .frame(width: avatarSize + 8, height: avatarSize + 8)
+
+                ProfilePicView(
+                    pubkey: story.author,
+                    size: avatarSize,
+                    highlight: .none,
+                    profiles: damus_state.profiles,
+                    disable_animation: damus_state.settings.disable_animation,
+                    damusState: damus_state
+                )
+            }
+        }
+        .frame(width: avatarSize + 14)
+    }
+}

--- a/damus/Features/Stories/Views/StoryViewerView.swift
+++ b/damus/Features/Stories/Views/StoryViewerView.swift
@@ -1,0 +1,121 @@
+//
+//  StoryViewerView.swift
+//  damus
+//
+//  Created by William Casarin on 2026-05-11.
+//
+
+import SwiftUI
+import Kingfisher
+
+struct StoryViewerView: View {
+    let damus_state: DamusState
+    @StateObject private var model: StoryViewerModel
+
+    init(damus_state: DamusState, stories: [Story], startAuthorIndex: Int, onDismiss: @escaping () -> Void) {
+        self.damus_state = damus_state
+        self._model = StateObject(wrappedValue: StoryViewerModel(stories: stories, startAuthorIndex: startAuthorIndex, onDismiss: onDismiss))
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            if let story = model.currentStory, let slide = model.currentSlide {
+                VStack(spacing: 0) {
+                    progressBars(slides: story.slides)
+                        .frame(height: 2.5)
+                        .padding(.horizontal, 8)
+                        .padding(.top, 8)
+
+                    header(author: story.author)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+
+                    Spacer()
+                    slideImage(slide: slide)
+                    Spacer()
+                }
+            }
+
+            HStack(spacing: 0) {
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture { model.previousSlide() }
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture { model.nextSlide() }
+            }
+        }
+        .gesture(
+            DragGesture()
+                .onEnded { val in
+                    let dy = val.translation.height
+                    let dx = val.translation.width
+                    if dy > 100 {
+                        model.onDismiss()
+                    } else if dx > 80 {
+                        model.previousAuthor()
+                    } else if dx < -80 {
+                        model.nextAuthor()
+                    }
+                }
+        )
+        .task(id: "\(model.authorIndex)-\(model.slideIndex)") {
+            await model.runCurrentSlide()
+        }
+        .statusBarHidden(true)
+    }
+
+    @ViewBuilder
+    private func progressBars(slides: [StorySlide]) -> some View {
+        HStack(spacing: 4) {
+            ForEach(slides.indices, id: \.self) { i in
+                GeometryReader { geo in
+                    ZStack(alignment: .leading) {
+                        Capsule().fill(Color.white.opacity(0.3))
+                        Capsule()
+                            .fill(Color.white)
+                            .frame(width: geo.size.width * model.fillFraction(at: i))
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func header(author: Pubkey) -> some View {
+        HStack(spacing: 10) {
+            ProfilePicView(
+                pubkey: author,
+                size: 32,
+                highlight: .none,
+                profiles: damus_state.profiles,
+                disable_animation: damus_state.settings.disable_animation,
+                damusState: damus_state
+            )
+
+            ProfileName(pubkey: author, damus: damus_state, show_nip5_domain: false)
+                .foregroundColor(.white)
+
+            Spacer()
+
+            Button(action: model.onDismiss) {
+                Image(systemName: "xmark")
+                    .foregroundColor(.white)
+                    .font(.title3)
+                    .padding(6)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func slideImage(slide: StorySlide) -> some View {
+        KFAnimatedImage(slide.imeta.url)
+            .imageContext(.note, disable_animation: damus_state.settings.disable_animation)
+            .configure { view in
+                view.framePreloadCount = 3
+            }
+            .scaledToFit()
+    }
+}

--- a/damus/Features/Timeline/Models/HomeModel.swift
+++ b/damus/Features/Timeline/Models/HomeModel.swift
@@ -294,6 +294,8 @@ class HomeModel: ContactsDelegate, ObservableObject {
             break   // Don't care for now
         case .live, .live_chat:
             break
+        case .picture:
+            break   // Story events are consumed by StoriesModel via local nostrdb subscription.
         }
     }
 

--- a/damus/Features/Timeline/Models/HomeModel.swift
+++ b/damus/Features/Timeline/Models/HomeModel.swift
@@ -74,6 +74,7 @@ class HomeModel: ContactsDelegate, ObservableObject {
     var dmsHandlerTask: Task<Void, Never>?
     var ndbOnlyHandlerTask: Task<Void, Never>?
     var nwcHandlerTask: Task<Void, Never>?
+    var storiesHandlerTask: Task<Void, Never>?
     
     @Published var loading: Bool = true
 
@@ -237,6 +238,7 @@ class HomeModel: ContactsDelegate, ObservableObject {
             }
 
             self.subscribe_to_home_filters()
+            self.subscribe_to_stories()
         }
     }
 
@@ -583,6 +585,7 @@ class HomeModel: ContactsDelegate, ObservableObject {
         //print_filters(relay_id: relay_id, filters: [home_filters, contacts_filters, notifications_filters, dms_filters])
 
         subscribe_to_home_filters()
+        subscribe_to_stories()
 
         self.notificationsHandlerTask?.cancel()
         self.notificationsHandlerTask = Task {
@@ -733,6 +736,28 @@ class HomeModel: ContactsDelegate, ObservableObject {
                 case .networkEose:
                     break
                 }
+            }
+        }
+    }
+
+    /// Remote subscription that pulls story events (kind:20, #T=story) into nostrdb.
+    /// `StoriesModel` then reacts via a local nostrdb subscription.
+    func subscribe_to_stories() {
+        var authors = damus_state.contacts.get_friend_list()
+        authors.insert(damus_state.pubkey)
+        let since = UInt32(Date().timeIntervalSince1970 - 24 * 60 * 60)
+        let stories_filter = NostrFilter(
+            kinds: [.picture],
+            since: since,
+            authors: Array(authors),
+            tag_T: ["story"]
+        )
+        let chunked = stories_filter.chunked(on: .authors, into: MAX_CONTACTS_ON_FILTER)
+
+        self.storiesHandlerTask?.cancel()
+        self.storiesHandlerTask = Task {
+            for await _ in damus_state.nostrNetwork.reader.streamIndefinitely(filters: chunked) {
+                // No-op: events ingest into nostrdb upstream; StoriesModel reacts via its local sub.
             }
         }
     }

--- a/damus/Features/Timeline/Views/PostingTimelineView.swift
+++ b/damus/Features/Timeline/Views/PostingTimelineView.swift
@@ -66,9 +66,7 @@ struct PostingTimelineView: View {
     
     func contentTimelineView(filter: (@escaping (NostrEvent) -> Bool)) -> some View {
         let eventsSource = timeline_source == .favorites ? home.favoriteEvents : home.events
-        return TimelineView(events: eventsSource, loading: self.loading, headerHeight: $headerHeight, headerOffset: $headerOffset, damus: damus_state, show_friend_icon: false, filter: filter, viewId: timeline_source) {
-            StoryTrayContainerView(damus_state: damus_state)
-        }
+        return TimelineView<AnyView>(events: eventsSource, loading: self.loading, headerHeight: $headerHeight, headerOffset: $headerOffset, damus: damus_state, show_friend_icon: false, filter: filter, viewId: timeline_source)
     }
     
     func HeaderView() -> some View {
@@ -123,6 +121,7 @@ struct PostingTimelineView: View {
                     .tipViewStyle(TrustedNetworkButtonTipViewStyle())
                     .padding(.horizontal)
             }
+            StoryTrayContainerView(damus_state: damus_state)
             VStack(spacing: 0) {
                 CustomPicker(tabs: [
                     (NSLocalizedString("Notes", comment: "Label for filter for seeing only notes (instead of notes and replies)."), FilterState.posts),

--- a/damus/Features/Timeline/Views/PostingTimelineView.swift
+++ b/damus/Features/Timeline/Views/PostingTimelineView.swift
@@ -66,7 +66,9 @@ struct PostingTimelineView: View {
     
     func contentTimelineView(filter: (@escaping (NostrEvent) -> Bool)) -> some View {
         let eventsSource = timeline_source == .favorites ? home.favoriteEvents : home.events
-        return TimelineView<AnyView>(events: eventsSource, loading: self.loading, headerHeight: $headerHeight, headerOffset: $headerOffset, damus: damus_state, show_friend_icon: false, filter: filter, viewId: timeline_source)
+        return TimelineView(events: eventsSource, loading: self.loading, headerHeight: $headerHeight, headerOffset: $headerOffset, damus: damus_state, show_friend_icon: false, filter: filter, viewId: timeline_source) {
+            StoryTrayContainerView(damus_state: damus_state)
+        }
     }
     
     func HeaderView() -> some View {

--- a/devtools/nostril-story.sh
+++ b/devtools/nostril-story.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# nostril-story.sh — emit test "story" events (kind:20, #T=story, NIP-40) to stdout.
+#
+# Examples:
+#   # Emit 3 picsum slides from a fresh ephemeral key, 24h expiration.
+#   # Prints the pubkey on stderr so you can follow it in damus.
+#   devtools/nostril-story.sh | nostcat wss://relay.damus.io
+#
+#   # Custom key (same "author" persists across runs), custom images, 1h expiration
+#   devtools/nostril-story.sh -s <hex_seckey> -d 1 \
+#     -i https://example.com/a.jpg -i https://example.com/b.jpg \
+#     | nostcat wss://relay.damus.io
+#
+# Requires: nostril, jq.
+
+set -euo pipefail
+
+rand_hex() {
+    # $1 = number of bytes. Outputs 2*N hex chars, no newline.
+    od -An -tx1 -N "$1" /dev/urandom | tr -d ' \n'
+}
+
+SEC=${SEC:=""}
+EXPIRY_HOURS=24
+IMAGES=()
+
+usage() {
+    sed -n '3,15p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1
+}
+
+while getopts ":s:d:i:h" opt; do
+    case "$opt" in
+        s) SEC="$OPTARG" ;;
+        d) EXPIRY_HOURS="$OPTARG" ;;
+        i) IMAGES+=("$OPTARG") ;;
+        h|*) usage ;;
+    esac
+done
+
+# Default slide set: 3 picsum images with random seeds so each run is unique.
+if [ "${#IMAGES[@]}" -eq 0 ]; then
+    for n in 1 2 3; do
+        IMAGES+=("https://picsum.photos/seed/$(rand_hex 4)/800/1200.jpg")
+    done
+fi
+
+if [ -z "$SEC" ]; then
+    SEC=$(rand_hex 32)
+    echo "# generated seckey: $SEC" >&2
+fi
+
+PUBKEY=$(nostril --sec "$SEC" --kind 0 --content '{}' 2>/dev/null | jq -r '.pubkey')
+echo "# author pubkey: $PUBKEY" >&2
+echo "# follow this pubkey in damus to see the stories in your tray" >&2
+
+now=$(date +%s)
+expiry=$(( now + EXPIRY_HOURS * 3600 ))
+
+# Stagger created_at so slides have a stable order within an author.
+i=0
+for url in "${IMAGES[@]}"; do
+    ts=$(( now - (${#IMAGES[@]} - i - 1) * 10 ))
+    # NOTE: nostril's --tagn is variadic-greedy, so all flags must come BEFORE
+    # any --tagn invocation.
+    nostril \
+        --sec "$SEC" \
+        --kind 20 \
+        --created-at "$ts" \
+        --content "test story slide" \
+        --envelope \
+        --tagn 2 T story \
+        --tagn 2 expiration "$expiry" \
+        --tagn 4 imeta "url $url" "m image/jpeg" "dim 800x1200"
+    i=$((i + 1))
+done
+
+echo "# done. emitted ${#IMAGES[@]} slide(s) (expiry: $(date -d @$expiry 2>/dev/null || date -r $expiry))" >&2

--- a/nostrdb/NdbFilter.swift
+++ b/nostrdb/NdbFilter.swift
@@ -286,6 +286,24 @@ class NdbFilter {
             ndb_filter_end_field(filterPointer)
         }
 
+        // Handle `tag_T` (uppercase single-letter `T` tag; case-distinct from `t`)
+        if let tag_T = nostrFilter.tag_T {
+            guard ndb_filter_start_tag_field(filterPointer, CChar(UnicodeScalar("T").value)) == 1 else {
+                ndb_filter_destroy(filterPointer)
+                filterPointer.deallocate()
+                throw NdbFilterConversionError.failedToStartField
+            }
+
+            for value in tag_T {
+                if ndb_filter_add_str_element(filterPointer, value.cString(using: .utf8)) != 1 {
+                    ndb_filter_destroy(filterPointer)
+                    filterPointer.deallocate()
+                    throw NdbFilterConversionError.failedToAddElement
+                }
+            }
+            ndb_filter_end_field(filterPointer)
+        }
+
         // Handle `quotes`
         if let quotes = nostrFilter.quotes {
             guard ndb_filter_start_tag_field(filterPointer, CChar(UnicodeScalar("q").value)) == 1 else {


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/4dcba31a-f849-4ddc-b72d-fb6f5ea68a23



First slice of the Stories epic ([IOS-2380](https://linear.app/damus/issue/IOS-2380) / #3745). Ships a viewer-only surface so we can iterate on the read experience before tackling authoring.

- Horizontal **Stories tray** above the home timeline, sourced from followed authors' `kind:20` (NIP-68 picture) events tagged `["T","story"]` within a 24h window.
- **NIP-40 expiration** honored — events past their expiration are dropped from the tray.
- Full-screen **viewer** with per-slide progress bars, auto-advance (5s), tap-to-advance, swipe-between-authors, and drag-down-to-dismiss.
- **Architecture split**: `HomeModel.subscribe_to_stories()` drives the remote REQ (events flow into nostrdb via the connection layer's ingestion). `StoriesModel` is a pure-local consumer subscribed to nostrdb, grouping events per author and rebuilding the tray.

### Plumbing changes
- `NostrFilter` gains a `tag_T: [String]?` field → JSON key `"#T"`. Uppercase is intentional: case-sensitive single-letter tag indexing keeps stories out of the `#t` hashtag namespace.
- `NdbFilter` learns to convert `tag_T` into a `#T` tag field via `ndb_filter_start_tag_field`.
- `NostrKind` adds `case picture = 20`.

### v1 scope explicitly out
- Authoring (deferred to v2 — IOS-2387).
- Video / `kind:22` (deferred to v2 — IOS-2385).
- Seen-state ([IOS-2388](https://linear.app/damus/issue/IOS-2388) — blocked on upstream nostrdb landing `ndb_note_meta` flags).

## Test plan

- [ ] Build on iPhone 16e simulator (`just build`).
- [ ] With a logged-in account that follows users who post `kind:20` + `["T","story"]` events, verify the tray appears above the home timeline.
- [ ] Verify the tray hides entirely when no followed user has a live story in the last 24h.
- [ ] Tap an avatar → full-screen viewer opens for that author.
- [ ] Verify auto-advance through slides (~5s each); after the last slide of the last author, viewer dismisses.
- [ ] Verify tap-left/tap-right manual advance.
- [ ] Verify horizontal swipe between authors.
- [ ] Verify drag-down to dismiss.
- [ ] Post a `kind:20` event with `["T","story"]` and a NIP-40 `expiration` in the past → confirm it does not appear in the tray.
- [ ] Confirm the home timeline is unchanged for accounts with no story-posting follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stories: horizontal tray, full‑screen interactive viewer with progress bars, tap/drag navigation, and auto‑advance (5s).
  * Stories expire after 24 hours and are presented in a per‑author tray.

* **Background Sync**
  * Dedicated background subscription keeps stories current and feeds the Stories UI.

* **Protocol / Backend**
  * Added picture event kind and new story tag axis to enable discovery/filtering of stories.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/damus-io/damus/pull/3757)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->