### PR TITLE
Fix issue where users sometimes cannot see their own posts

### DIFF
--- a/damus/Features/Follows/Models/Contacts.swift
+++ b/damus/Features/Follows/Models/Contacts.swift
@@ -98,10 +98,11 @@ class Contacts {
         return Array((pubkey_to_our_friends[pubkey] ?? Set()))
     }
 
+    /// Filters timeline events to authors the user follows, while still allowing the user's own events through.
     var friend_filter: (NostrEvent) -> Bool {
         { [weak self] ev in
             guard let self else { return false }
-            return self.is_friend(ev.pubkey)
+            return self.is_friend_or_self(ev.pubkey)
         }
     }
 }


### PR DESCRIPTION
## Summary

Sometimes users would not see their own posts on the home timeline after posting.

The issue was that there was a filter being applied to the home timeline that would hide their own posts if they did not follow themselves (which I confirmed was the case for the users who recently reported the issue)

## Checklist

<!-- 
CHOOSE YOUR CHECKLIST: 
- If this is an EXPERIMENTAL DAMUS LABS FEATURE, follow the "Experimental Feature Checklist" below and DELETE the "Standard PR Checklist"
- If this is a STANDARD PR, follow the "Standard PR Checklist" below and DELETE the "Experimental Feature Checklist"
-->

> [!WARNING]
> Please file an issue or create a ticket for the work in this PR, then link it here.
> We use issues and tickets to triage and prioritize work, so PRs without a linked issue/ticket may be delayed.

### Standard PR Checklist

<!-- DELETE THIS SECTION if this is an experimental Damus Labs feature -->

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: Changes should not affect performance
- [x] I have filed or linked an existing issue/ticket related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

_Please provide a test report for the changes in this PR. You can use the template below, but feel free to modify it as needed._

**Device:** iPhone simulator

**iOS:** 26

**Damus:** c035ceea6faf89bf241ead9d5c6734a0ad347926

**Steps:**
1. Unfollow self
2. Post something
3. Check if it appears on the home timeline

**Results:**
- [x] PASS

Note: Also verified that problem was reproducible before the change using the same procedure

## Other notes

_[Please provide any other information that you think is relevant to this PR.]_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the contact filter to now include the user's own posts alongside posts from contacts, improving content visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/damus-io/damus/pull/3785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->