### PR TITLE
input: fix caret jumping to end of text on iOS keyboard switch

### DIFF
--- a/damus/Shared/Components/Text/TextViewWrapper.swift
+++ b/damus/Shared/Components/Text/TextViewWrapper.swift
@@ -50,6 +50,11 @@ struct TextViewWrapper: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UITextView, context: Context) {
+        // The programmatic changes below fire delegate callbacks; suppress selection
+        // tracking so that only user-driven caret moves update the tracked position
+        context.coordinator.isApplyingProgrammaticChange = true
+        defer { context.coordinator.isApplyingProgrammaticChange = false }
+
         // Save the current selection BEFORE making any changes
         // This is critical because setting attributedText causes UITextView to reset the cursor position
         let savedRange = uiView.selectedRange
@@ -108,6 +113,9 @@ struct TextViewWrapper: UIViewRepresentable {
         let initialTextSuffix: String?
         var initialTextSuffixWasAdded: Bool = false
         var convertMentionRef: ((Pubkey) -> NSMutableAttributedString?)? = nil
+        // True while updateUIView applies programmatic text/selection changes,
+        // whose delegate callbacks must not be recorded as user-driven caret moves
+        var isApplyingProgrammaticChange: Bool = false
         static let ESCAPE_SEQUENCES = ["\n", "@", "  ", ", ", ". ", "! ", "? ", "; ", "#"]
 
         init(attributedText: Binding<NSMutableAttributedString>,
@@ -146,6 +154,16 @@ struct TextViewWrapper: UIViewRepresentable {
             // placeholder removal, height change). The getFocusWordForMention callback
             // sets newCursorIndex to nil, forcing reliance on savedRange which may be
             // stale. Explicitly tracking cursor position here ensures correct restoration.
+            updateCursorPosition(textView.selectedRange.location)
+        }
+
+        // Keep the tracked cursor position in sync when the user moves the caret
+        // without editing text (e.g. tapping mid-text). Otherwise the position
+        // recorded at the last text change goes stale, and the next view update
+        // (e.g. triggered by an iOS keyboard switch) re-applies it, jumping the
+        // caret to the end of the text (issue #3545).
+        func textViewDidChangeSelection(_ textView: UITextView) {
+            guard !isApplyingProgrammaticChange, textView.selectedRange.length == 0 else { return }
             updateCursorPosition(textView.selectedRange.location)
         }
 

--- a/damus/Shared/Components/Text/TextViewWrapper.swift
+++ b/damus/Shared/Components/Text/TextViewWrapper.swift
@@ -49,9 +49,13 @@ struct TextViewWrapper: UIViewRepresentable {
         uiView.linkTextAttributes = linkAttributes
     }
 
+    /// Pushes the SwiftUI-side attributed text into the text view and restores the
+    /// caret position, which UIKit resets whenever `attributedText` is re-assigned.
+    ///
+    /// Every text/selection change made here is programmatic, so the coordinator's
+    /// selection tracking is suppressed for the duration of this update: the delegate
+    /// callbacks fired by these changes must not be recorded as user-driven caret moves.
     func updateUIView(_ uiView: UITextView, context: Context) {
-        // The programmatic changes below fire delegate callbacks; suppress selection
-        // tracking so that only user-driven caret moves update the tracked position
         context.coordinator.isApplyingProgrammaticChange = true
         defer { context.coordinator.isApplyingProgrammaticChange = false }
 
@@ -113,8 +117,10 @@ struct TextViewWrapper: UIViewRepresentable {
         let initialTextSuffix: String?
         var initialTextSuffixWasAdded: Bool = false
         var convertMentionRef: ((Pubkey) -> NSMutableAttributedString?)? = nil
-        // True while updateUIView applies programmatic text/selection changes,
-        // whose delegate callbacks must not be recorded as user-driven caret moves
+        /// True while `updateUIView` applies programmatic text/selection changes.
+        ///
+        /// `textViewDidChangeSelection` checks this flag so that delegate callbacks
+        /// fired by those changes are not recorded as user-driven caret moves.
         var isApplyingProgrammaticChange: Bool = false
         static let ESCAPE_SEQUENCES = ["\n", "@", "  ", ", ", ". ", "! ", "? ", "; ", "#"]
 
@@ -157,11 +163,15 @@ struct TextViewWrapper: UIViewRepresentable {
             updateCursorPosition(textView.selectedRange.location)
         }
 
-        // Keep the tracked cursor position in sync when the user moves the caret
-        // without editing text (e.g. tapping mid-text). Otherwise the position
-        // recorded at the last text change goes stale, and the next view update
-        // (e.g. triggered by an iOS keyboard switch) re-applies it, jumping the
-        // caret to the end of the text (issue #3545).
+        /// Keeps the tracked cursor position in sync when the user moves the caret
+        /// without editing the text (e.g. by tapping mid-text).
+        ///
+        /// Without this, the position recorded at the last text change goes stale,
+        /// and the next view update (e.g. one triggered by an iOS keyboard switch)
+        /// would re-apply it, jumping the caret to the end of the text (issue #3545).
+        ///
+        /// Programmatic selection changes are ignored while `isApplyingProgrammaticChange`
+        /// is set, as are range selections, which a single index cannot represent.
         func textViewDidChangeSelection(_ textView: UITextView) {
             guard !isApplyingProgrammaticChange, textView.selectedRange.length == 0 else { return }
             updateCursorPosition(textView.selectedRange.location)

--- a/damusTests/PostViewTests.swift
+++ b/damusTests/PostViewTests.swift
@@ -319,6 +319,42 @@ final class PostViewTests: XCTestCase {
         XCTAssertTrue(shouldChange, "shouldChangeTextIn should return true for regular text")
     }
 
+    /// Tests that moving the caret without editing text updates the tracked cursor
+    /// position, so a later view update does not restore a stale position (issue #3545)
+    func testSelectionChangeUpdatesTrackedCursorPosition() {
+        let content = NSMutableAttributedString(string: "Hello world")
+        let bindingContent: Binding<NSMutableAttributedString> = Binding(get: { content }, set: { _ in })
+
+        var trackedCursorPosition: Int? = nil
+        let coordinator = TextViewWrapper.Coordinator(
+            attributedText: bindingContent,
+            getFocusWordForMention: nil,
+            updateCursorPosition: { trackedCursorPosition = $0 },
+            initialTextSuffix: nil,
+            convertMentionRef: nil
+        )
+
+        let textView = UITextView()
+        textView.attributedText = content
+
+        // Simulate the user tapping to place the caret mid-text
+        textView.selectedRange = NSRange(location: 5, length: 0)
+        coordinator.textViewDidChangeSelection(textView)
+        XCTAssertEqual(trackedCursorPosition, 5, "A user-driven caret move should update the tracked cursor position")
+
+        // Range selections cannot be represented by a single index, so they are not tracked
+        trackedCursorPosition = nil
+        textView.selectedRange = NSRange(location: 2, length: 3)
+        coordinator.textViewDidChangeSelection(textView)
+        XCTAssertNil(trackedCursorPosition, "Range selections should not update the tracked cursor position")
+
+        // Programmatic selection changes made by updateUIView should not be recorded
+        coordinator.isApplyingProgrammaticChange = true
+        textView.selectedRange = NSRange(location: 8, length: 0)
+        coordinator.textViewDidChangeSelection(textView)
+        XCTAssertNil(trackedCursorPosition, "Programmatic selection changes should not update the tracked cursor position")
+    }
+
     /// Tests that client tags are added to events when provided.
     func testToEventAddsClientTagWhenProvided() {
         let post = NostrPost(content: "gm")


### PR DESCRIPTION
## Summary

Fixes the post composer caret jumping to the end of the text when the iOS keyboard-switching (globe) button is pressed while the caret is placed mid-text (#3545).

**Root cause:** `PostView` keeps an explicitly tracked cursor position (`newCursorIndex`) which `TextViewWrapper.updateUIView` applies with priority over the saved selection (a mechanism introduced in 4941b502 to fix #3461). The tracked position is updated on every text change, but never when the user moves the caret without editing (e.g. by tapping), and it is never cleared after being applied. After typing, it goes stale, still pointing at the position of the last edit — typically the end of the text. Switching keyboards changes the keyboard height, which triggers a SwiftUI re-render, and `updateUIView` re-applies the stale index, jumping the caret to the end.

**Fix:** implement `textViewDidChangeSelection` in the coordinator so user-driven caret moves keep the tracked position in sync, and suppress that tracking while `updateUIView` applies programmatic text/selection changes — their delegate callbacks must not be recorded as user moves, and view state must not be mutated during a SwiftUI view update. Range selections (length > 0) are left untracked since a single index cannot represent them; behavior there is unchanged.

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - If not needed, provide reason: the change adds a constant-time delegate callback on caret moves; no loops, I/O, or allocations on hot paths.
- [x] I have filed or linked an existing issue/ticket related to this change: #3545
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](https://github.com/damus-io/damus/blob/master/docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR (`Changelog-Fixed`)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable

## Test report

**Device:** iPhone 11 Pro

**iOS:** 26.5.2

**Damus (before / bug reproduction):** official TestFlight build 1.18 (1332), commit 85e38ad4

**Damus (after / fix verification):** Debug build of this change sideloaded via AltStore, shown as version 1.18 (6) — built from the fork test branch (koteitan/damus @ 31be5c46 = this PR's change plus sideload-packaging-only commits)

**Setup:** English (QWERTY) and Japanese (Romaji QWERTY) keyboards enabled; logged in with an existing account.

### Test 1 — main effect (with video)

Video comparing both builds: https://v.nostr.build/sdiqpZlYTsx9Cfup.mp4

**Steps:**
1. Open the post composer and type a few lines of text
2. Move the caret to the middle of the text using space-bar long-press (trackpad mode)
3. Press the iOS keyboard-switching (globe) button

**Results:**
- Before (1.18 (1332)): the caret jumps to the end of the text — reproduces #3545
- After (this change): the caret stays in place

### Test 2 — range selections are not tracked (the `selectedRange.length == 0` guard)

**Steps:** double-tap a word to select it, then drag the selection handles to grow and shrink the selection.

**Results:** the selection stays stable while dragging and the edit menu works normally. (If range selections were tracked, each handle drag would mutate the tracked state and the resulting re-render would collapse the in-progress selection.)

### Test 3 — programmatic changes are not tracked (the `isApplyingProgrammaticChange` guard)

**Steps:** with the caret mid-text, type `@` plus a few letters, insert a mention from the autocomplete list, then press the globe button.

**Results:** after insertion the caret sits right after the mention, and it stays there across the keyboard switch. (When `updateUIView` re-assigns the attributed text, UIKit transiently resets the caret to the end and fires `textViewDidChangeSelection`; if that callback were recorded, the next keyboard switch would jump the caret to the end.)

**Overall:**
- [x] PASS (all three tests)

Unit test added: `PostViewTests.testSelectionChangeUpdatesTrackedCursorPosition`, covering the same three paths at the unit level: caret-move tracking, exclusion of range selections, and suppression of programmatic selection changes.

## Other notes

- #3545 was closed during a backlog triage, but it reproduces reliably with the steps above (see the video).
- The explicit cursor tracking introduced in 4941b502 ("input: fix cursor jumping to position 0 after typing first character", #3461) is kept as-is; this PR only fixes its staleness on user-driven caret moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118vy9nfQ3SYqh8ARtMRRyb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracked caret/cursor position when users move the caret without editing text.
  * Prevented programmatic updates from incorrectly affecting tracked cursor position.
  * Ensured caret tracking ignores text-range selections (only single-caret movement is considered).
* **Tests**
  * Added XCTest coverage for user-driven caret moves, range selection behavior, and ignoring programmatic selection changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->