### PR TITLE
relay: fix relays refusing to reconnect after initial connect fails

### DIFF
--- a/damus/Core/Nostr/RelayConnection.swift
+++ b/damus/Core/Nostr/RelayConnection.swift
@@ -114,7 +114,7 @@ final class RelayConnection: ObservableObject {
             guard let self else {
                 return
             }
-            
+
             if err == nil {
                 self.last_pong = .now
                 Log.info("Got pong from '%s'", for: .networking, self.relay_url.absoluteString)
@@ -214,7 +214,7 @@ final class RelayConnection: ObservableObject {
                 return
             }
             if nserr.domain == NSURLErrorDomain && nserr.code == -999 {
-                // these aren't real error, it just means task was cancelled
+                // these aren't real errors, it just means task was cancelled
                 return
             }
             DispatchQueue.main.async {
@@ -237,14 +237,25 @@ final class RelayConnection: ObservableObject {
     }
     
     func reconnect() {
-        guard !isConnecting && !isDisabled else {
-            self.log?.add("Cancelling reconnect, already connecting")
-            return  // we're already trying to connect or we're disabled
+        guard !isDisabled else {
+            self.log?.add("Cancelling reconnect, relay is disabled")
+            return
         }
 
         guard !self.isConnected else {
             self.log?.add("Cancelling reconnect, already connected")
             return
+        }
+
+        // If we're already connecting, only force a reconnect if the
+        // attempt has gone stale (>5s with no response from the socket)
+        if isConnecting {
+            let elapsed = Date.now.timeIntervalSince1970 - last_connection_attempt
+            guard elapsed > 5 else {
+                self.log?.add("Cancelling reconnect, already connecting")
+                return
+            }
+            self.log?.add("Stale connection detected, forcing reconnect")
         }
 
         disconnect()


### PR DESCRIPTION
## Summary
- When `isConnecting` gets stuck (e.g. from silenced error 57 or lost WebSocket events), `reconnect()` would bail out permanently, bricking the app until restart
- Instead of unconditionally blocking on `isConnecting`, allow reconnect if the connection attempt has gone stale (>5s with no socket response)

- Closes #3774

## Test plan
- [x] Enable airplane mode, launch app (relays fail to connect)
- [x] Disable airplane mode, wait for ping cycle
- [x] Verify relays reconnect successfully instead of staying stuck with "Ping failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay reconnection logic to prevent unnecessary reconnection attempts when the relay is disabled or already connected
  * Enhanced handling of stale reconnection attempts with better validation to avoid redundant reconnect cycles

* **Chores**
  * Minor code formatting and comment updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/damus-io/damus/pull/3775?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->