### PR TITLE
Do not filter user's own posts

### DIFF
--- a/damus/Features/Profile/Views/ProfileView.swift
+++ b/damus/Features/Profile/Views/ProfileView.swift
@@ -118,6 +118,7 @@ struct ProfileView: View {
         damus_state.contacts.follow_state(profile.pubkey) == .unfollows && bannerBlurViewOpacity() > 1.0
     }
     
+    /// Builds the profile timeline filter, while ensuring the user's own profile bypasses NSFW and hashtag-spam content filters.
     func content_filter(_ fstate: FilterState) -> ((NostrEvent) -> Bool) {
         var filters = ContentFilters.defaults(damus_state: damus_state)
         filters.append(fstate.filter)

--- a/damus/Features/Timeline/Models/ContentFilters.swift
+++ b/damus/Features/Timeline/Models/ContentFilters.swift
@@ -107,15 +107,24 @@ extension ContentFilters {
         return ContentFilters(filters: ContentFilters.defaults(damus_state: damus_state))
     }
 
+    /// Returns the app's standard content filters.
+    ///
+    /// The logged-in user's own events bypass NSFW and hashtag-spam filters so they remain visible on their own profile.
     @MainActor
     static func defaults(damus_state: DamusState) -> [(NostrEvent) -> Bool] {
         var filters = Array<(NostrEvent) -> Bool>()
         if damus_state.settings.hide_nsfw_tagged_content {
-            filters.append(nsfw_tag_filter)
+            filters.append { ev in
+                guard ev.pubkey != damus_state.pubkey else { return true }
+                return nsfw_tag_filter(ev: ev)
+            }
         }
         if damus_state.settings.hide_hashtag_spam {
             let max_hashtags = damus_state.settings.max_hashtags
-            filters.append({ ev in hashtag_spam_filter(ev: ev, max_hashtags: max_hashtags) })
+            filters.append { ev in
+                guard ev.pubkey != damus_state.pubkey else { return true }
+                return hashtag_spam_filter(ev: ev, max_hashtags: max_hashtags)
+            }
         }
         filters.append(get_repost_of_muted_user_filter(damus_state: damus_state))
         filters.append(timestamp_filter)

--- a/damusTests/ProfileViewTests.swift
+++ b/damusTests/ProfileViewTests.swift
@@ -12,12 +12,43 @@ final class ProfileViewTests: XCTestCase {
 
     let enUsLocale = Locale(identifier: "en-US")
 
+    @MainActor
+    private func makeProfileEvent(content: String, tags: [[String]], keypair: Keypair = test_keypair) -> NostrEvent {
+        guard let event = NostrEvent(content: content, keypair: keypair, tags: tags) else {
+            XCTFail("Expected test event creation to succeed")
+            fatalError("Failed to create test event")
+        }
+        return event
+    }
+
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
 
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testOwnProfileBypassesNsfwAndHashtagFilters() throws {
+        let damusState = generate_test_damus_state(mock_profile_info: nil)
+        damusState.settings.hide_nsfw_tagged_content = true
+        damusState.settings.hide_hashtag_spam = true
+        damusState.settings.max_hashtags = 1
+
+        let ownNsfwEvent = makeProfileEvent(content: "hello #nsfw", tags: [["t", "nsfw"]])
+        let ownHashtagSpamEvent = makeProfileEvent(content: "#one #two", tags: [["t", "one"], ["t", "two"]])
+        let otherKeypair = generate_new_keypair().to_keypair()
+        let otherNsfwEvent = makeProfileEvent(content: "hello #nsfw", tags: [["t", "nsfw"]], keypair: otherKeypair)
+        let otherHashtagSpamEvent = makeProfileEvent(content: "#one #two", tags: [["t", "one"], ["t", "two"]], keypair: otherKeypair)
+
+        let filters = ContentFilters.defaults(damus_state: damusState)
+        let combinedFilter = ContentFilters(filters: filters)
+
+        XCTAssertTrue(combinedFilter.filter(ev: ownNsfwEvent))
+        XCTAssertTrue(combinedFilter.filter(ev: ownHashtagSpamEvent))
+        XCTAssertFalse(combinedFilter.filter(ev: otherNsfwEvent))
+        XCTAssertFalse(combinedFilter.filter(ev: otherHashtagSpamEvent))
     }
 
     func testFollowedByString() throws {


### PR DESCRIPTION
## Summary

Fixes cases where users could fail to see their own posts after posting.

This PR addresses two filtering paths found during investigation:

1. **Content filters:** make the logged-in user’s own events bypass the NSFW and hashtag spam filters so they are not hidden from the user’s own views.
3. **Tests:** add regression coverage for the NSFW/hashtag bypass behavior using tagged `NostrEvent` fixtures.

During investigation, I also checked user reports and confirmed that affected notes had **more than 3 hashtags**, which matches the current `max_hashtags` default and explains why those notes could be filtered out.

## Checklist

> [!WARNING]
> Please file an issue or create a ticket for the work in this PR, then link it here.
> We use issues and tickets to triage and prioritize work, so PRs without a linked issue/ticket may be delayed.

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - Utilize Xcode profiler to measure performance impact of code changes. See https://developer.apple.com/videos/play/wwdc2025/306
    - If not needed, provide reason: This change is limited to lightweight timeline filtering logic and unit coverage. It does not introduce new network requests, blocking work, or heavy rendering paths.
- [x] I have filed or linked an existing issue/ticket related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed. See [Submitting patches](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#submitting-patches)

## Test report

**Device:** iPhone 17e Simulator, plus manual app verification

**iOS:** 26

**Damus:** fc69dba2432d07d4598af4ce3058695162c28737

**Setup:**  
Used the local test target and targeted `just test <TEST_PATH>` workflow from `justfile`, then manually reproduced the issue by posting a note containing multiple hashtags.

**Steps:**  
1. Checked affected user reports and confirmed reported notes had more than 3 hashtags.
2. Reproduced manually without the fix by posting a note containing hashtags and confirming the note did not appear.
3. Applied the fix and repeated the same manual posting flow.
4. Verified that the note now appears.
5. Added unit coverage in `damusTests/ProfileViewTests.swift`.
6. Constructed tagged `NostrEvent` fixtures for:
   - an own NSFW-tagged event
   - an own hashtag-spam event
   - another user’s NSFW-tagged event
   - another user’s hashtag-spam event
7. Ran targeted test:
   - `just test damusTests/ProfileViewTests/testOwnProfileBypassesNsfwAndHashtagFilters`

**Results:**
- [x] PASS
- [ ] Partial PASS
  - Details: N/A

## Other notes

Related issue: #3784


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users' own profile posts now bypass NSFW and hashtag-spam content filters, allowing you to see your own content regardless of these filter settings.

* **Tests**
  * Added test coverage for user profile filter-bypass behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/damus-io/damus/pull/3788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->