### PR TITLE
wallet: version the Coinos NWC key derivation so it can be rotated

### DIFF
--- a/damus/Features/Wallet/Models/CoinosDeterministicAccountClient.swift
+++ b/damus/Features/Wallet/Models/CoinosDeterministicAccountClient.swift
@@ -23,8 +23,17 @@ class CoinosDeterministicAccountClient {
     // MARK: - Computed properties for a deterministic wallet
     
     /// A deterministic keypair for the NWC connection derived from the user's private key
+    ///
+    /// The derivation is versioned via a salt so the credential can be rotated. The NWC secret is a
+    /// long-lived bearer credential held by Coinos, so if it is ever compromised on the server side
+    /// the only remedy is to mint a different secret — and an unversioned derivation can only ever
+    /// produce the same one. Coinos retired all pre-incident NWC keys in August 2026 and now refuses
+    /// to re-authorize a retired key, which is why v1 (unsalted sha256 of the private key) can no
+    /// longer be used. If another rotation is ever needed, bump the version in the salt below.
     private var nwcKeypair: FullKeypair? {
-        let nwcPrivateKey: Privkey = Privkey(sha256(self.userKeypair.privkey.id))   // SHA256 is an irreversible operation, user's nsec should not be deriveable from this new private key
+        // Add a versioned prefix so that we can ensure this will NOT match the username, the password, nor a previously derived NWC key
+        guard let saltedInput = ("coinos_nwc_v2:" + self.userKeypair.privkey.hex()).data(using: .utf8) else { return nil }
+        let nwcPrivateKey: Privkey = Privkey(sha256(saltedInput))   // SHA256 is an irreversible operation, user's nsec should not be deriveable from this new private key
         return FullKeypair(privkey: nwcPrivateKey)
     }
     


### PR DESCRIPTION
## Summary

Fixes the one-click Coinos wallet being unable to reconnect after the Coinos NWC credential invalidation (context in #3800, and the thread at https://damus.io/nevent1qqsp4eq6az9qafqhy7c0h0tt0g4a2e9gmzyrvtnrg86etu35ahuv4zgwzyymn).

`CoinosDeterministicAccountClient` derives the NWC secret as an unsalted `sha256(user's private key)`, so re-running the one-click setup always re-mints the same secret and pubkey. That secret is a long-lived bearer credential stored server-side by Coinos; after the suspected disclosure Coinos retired all pre-incident keys and now rejects re-registration of a retired key with an explicit 403 (re-authorizing it would re-authorize the potentially leaked credential). With an unversioned derivation, the client can only ever produce the retired key, so reconnects "succeed" over HTTP and then sync endlessly against a connection the NWC server refuses.

This salts the derivation with a versioned prefix (`coinos_nwc_v2:`), mirroring the `coinos_username:` / `coinos_password:` prefixes already used for the deterministic account credentials in the same file. Reconnecting now mints a genuinely new secret/pubkey, and any future rotation only needs a version bump. The account username/password derivations are deliberately untouched — the account itself was not affected, only the NWC keys.

Server-side, Coinos has deployed the matching fixes: `GET /app/:pubkey` now returns 404 (previously 500) for missing connections so the client's probe-then-create flow works, owner re-mints refresh the connection's creation epoch, and retired/quarantined pubkeys are rejected with a clear error.

No v1 fallback is included on purpose: every v1-derived Coinos connection has been retired server-side, so there is nothing for v1 to reconnect to.

## Test report

I operate the Coinos server, so this was verified from the server side rather than in the simulator (I don't have an iOS build environment on this machine):

- Reproduced the failure mode end-to-end against production coinos.io by driving the exact request sequence `CoinosDeterministicAccountClient` makes (register → login → `GET /app/<pubkey>` → `POST /app` → `GET /app/<pubkey>`).
- Verified against the updated server that a retired pubkey is rejected on `POST /app` (403) and that a freshly derived secret (which is what this patch makes the client produce) completes the same sequence successfully and yields a working `nostr+walletconnect://` string.
- The Swift change is mechanical and mirrors constructs already used in the same file (`Privkey(_: Data)`, `sha256(Data)`, `privkey.hex()`), but I'd appreciate a maintainer running a build/simulator pass since I could not.

## Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md).
- [x] I have done some testing on the changes in this PR to ensure it is at least functional.
- [x] I have filed or linked an existing issue/ticket related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review.
- [x] I have added the signoff line to all my commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Updated deterministic wallet connection key derivation to use a versioned salt and private-key data.
  * Improved key uniqueness and protection against predictable derivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->